### PR TITLE
fix: Python 3.9 compatibility — add `from __future__ import annotations`

### DIFF
--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -60,6 +60,7 @@ Snapshots are saved to SNAPSHOT_DIR under the active runtime home.
 Copyright (C) 2026 Alex Greenshpun
 SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 """
+from __future__ import annotations
 
 import hashlib
 import heapq


### PR DESCRIPTION
## Summary

Fixes #40 — `measure.py` crashes on Python 3.9 (macOS system Python) with `TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'`.

## Root cause

Commit `df1c58c` (Codex beta adapter) introduced a module-level variable:

```python
_codex_config_cache: tuple[float, dict] | None = None
```

PEP 604 union syntax (`X | Y`) requires Python 3.10+. macOS ships Python 3.9.6 via CommandLineTools, which is the most common interpreter `python-launcher.sh` finds.

## Fix

One-line: `from __future__ import annotations` after the module docstring. This defers all annotation evaluation to string form, making union syntax work on Python 3.7+.

## Who's affected

Every macOS user without Homebrew Python 3.10+ installed — `python-launcher.sh` finds `/usr/bin/python3` (3.9.6) first, runs `measure.py`, which crashes at import time. The launcher treats this as "no usable Python" and logs:

```
token-optimizer: no usable Python 3 interpreter found
```

## Verified

- `python3.9 measure.py --help` → works after fix
- `python3.12 measure.py --help` → still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)