### PR TITLE
feat: first-run nudge for marketplace users to enable auto-update (v3.5.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "token-optimizer",
       "source": "./",
       "description": "Audit, fix, and monitor Claude Code context window usage. Find the ghost tokens.",
-      "version": "3.5.1",
+      "version": "3.5.2",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "license": "AGPL-3.0-only",
   "keywords": ["token", "optimization", "context", "audit", "cost", "coach"]
 }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/alexgreensh/token-optimizer/releases"><img src="https://img.shields.io/badge/version-3.5.1-green" alt="Version 3.5.1"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/releases"><img src="https://img.shields.io/badge/version-3.5.2-green" alt="Version 3.5.2"></a>
   <a href="https://github.com/alexgreensh/token-optimizer"><img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet" alt="Claude Code Plugin"></a>
   <a href="https://github.com/alexgreensh/token-optimizer/tree/main/openclaw"><img src="https://img.shields.io/badge/OpenClaw-Plugin-brightgreen" alt="OpenClaw Plugin"></a>
   <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/github/license/alexgreensh/token-optimizer" alt="License"></a>
@@ -35,14 +35,14 @@ Opus 4.6 drops from 93% to 76% accuracy across a 1M context window. Compaction l
 
 Then in Claude Code: `/token-optimizer`
 
-Also available as a script install:
+> **Please enable auto-update after installing.** Claude Code ships third-party marketplaces with auto-update **off by default**, and plugin authors cannot change that default. So you won't get bug fixes automatically unless you turn it on. In Claude Code: `/plugin` → **Marketplaces** tab → select `alexgreensh-token-optimizer` → **Enable auto-update**. One-time, 10 seconds, and you'll never miss a fix again. Token Optimizer also prints a one-time reminder on your first SessionStart so you don't forget.
+
+Also available as a script install, which auto-updates daily via `git pull --ff-only` with no toggles required:
 
 ```bash
 git clone https://github.com/alexgreensh/token-optimizer.git ~/.claude/token-optimizer
 bash ~/.claude/token-optimizer/install.sh
 ```
