### PR TITLE
Fix possible 2-min hang on Windows in read_cache.py (use shared stdin helper)

### DIFF
--- a/skills/token-optimizer/scripts/read_cache.py
+++ b/skills/token-optimizer/scripts/read_cache.py
@@ -30,6 +30,7 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Optional
 
+from hook_io import read_stdin_hook_input
 from plugin_env import is_v5_flag_enabled, resolve_snapshot_dir
 from runtime_env import runtime_home
 
@@ -1151,9 +1152,8 @@ def main() -> None:
         return
 
     if "--invalidate" in args:
-        try:
-            hook_input = json.loads(sys.stdin.read(1_000_000))
-        except (json.JSONDecodeError, OSError):
+        hook_input = read_stdin_hook_input(1_000_000)
+        if not hook_input:
             return
         handle_invalidate(hook_input, quiet)
         return
@@ -1165,9 +1165,8 @@ def main() -> None:
     if mode not in READ_CACHE_MODES:
         mode = DEFAULT_MODE
 
-    try:
-        hook_input = json.loads(sys.stdin.read(1_000_000))
-    except (json.JSONDecodeError, OSError):
+    hook_input = read_stdin_hook_input(1_000_000)
+    if not hook_input:
         return
 
     tool_name = hook_input.get("tool_name", "")


### PR DESCRIPTION
 **What this fixes:** on Windows, `read_cache.py` can hang for up to 2 minutes on a Read hook. It reads stdin with a raw   `sys.stdin.read()` and no timeout, so if the stdin pipe is open but has no data, it just waits until `hooks/run.py` kills it at the 120s mark. The Read hook is synchronous, so the user's Read tool call waits the whole time. This swaps the two raw reads for the shared `hook_io.read_stdin_hook_input` helper, which has a 0.5s timeout. 5 line diff.

## The inconsistency
4 hook scripts read JSON from stdin. Three of them (`archive_result.py`, `bash_hook.py`, `context_intel.py`) use the shared `hook_io.read_stdin_hook_input` helper; `read_cache.py` was the lone outlier, doing 2 raw `json.loads(sys.stdin.read(1_000_000))` calls in `main()` (the `--invalidate` arm and the main PreToolUse Read arm). `archive_result.py:15` even names `hook_io.py` the "SOURCE OF TRUTH for read_stdin_hook_input", so the project already declared the helper canonical, this just brings the last script in line.

## On Windows OS 
The raw read has no stdin guard. `hook_io.read_stdin_hook_input` exists precisely because raw `sys.stdin.read()` is unsafe in hook context:
There is no `select` on Windows stdin handles, so the helper spawns a daemon thread that reads with a 0.5s join timeout (see: https://github.com/danikdanik/token-optimizer/blob/0ae279e0a0c5b8c1c288eccfdbd0f42d028c86c1/skills/token-optimizer/scripts/hook_io.py#L17)

Without that guard, on Windows a stale-but-not-EOFed stdin pipe blocks until the parent `hooks/run.py` kills the subprocess at its 120-second timeout (https://github.com/danikdanik/token-optimizer/blob/0ae279e0a0c5b8c1c288eccfdbd0f42d028c86c1/hooks/run.py#L69). That is a 2-minute stall on a *synchronous* PreToolUse hook: the user's Read tool call is gated on it.

## Verification

- `echo '' | read_cache.py --quiet` exits 0 fast, no hang.
- `sleep 1 | read_cache.py --quiet` (pipe open, no data) hits the 0.5s timeout and exits 0 clean.
- `echo '{}' | read_cache.py --invalidate --quiet` exits 0, no traceback.
- `json` and `sys` are still used, no leftover imports.