### PR TITLE
fix: reset IFS in _is_safe_prefix to prevent inheritance from find_interpreter

### DIFF
--- a/hooks/python-launcher.sh
+++ b/hooks/python-launcher.sh
@@ -18,6 +18,7 @@ set -eu
 _SAFE_PREFIXES="/usr/bin /usr/local/bin /opt/homebrew/bin /opt/homebrew/opt /home/linuxbrew/.linuxbrew/bin"
 
 _is_safe_prefix() {
+    local IFS=$' \t\n'
     local binpath="$1" prefix
     for prefix in $_SAFE_PREFIXES; do
         case "$binpath" in


### PR DESCRIPTION
`find_interpreter` sets local IFS=: to split PATH by colons. In bash, local variables have dynamic scope, so _is_safe_prefix inherits IFS=: when called from `find_interpreter`. 
This means $_SAFE_PREFIXES (space- separated) is treated as one big token instead of five prefixes, and every safe-prefix check silently fails -- rejecting all Python interpreters as unsafe.

Adding local IFS=$' \t\n' at the top of _is_safe_prefix resets it to the bash default before the loop so the prefixes split correctly.

Reproduced on macOS with Python via Homebrew (/opt/homebrew/bin/python3)