### PR TITLE
Extract shared path resolver to eliminate duplication across skill files

### DIFF
--- a/commands/health.md
+++ b/commands/health.md
@@ -8,27 +8,13 @@ Run a session health check and help the user manage running sessions safely.
 
 ## Steps
 
-1. Resolve measure.py path:
+1. Resolve measure.py path (shared resolver):
 ```bash
-RUNTIME="${TOKEN_OPTIMIZER_RUNTIME:-}"
-if [ -z "$RUNTIME" ]; then
-  if [ -n "$CLAUDE_PLUGIN_ROOT" ] || [ -n "$CLAUDE_PLUGIN_DATA" ]; then
-    RUNTIME="claude"
-  elif [ -n "$CODEX_HOME" ] || [ -d "$HOME/.codex" ]; then
-    RUNTIME="codex"
-  else
-    RUNTIME="claude"
-  fi
-fi
-MEASURE_PY=""
-for f in "$HOME/.codex/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$HOME/.codex/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$HOME/.claude/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/token-optimizer/skills/token-optimizer/scripts/measure.py"; do
-  [ -f "$f" ] && MEASURE_PY="$f" && break
-done
-export TOKEN_OPTIMIZER_RUNTIME="$RUNTIME"
+_r="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/token-optimizer}/hooks/resolve.sh"
+[ -f "$_r" ] || _r=$(ls "$HOME/.codex/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$HOME/.claude/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$PWD/hooks/resolve.sh" 2>/dev/null | head -1)
+[ -f "$_r" ] || { echo "[Error] Token Optimizer resolver not found. Is Token Optimizer installed?" >&2; exit 1; }
+_o=$(bash "$_r" --export --need measure) || exit 1
+eval "$_o"
 ```
 
 2. Run:

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -8,27 +8,13 @@ Fast health check. Show the user where they stand in under 10 lines.
 
 ## Steps
 
-1. Resolve measure.py path:
+1. Resolve measure.py path (shared resolver):
 ```bash
-RUNTIME="${TOKEN_OPTIMIZER_RUNTIME:-}"
-if [ -z "$RUNTIME" ]; then
-  if [ -n "$CLAUDE_PLUGIN_ROOT" ] || [ -n "$CLAUDE_PLUGIN_DATA" ]; then
-    RUNTIME="claude"
-  elif [ -n "$CODEX_HOME" ] || [ -d "$HOME/.codex" ]; then
-    RUNTIME="codex"
-  else
-    RUNTIME="claude"
-  fi
-fi
-MEASURE_PY=""
-for f in "$HOME/.codex/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$HOME/.codex/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$HOME/.claude/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/token-optimizer/skills/token-optimizer/scripts/measure.py"; do
-  [ -f "$f" ] && MEASURE_PY="$f" && break
-done
-export TOKEN_OPTIMIZER_RUNTIME="$RUNTIME"
+_r="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/token-optimizer}/hooks/resolve.sh"
+[ -f "$_r" ] || _r=$(ls "$HOME/.codex/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$HOME/.claude/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$PWD/hooks/resolve.sh" 2>/dev/null | head -1)
+[ -f "$_r" ] || { echo "[Error] Token Optimizer resolver not found. Is Token Optimizer installed?" >&2; exit 1; }
+_o=$(bash "$_r" --export --need measure) || exit 1
+eval "$_o"
 ```
 
 2. Run:

