### PR TITLE
Restore Windows interpreter support (regression in 5.7.2)

### DIFF
--- a/hooks/python-launcher.sh
+++ b/hooks/python-launcher.sh
@@ -24,6 +24,19 @@ _is_safe_prefix() {
             "$prefix"/*) return 0 ;;
         esac
     done
+    # Windows install locations (git-bash/MSYS path form, e.g. /c/...). These map
+    # to admin- or user-owned Python install roots, not arbitrary PATH dirs, so
+    # they preserve the anti-PATH-hijack intent of the Unix prefix list above.
+    # WindowsApps is still probed with --version downstream to reject alias stubs.
+    # A case statement is used (not $_SAFE_PREFIXES) because these roots contain
+    # spaces (Program Files), which would break the space-split prefix loop.
+    case "$binpath" in
+        /[a-zA-Z]/Program\ Files/Python*) return 0 ;;
+        /[a-zA-Z]/Program\ Files\ \(x86\)/Python*) return 0 ;;
+        /[a-zA-Z]/Python3*) return 0 ;;
+        */AppData/Local/Programs/Python/*) return 0 ;;
+        */AppData/Local/Microsoft/WindowsApps/*) return 0 ;;
+    esac
     return 1
 }
 


### PR DESCRIPTION
## Summary

On Windows, every hook (SessionStart, PreToolUse, etc.) fails with:

```
token-optimizer: no usable Python 3 interpreter found
```

even when Python 3 is installed and on PATH.

## Root cause

`hooks/python-launcher.sh` `_is_safe_prefix()` only allows macOS/Linux prefixes:

```
_SAFE_PREFIXES="/usr/bin /usr/local/bin /opt/homebrew/bin /opt/homebrew/opt /home/linuxbrew/.linuxbrew/bin"
```

Under git-bash/MSYS, Windows interpreters resolve to paths like `/c/Program Files/Python313/python` or `/c/Users/<user>/AppData/Local/Programs/Python/Python312/python` -- none match an allowed prefix, so `find_interpreter` rejects them all and the script exits 127. The Unix-only direct-probe fallback at the bottom never matches on Windows either.

This is a **regression**: the allowlist was introduced in 5.7.2 (PATH-hijack hardening). 5.7.1 had no allowlist and worked on Windows. The script header still advertises Windows support (`python.org installs at spaced paths`, `py -3`, `Windows Store Python`), which the allowlist silently broke.

## Fix

Extend `_is_safe_prefix()` to also accept the standard Windows Python install roots (git-bash path form), preserving the anti-hijack intent (admin-/user-owned install dirs, not arbitrary PATH entries). WindowsApps is still `--version`-probed downstream, so non-functional AppExecutionAlias stubs are still rejected. A `case` statement is used rather than appending to `_SAFE_PREFIXES` because the Windows roots contain spaces (`Program Files`), which would break the space-split `for prefix in $_SAFE_PREFIXES` loop.

## Testing

Windows 11, git-bash. Before: launcher exits 127. After: `bash -n` passes; launcher resolves Python 3.13 and execs it (exit 0); the SessionStart hook command runs cleanly.