-
-That install path still keeps automatic updates, because script-installed checkouts run a daily `git pull --ff-only`.
 
 Works on Claude Code and [OpenClaw](#openclaw-plugin). Each platform gets its own native plugin (Python for Claude Code, TypeScript for OpenClaw). No bridging, no shared runtime, zero cross-platform dependencies.
 

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -9948,6 +9948,37 @@ def _set_quality_bar_disabled(disabled):
         pass
 
 
+def _read_config_flag(key, default=False):
+    """Read a single flag from config.json. Returns default on any error."""
+    try:
+        if not CONFIG_PATH.exists():
+            return default
+        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        if isinstance(cfg, dict) and key in cfg:
+            return cfg[key]
+    except (json.JSONDecodeError, OSError):
+        pass
+    return default
+
+
+def _write_config_flag(key, value):
+    """Merge a single flag into config.json. Non-fatal on I/O errors."""
+    try:
+        cfg = {}
+        if CONFIG_PATH.exists():
+            try:
+                loaded = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    cfg = loaded
+            except (json.JSONDecodeError, OSError):
+                pass
+        cfg[key] = value
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        CONFIG_PATH.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
 def setup_quality_bar(dry_run=False, uninstall=False, status_only=False, force=False):
     """Install, uninstall, or check quality bar (status line + cache hook).
 
@@ -10637,6 +10668,32 @@ if __name__ == "__main__":
                     )
                     os.close(log_fd)
                     update_marker.touch()
+        except Exception:
+            pass
+        # One-time first-run nudge for marketplace users: Claude Code ships
+        # third-party marketplaces with auto-update off by default, and plugin
+        # authors cannot change that default. Tell the user how to flip it
+        # so they get future bug fixes automatically. Shown exactly once,
+        # suppressed if the user has opted out of the quality bar entirely,
+        # and skipped for script-install / dev-symlink users (they get their
+        # updates via the daily git pull above or via their local checkout).
+        try:
+            already_shown = _read_config_flag("autoupdate_nudge_shown", False)
+            qb_disabled = _read_config_flag("quality_bar_disabled", False)
+            if (_is_running_from_plugin_cache()
+                    and not already_shown
+                    and not qb_disabled):
+                print("")
+                print("  [Token Optimizer] First-run tip: enable auto-update for this marketplace")
+                print("  so you get bug fixes automatically. In Claude Code:")
+                print("")
+                print("      /plugin  ->  Marketplaces  ->  alexgreensh-token-optimizer")
+                print("               ->  Enable auto-update")
+                print("")
+                print("  Third-party marketplaces ship with auto-update off by default in")
+                print("  Claude Code. This is not our choice. This message will not show again.")
+                print("")
+                _write_config_flag("autoupdate_nudge_shown", True)
         except Exception:
             pass
     elif args[0] == "setup-quality-bar":


### PR DESCRIPTION
## The problem

Claude Code ships third-party marketplaces with `autoUpdate=false` by default, and **plugin authors cannot change that default** — there is no author-controlled field in `plugin.json` or `marketplace.json` for it. Only Anthropic's official marketplace gets `autoUpdate=true` at registration.

Result: marketplace-installed Token Optimizer users never receive bug fixes automatically unless they manually toggle the flag in `/plugin` → Marketplaces tab, which almost nobody discovers.

Hit this directly yesterday when v3.5.1 shipped to fix a statusline clobber bug — script-install users got it within 24h via the existing daily `git pull --ff-only`, but marketplace users would stay on v3.5.0 forever unless they happened to open the plugin manager.

## What this PR does

Two changes, both closing as much of the gap as a plugin can close from inside:

### 1. One-time SessionStart nudge (`measure.py`)

In the `ensure-health` block, after all the self-healing runs, detect marketplace installs and print a one-time message walking the user through enabling auto-update:

```
  [Token Optimizer] First-run tip: enable auto-update for this marketplace
  so you get bug fixes automatically. In Claude Code:

      /plugin  ->  Marketplaces  ->  alexgreensh-token-optimizer
               ->  Enable auto-update

  Third-party marketplaces ship with auto-update off by default in
  Claude Code. This is not our choice. This message will not show again.
```

Conditions:
- Only fires when running from `/plugins/cache/` (marketplace install). Script-install users get updates via their existing daily `git pull --ff-only` so they don't need the nudge. Dev-symlink users (like Alex's own setup) never see it either.
- Only fires once per user — tracked via new `autoupdate_nudge_shown` flag in `~/.claude/token-optimizer/config.json`.
- Skipped entirely if `quality_bar_disabled=true` (user has already opted out of Token Optimizer's quality bar; don't pester them).

### 2. Bold README callout

Right after the install block:

> **Please enable auto-update after installing.** Claude Code ships third-party marketplaces with auto-update **off by default**, and plugin authors cannot change that default. So you won't get bug fixes automatically unless you turn it on. In Claude Code: `/plugin` → **Marketplaces** tab → select `alexgreensh-token-optimizer` → **Enable auto-update**. One-time, 10 seconds, and you'll never miss a fix again. Token Optimizer also prints a one-time reminder on your first SessionStart so you don't forget.

Also repositions the script-install block as the auto-updating alternative for users who want zero-configuration update flow.

### 3. Small internal cleanup

Added `_read_config_flag(key, default)` and `_write_config_flag(key, value)` helpers. The existing `_set_quality_bar_disabled` was single-purpose and we now have multiple flags to manage (`quality_bar_disabled`, `autoupdate_nudge_shown`). Cleaner surface, no behavioral change for the existing flag.

## What this PR does NOT do

- **Does not silently force-enable auto-update** for the user. That flag is stored internally by Claude Code (not in any user-visible config file I could find), and even if we found the storage location, silently overriding user update-policy settings would damage trust in the plugin fleet. The nudge respects consent.
- **Does not apply to total-recall or repo-forensics yet.** Same pattern ports cleanly; follow-up PRs.
- **Does not address the platform-level root cause.** That needs a feature request to Anthropic asking for a plugin-author-settable `autoUpdate` field in `marketplace.json`. Will draft separately.

## Verification

Four-scenario local harness against the real `ensure-health` code path with sandboxed `HOME` directories that simulate both plugin-cache and script-install layouts:

```
1 plugin first-run:  nudged=True  flag=True   OK
2 plugin second-run: nudge_absent=True         OK  (flag survives across sessions)
3 plugin opted-out:  nudge_absent=True         OK  (quality_bar_disabled respected)
4 script install:    nudge_absent=True         OK  (only plugin-cache path triggers)
```

## Files

```
 .claude-plugin/marketplace.json           |  2 +-
 .claude-plugin/plugin.json                |  2 +-
 README.md                                 |  8 ++---
 skills/token-optimizer/scripts/measure.py | 57 +++++++++++++++++++++++++++++++
 4 files changed, 63 insertions(+), 6 deletions(-)
```

## Checklist

- [x] Version bumped: 3.5.1 → 3.5.2 in plugin.json + marketplace.json + README badge
- [x] Local scenarios verified (4/4 pass)
- [x] No tests committed to public repo
- [x] No `Co-Authored-By` trailer (CLA-gated repo)
- [x] Respects `quality_bar_disabled` opt-out
- [x] Skips script-install users (they already auto-update via daily git pull)
- [x] One-shot: nudge never repeats