--- a/hooks/resolve.sh
+++ b/hooks/resolve.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Token Optimizer: shared path resolver. Centralizes the runtime
+# detection and measure.py / fleet.py / token-coach lookup that used to
+# be duplicated as ~20-line bash blocks at the top of every SKILL.md
+# and command body. Each skill body line costs auto-compaction budget
+# (https://code.claude.com/docs/en/skills), so the bodies just `eval`
+# the export form below.
+#
+# Usage:
+#   eval "$(bash resolve.sh --export [--need measure[,fleet][,coach-dir]])"
+#   bash resolve.sh --what runtime|measure|fleet|coach-dir
+#
+# Supports Claude plugin (${CLAUDE_PLUGIN_ROOT}), legacy install.sh
+# (~/.claude/token-optimizer/), Codex plugin
+# (~/.codex/plugins/cache/.../), and dev checkout ($PWD). Bash-only,
+# Git-Bash / MSYS friendly on Windows.
+
+set -u
+shopt -s nullglob 2>/dev/null || true
+
+what="" do_export=0 need_measure=0 need_fleet=0 need_coach=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --what)   what="${2:-}";   shift 2 ;;
+        --export) do_export=1;     shift   ;;
+        --need)
+            _old_ifs="${IFS-}"; IFS=','
+            for _i in ${2:-}; do
+                case "$_i" in
+                    measure)         need_measure=1 ;;
+                    fleet)           need_fleet=1   ;;
+                    coach-dir|coach) need_coach=1   ;;
+                    *) echo "[Error] resolve.sh: unknown --need value: $_i" >&2; exit 2 ;;
+                esac
+            done
+            IFS="$_old_ifs"; shift 2 ;;
+        *) echo "[Error] resolve.sh: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# Runtime: explicit env wins, else Claude plugin signals, else Codex, else claude.
+RUNTIME="${TOKEN_OPTIMIZER_RUNTIME:-}"
+if [ -z "$RUNTIME" ]; then
+    if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then RUNTIME=claude
+    elif [ -n "${CODEX_HOME:-}" ] || [ -d "${HOME}/.codex" ];                 then RUNTIME=codex
+    else                                                                           RUNTIME=claude
+    fi
+fi
+
+# Resolve a relative tail across all known install layouts.
+# Order: CLAUDE_PLUGIN_ROOT (if set) → codex-first/claude-first per RUNTIME
+# → legacy install.sh → dev checkout ($PWD).
+_resolve() {
+    local op="$1" tail="$2" c
+    local -a cs=()
+    [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && cs+=("${CLAUDE_PLUGIN_ROOT}/${tail}")
+    local -a codex=(
+        "${HOME}/.codex/${tail}"
+        "${HOME}/.codex/plugins/cache"/*/token-optimizer/*/"${tail}"
+    )
+    local -a claude=(
+        "${HOME}/.claude/${tail}"
+        "${HOME}/.claude/plugins/cache"/*/token-optimizer/*/"${tail}"
+        "${HOME}/.claude/token-optimizer/${tail}"
+    )
+    if [ "$RUNTIME" = codex ]; then cs+=("${codex[@]}" "${claude[@]}")
+    else                            cs+=("${claude[@]}" "${codex[@]}")
+    fi
+    cs+=("${PWD}/${tail}")
+    for c in "${cs[@]}"; do
+        [ -n "$c" ] || continue
+        { [ "$op" = f ] && [ -f "$c" ]; } || { [ "$op" = d ] && [ -d "$c" ]; } || continue
+        printf '%s\n' "$c"; return 0
+    done
+    return 1
+}
+
+MEASURE_PY="$(_resolve f 'skills/token-optimizer/scripts/measure.py' || true)"
+FLEET_PY="$(_resolve f 'skills/fleet-auditor/scripts/fleet.py' || true)"
+COACH_DIR="$(_resolve d 'skills/token-coach' || true)"
+
+_die_measure() { echo "[Error] measure.py not found. Is Token Optimizer installed?" >&2; exit 1; }
+_die_fleet()   { echo "[Error] fleet.py not found. Is Fleet Auditor installed?"    >&2; exit 1; }
+_die_coach()   { echo "[Error] token-coach directory not found. Is Token Coach installed?" >&2; exit 1; }
+
+if [ -n "$what" ]; then
+    case "$what" in
+        runtime)         printf '%s\n' "$RUNTIME" ;;
+        measure)         [ -n "$MEASURE_PY" ] || _die_measure; printf '%s\n' "$MEASURE_PY" ;;
+        fleet)           [ -n "$FLEET_PY"   ] || _die_fleet;   printf '%s\n' "$FLEET_PY"   ;;
+        coach-dir|coach) [ -n "$COACH_DIR"  ] || _die_coach;   printf '%s\n' "$COACH_DIR"  ;;
+        *) echo "[Error] resolve.sh: unknown --what value: $what" >&2; exit 2 ;;
+    esac
+    exit 0
+fi
+
+if [ "$do_export" -eq 1 ]; then
+    [ "$need_measure" -eq 1 ] && [ -z "$MEASURE_PY" ] && _die_measure
+    [ "$need_fleet"   -eq 1 ] && [ -z "$FLEET_PY"   ] && _die_fleet
+    [ "$need_coach"   -eq 1 ] && [ -z "$COACH_DIR"  ] && _die_coach
+    # %q quotes paths so spaces in $HOME (Windows /c/Users/Some Name/) survive eval.
+    printf 'export TOKEN_OPTIMIZER_RUNTIME=%q\n' "$RUNTIME"
+    [ -n "$MEASURE_PY" ] && printf 'export MEASURE_PY=%q\n' "$MEASURE_PY"
+    [ -n "$FLEET_PY"   ] && printf 'export FLEET_PY=%q\n'   "$FLEET_PY"
+    [ -n "$COACH_DIR"  ] && printf 'export COACH_DIR=%q\n'  "$COACH_DIR"
+    exit 0
+fi
+
+echo "[Error] resolve.sh: must specify --what or --export" >&2
+exit 2

