### PR TITLE
docs: add Sponsor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <img src="https://img.shields.io/badge/python-3.8+-blue" alt="Python 3.8+">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platform">
   <a href="https://linkedin.com/in/alexgreensh"><img src="https://img.shields.io/badge/LinkedIn-Connect-0A66C2?logo=linkedin&logoColor=white" alt="Connect on LinkedIn"></a>
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4.svg?labelColor=262626" alt="Sponsor"></a>
 </p>
 
 <h2 align="center">Your AI is getting dumber and you can't see it.</h2>


### PR DESCRIPTION
Adds a pink-heart Sponsor badge to the badge row in the README, matching the style used by Cognee and others in the AI-agent ecosystem.

Links to https://github.com/sponsors/alexgreensh which is already live (`.github/FUNDING.yml` has been in place). This just puts the ask in the body of the README where visitors land, not just the sidebar.

## Preview

![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4.svg?labelColor=262626)

## Diff

```diff
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-ff69b4.svg?labelColor=262626" alt="Sponsor"></a>
```

One-line change, README only. No version bump needed.

Generated with [Claude Code](https://claude.com/claude-code)