### PR TITLE
docs: add missing plugin install step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Opus 4.6 drops from 93% to 76% accuracy across a 1M context window. Compaction l
 
 ```bash
 /plugin marketplace add alexgreensh/token-optimizer
+/plugin install token-optimizer@alexgreensh-token-optimizer
 ```
 
 Then in Claude Code: `/token-optimizer`


### PR DESCRIPTION
## Summary
- README only showed `/plugin marketplace add` but never the `/plugin install` step, so users couldn't actually get the `/token-optimizer` command.

## Test plan
- [x] Follow README install steps in a fresh Claude Code session and confirm `/token-optimizer` is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)