--- a/skills/fleet-auditor/SKILL.md
+++ b/skills/fleet-auditor/SKILL.md
@@ -13,29 +13,13 @@ Detects installed agent systems, collects token usage data, identifies waste pat
 
 ## Phase 0: Initialize
 
-1. **Resolve runtime and fleet.py path** (works for both skill and plugin installs):
+1. **Resolve runtime and fleet.py path** (shared resolver):
 ```bash
-RUNTIME="${TOKEN_OPTIMIZER_RUNTIME:-}"
-if [ -z "$RUNTIME" ]; then
-  if [ -n "$CLAUDE_PLUGIN_ROOT" ] || [ -n "$CLAUDE_PLUGIN_DATA" ]; then
-    RUNTIME="claude"
-  elif [ -n "$CODEX_HOME" ] || [ -d "$HOME/.codex" ]; then
-    RUNTIME="codex"
-  else
-    RUNTIME="claude"
-  fi
-fi
-
-FLEET_PY=""
-for f in "$HOME/.codex/skills/fleet-auditor/scripts/fleet.py" \
-         "$HOME/.codex/plugins/cache"/*/token-optimizer/*/skills/fleet-auditor/scripts/fleet.py \
-         "$HOME/.claude/skills/fleet-auditor/scripts/fleet.py" \
-         "$HOME/.claude/plugins/cache"/*/token-optimizer/*/skills/fleet-auditor/scripts/fleet.py; do
-  [ -f "$f" ] && FLEET_PY="$f" && break
-done
-[ -z "$FLEET_PY" ] && { echo "[Error] fleet.py not found. Is Fleet Auditor installed?"; exit 1; }
-echo "Using: $FLEET_PY"
-export TOKEN_OPTIMIZER_RUNTIME="$RUNTIME"
+_r="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/token-optimizer}/hooks/resolve.sh"
+[ -f "$_r" ] || _r=$(ls "$HOME/.codex/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$HOME/.claude/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$PWD/hooks/resolve.sh" 2>/dev/null | head -1)
+[ -f "$_r" ] || { echo "[Error] Token Optimizer resolver not found. Is Token Optimizer installed?" >&2; exit 1; }
+_o=$(bash "$_r" --export --need fleet) || exit 1
+eval "$_o"
 ```
 Use `$FLEET_PY` for all subsequent fleet.py calls.
 

--- a/skills/token-coach/SKILL.md
+++ b/skills/token-coach/SKILL.md
@@ -13,29 +13,13 @@ Interactive coaching for Claude Code or Codex architecture decisions. Analyzes y
 
 ## Phase 0: Initialize
 
-1. **Resolve runtime and measure.py path** (same as token-optimizer):
+1. **Resolve runtime, measure.py, and coach dir** (shared resolver):
 ```bash
-RUNTIME="${TOKEN_OPTIMIZER_RUNTIME:-}"
-if [ -z "$RUNTIME" ]; then
-  if [ -n "$CLAUDE_PLUGIN_ROOT" ] || [ -n "$CLAUDE_PLUGIN_DATA" ]; then
-    RUNTIME="claude"
-  elif [ -n "$CODEX_HOME" ] || [ -d "$HOME/.codex" ]; then
-    RUNTIME="codex"
-  else
-    RUNTIME="claude"
-  fi
-fi
-
-MEASURE_PY=""
-for f in "$HOME/.codex/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.codex/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$HOME/.claude/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$PWD/skills/token-optimizer/scripts/measure.py"; do
-  [ -f "$f" ] && MEASURE_PY="$f" && break
-done
-[ -z "$MEASURE_PY" ] || [ ! -f "$MEASURE_PY" ] && { echo "[Error] measure.py not found. Is Token Optimizer installed?"; exit 1; }
-export TOKEN_OPTIMIZER_RUNTIME="$RUNTIME"
+_r="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/token-optimizer}/hooks/resolve.sh"
+[ -f "$_r" ] || _r=$(ls "$HOME/.codex/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$HOME/.claude/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$PWD/hooks/resolve.sh" 2>/dev/null | head -1)
+[ -f "$_r" ] || { echo "[Error] Token Optimizer resolver not found. Is Token Optimizer installed?" >&2; exit 1; }
+_o=$(bash "$_r" --export --need measure,coach-dir) || exit 1
+eval "$_o"
 ```
 
 2. **Collect coaching data**:
@@ -52,7 +36,7 @@ If available, parse the quality score and issues. This enriches coaching with se
 
 4. **For Codex, check setup readiness**:
 ```bash
-if [ "$RUNTIME" = "codex" ]; then
+if [ "$TOKEN_OPTIMIZER_RUNTIME" = "codex" ]; then
   python3 "$MEASURE_PY" codex-doctor --project "$PWD" --json 2>/dev/null
 fi
 ```
@@ -72,23 +56,7 @@ Wait for the answer. Don't dump info before they choose.
 
 ## Phase 2: Load Context (based on intake)
 
-Resolve the token-coach skill directory:
-```bash
-COACH_DIR=""
-if [ -d "$HOME/.codex/skills/token-coach" ]; then
-  COACH_DIR="$HOME/.codex/skills/token-coach"
-elif [ -d "$HOME/.codex/skills/token-optimizer/../token-coach" ]; then
-  COACH_DIR="$HOME/.codex/skills/token-optimizer/../token-coach"
-elif [ -d "$HOME/.claude/skills/token-coach" ]; then
-  COACH_DIR="$HOME/.claude/skills/token-coach"
-elif [ -d "$HOME/.claude/skills/token-optimizer/../token-coach" ]; then
-  COACH_DIR="$HOME/.claude/skills/token-optimizer/../token-coach"
-else
-  COACH_DIR="$(find "$HOME/.codex/plugins/cache" "$HOME/.claude/plugins/cache" -path "*/token-coach" -type d 2>/dev/null | head -1)"
-fi
-```
-
-Load references based on intake choice:
+`$COACH_DIR` was resolved in Phase 0. Load references based on intake choice:
 - **Option a or b**: Read `$COACH_DIR/references/coach-patterns.md` + `$COACH_DIR/references/quick-reference.md`
 - **Option c**: Read `$COACH_DIR/references/agentic-systems.md` + `$COACH_DIR/references/quick-reference.md`
 - **Option d**: Read `$COACH_DIR/references/quick-reference.md` only (fast path)

--- a/skills/token-dashboard/SKILL.md
+++ b/skills/token-dashboard/SKILL.md
@@ -9,28 +9,13 @@ Opens an up-to-date dashboard showing your context usage trends, quality scores,
 
 ## Instructions
 
-1. **Resolve runtime and measure.py path**:
+1. **Resolve runtime and measure.py path** (shared resolver):
 ```bash
-RUNTIME="${TOKEN_OPTIMIZER_RUNTIME:-}"
-if [ -z "$RUNTIME" ]; then
-  if [ -n "$CLAUDE_PLUGIN_ROOT" ] || [ -n "$CLAUDE_PLUGIN_DATA" ]; then
-    RUNTIME="claude"
-  elif [ -n "$CODEX_HOME" ] || [ -d "$HOME/.codex" ]; then
-    RUNTIME="codex"
-  else
-    RUNTIME="claude"
-  fi
-fi
-
-MEASURE_PY=""
-for f in "$HOME/.codex/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.codex/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py \
-         "$HOME/.claude/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py; do
-  [ -f "$f" ] && MEASURE_PY="$f" && break
-done
-[ -z "$MEASURE_PY" ] && { echo "[Error] measure.py not found. Is Token Optimizer installed?"; exit 1; }
-export TOKEN_OPTIMIZER_RUNTIME="$RUNTIME"
+_r="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/token-optimizer}/hooks/resolve.sh"
+[ -f "$_r" ] || _r=$(ls "$HOME/.codex/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$HOME/.claude/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$PWD/hooks/resolve.sh" 2>/dev/null | head -1)
+[ -f "$_r" ] || { echo "[Error] Token Optimizer resolver not found. Is Token Optimizer installed?" >&2; exit 1; }
+_o=$(bash "$_r" --export --need measure) || exit 1
+eval "$_o"
 ```
 
 2. **Collect and open**:

--- a/skills/token-optimizer/SKILL.md
+++ b/skills/token-optimizer/SKILL.md
@@ -22,12 +22,11 @@ If `TOKEN_OPTIMIZER_RUNTIME=codex` or Codex environment is detected, read `refer
 
 Resolve measure.py path:
 ```bash
-MEASURE_PY=""
-for f in "$HOME/.claude/skills/token-optimizer/scripts/measure.py" \
-         "$HOME/.claude/plugins/cache"/*/token-optimizer/*/skills/token-optimizer/scripts/measure.py; do
-  [ -f "$f" ] && MEASURE_PY="$f" && break
-done
-[ -z "$MEASURE_PY" ] && { echo "[Error] measure.py not found."; exit 1; }
+_r="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/token-optimizer}/hooks/resolve.sh"
+[ -f "$_r" ] || _r=$(ls "$HOME/.codex/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$HOME/.claude/plugins/cache"/*/token-optimizer/*/hooks/resolve.sh "$PWD/hooks/resolve.sh" 2>/dev/null | head -1)
+[ -f "$_r" ] || { echo "[Error] Token Optimizer resolver not found. Is Token Optimizer installed?" >&2; exit 1; }
+_o=$(bash "$_r" --export --need measure) || exit 1
+eval "$_o"
 ```
 
 Read `references/phase0-setup.md` for the full setup sequence: context window detection, pre-check, backup, coordination folder, hook checks, daemon setup, and smart compaction.


### PR DESCRIPTION
## Summary
Consolidates duplicated path-resolution logic across multiple scripts into a single shared resolver module, reducing code duplication and improving maintainability.

## Changes
- Extracts common path-resolution prelude into a dedicated resolver script
- Updates dependent scripts to use the shared resolver
- Maintains backward compatibility with existing functionality

The resolver is 111 lines but it lives in hooks/ and **isn't loaded** into LLM context the way skill bodies are, so the LLM-visible delta is almost -100 .
