### PR TITLE
fix(health): detect CLI sessions launched by absolute path or .exe wrapper

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -9103,6 +9103,30 @@ def _find_session_version_for_pid(pid):
     return None  # No confident match; don't guess (causes false OUTDATED flags)
 
 
+def _command_matches_process(command, process_name):
+    """True if a `ps` COMMAND field denotes a `process_name` CLI session.
+
+    Matches a bare ``argv[0]`` (``claude`` / ``claude --resume ...``) and
+    also absolute-path or wrapper launches -- e.g.
+    ``/usr/local/.../@anthropic-ai/claude-code/bin/claude`` and the patched
+    ``.../bin/claude.exe ...`` form -- by comparing the executable basename
+    with a trailing ``.exe`` stripped. The bare-name fast path is preserved
+    for backward compatibility. Matching is case-sensitive so the macOS
+    desktop app (``/Applications/Claude.app/Contents/MacOS/Claude``) is not
+    mistaken for the ``claude`` CLI, and ``claude`` appearing only as an
+    argument (``vim claude.py``) does not match.
+    """
+    command = (command or "").strip()
+    if not command:
+        return False
+    if command == process_name or command.startswith(process_name + " "):
+        return True
+    exe_base = os.path.basename(command.split()[0])
+    if exe_base.endswith(".exe"):
+        exe_base = exe_base[:-4]
+    return exe_base == process_name
+
+
 def _collect_posix_claude_sessions(process_name="claude"):
     """Collect running Claude/Codex CLI sessions via `ps` on macOS/Linux.
 
@@ -9131,7 +9155,7 @@ def _collect_posix_claude_sessions(process_name="claude"):
         # Fields: PID TTY LSTART(5 fields) ETIME COMMAND...
         tty = parts[1]
         command = " ".join(parts[8:])
-        if not (command.strip() == process_name or command.startswith(process_name + " ")):
+        if not _command_matches_process(command, process_name):
             continue
         try:
             pid = int(parts[0])
@@ -9519,6 +9543,23 @@ def health_selfcheck():
 
     iso_probe = _parse_iso_process_datetime("2026-01-01T12:00:00Z")
     check("ISO-8601 datetime parser", iso_probe is not None and iso_probe["elapsed_seconds"] > 0)
+
+    # Process-name matcher: bare argv0, absolute-path and ".exe" wrapper
+    # launches all match; the case-different desktop app, an arg-only
+    # mention, and unrelated processes must not.
+    _m = _command_matches_process
+    matcher_ok = (
+        _m("claude", "claude")
+        and _m("claude --resume abc", "claude")
+        and _m("/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude", "claude")
+        and _m("/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe --resume abc", "claude")
+        and _m("/opt/homebrew/bin/codex serve", "codex")
+        and not _m("/Applications/Claude.app/Contents/MacOS/Claude", "claude")
+        and not _m("/usr/bin/vim claude.py", "claude")
+        and not _m("node /path/to/app.js", "claude")
+        and not _m("", "claude")
+    )
+    check("process-name matcher (basename + .exe)", matcher_ok)
 
     # Live process-listing command
     if system == "Windows":

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -9103,6 +9103,30 @@ def _find_session_version_for_pid(pid):
     return None  # No confident match; don't guess (causes false OUTDATED flags)
 
 
+def _command_matches_process(command, process_name):
+    """True if a `ps` COMMAND field denotes a `process_name` CLI session.
+
+    Matches a bare ``argv[0]`` (``claude`` / ``claude --resume ...``) and
+    also absolute-path or wrapper launches -- e.g.
+    ``/usr/local/.../@anthropic-ai/claude-code/bin/claude`` and the patched
+    ``.../bin/claude.exe ...`` form -- by comparing the executable basename
+    with a trailing ``.exe`` stripped. The bare-name fast path is preserved
+    for backward compatibility. Matching is case-sensitive so the macOS
+    desktop app (``/Applications/Claude.app/Contents/MacOS/Claude``) is not
+    mistaken for the ``claude`` CLI, and ``claude`` appearing only as an
+    argument (``vim claude.py``) does not match.
+    """
+    command = (command or "").strip()
+    if not command:
+        return False
+    if command == process_name or command.startswith(process_name + " "):
+        return True
+    exe_base = os.path.basename(command.split()[0])
+    if exe_base.endswith(".exe"):
+        exe_base = exe_base[:-4]
+    return exe_base == process_name
+
+
 def _collect_posix_claude_sessions(process_name="claude"):
     """Collect running Claude/Codex CLI sessions via `ps` on macOS/Linux.
 
@@ -9131,7 +9155,7 @@ def _collect_posix_claude_sessions(process_name="claude"):
         # Fields: PID TTY LSTART(5 fields) ETIME COMMAND...
         tty = parts[1]
         command = " ".join(parts[8:])
-        if not (command.strip() == process_name or command.startswith(process_name + " ")):
+        if not _command_matches_process(command, process_name):
             continue
         try:
             pid = int(parts[0])
@@ -9519,6 +9543,23 @@ def health_selfcheck():
 
     iso_probe = _parse_iso_process_datetime("2026-01-01T12:00:00Z")
     check("ISO-8601 datetime parser", iso_probe is not None and iso_probe["elapsed_seconds"] > 0)
+
+    # Process-name matcher: bare argv0, absolute-path and ".exe" wrapper
+    # launches all match; the case-different desktop app, an arg-only
+    # mention, and unrelated processes must not.
+    _m = _command_matches_process
+    matcher_ok = (
+        _m("claude", "claude")
+        and _m("claude --resume abc", "claude")
+        and _m("/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude", "claude")
+        and _m("/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe --resume abc", "claude")
+        and _m("/opt/homebrew/bin/codex serve", "codex")
+        and not _m("/Applications/Claude.app/Contents/MacOS/Claude", "claude")
+        and not _m("/usr/bin/vim claude.py", "claude")
+        and not _m("node /path/to/app.js", "claude")
+        and not _m("", "claude")
+    )
+    check("process-name matcher (basename + .exe)", matcher_ok)
 
     # Live process-listing command
     if system == "Windows":


### PR DESCRIPTION
# PR: Detect CLI sessions launched by absolute path or `.exe` wrapper

**Repo:** `alexgreensh/token-optimizer`
**Affected version:** 5.9.1 (latest) and earlier (≥ the introduction of POSIX session health)
**Files:** `plugins/token-optimizer/skills/token-optimizer/scripts/measure.py` and the
mirrored `skills/token-optimizer/scripts/measure.py` (both git-tracked, byte-identical)
**Branch suggestion:** `fix/session-detection-absolute-path-exe`

## Summary

`/token-optimizer:health` and `kill-stale` report **0 running sessions** on machines
where the Claude Code CLI is launched by absolute path (the common case) or via a
patched `claude.exe` wrapper. The session matcher only recognizes a `ps` `COMMAND`
field whose `argv[0]` is the bare string `claude`.

## Reproduction

On macOS with Claude Code installed globally, the CLI runs as:

```
/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude --resume <uuid>
```

`python3 measure.py health` then prints:

```
No running Claude Code CLI sessions found.
```

even though `ps -eo pid,etime,command | grep claude-code/bin/claude` lists several live
sessions. `kill-stale` likewise previews/kills nothing.

## Root cause

`_collect_posix_claude_sessions()` (measure.py:9106) filters each `ps` line with:

```python
command = " ".join(parts[8:])
if not (command.strip() == process_name or command.startswith(process_name + " ")):
    continue
```

`command` is the full `COMMAND` field — for an absolute-path launch it is
`/usr/local/.../@anthropic-ai/claude-code/bin/claude …`, which is neither equal to
`"claude"` nor starts with `"claude "`. The check only succeeds when `argv[0]` is
exactly `claude` (a bare-name invocation). Absolute-path launches — and the patched
`.exe` wrapper — are silently dropped, so the collector returns `[]`.

Demonstration with the current condition:

```
match=False  /usr/local/.../claude-code/bin/claude.exe --resume x   (patched wrapper)
match=False  /usr/local/.../claude-code/bin/claude --resume x       (vanilla, absolute path)
match=True   claude --resume x                                       (bare argv0 — only case that works)
match=False  /Applications/Claude.app/Contents/MacOS/Claude          (desktop app — correctly excluded)
```

## Fix

Extract the per-line decision into a pure, testable `_command_matches_process()` that
also matches the **executable basename** (with a trailing `.exe` stripped), while
preserving the bare-name fast path for backward compatibility:

```python
def _command_matches_process(command, process_name):
    command = (command or "").strip()
    if not command:
        return False
    if command == process_name or command.startswith(process_name + " "):
        return True
    exe_base = os.path.basename(command.split()[0])
    if exe_base.endswith(".exe"):
        exe_base = exe_base[:-4]
    return exe_base == process_name
```

Matching stays **case-sensitive** so the macOS desktop app
(`/Applications/Claude.app/Contents/MacOS/Claude`, basename `Claude`) is not mistaken
for the `claude` CLI, and `claude` appearing only as an argument (`vim claude.py`) does
not match. The same fix benefits the `codex` runtime symmetrically (it uses the same
collector with `process_name="codex"`).

## Tests

A deterministic matcher self-test is added to `health-selfcheck` (alongside the existing
platform-agnostic parser self-tests), covering: bare argv0, absolute path, `.exe`
wrapper, codex, and the three negative cases (desktop app, arg-only mention, empty / node).

Verified on the affected machine:

```
SESSION HEALTH SELF-CHECK  (platform: Darwin)
  [PASS]  WMI datetime parser
  [PASS]  ISO-8601 datetime parser
  [PASS]  process-name matcher (basename + .exe)
  [PASS]  ps -eo pid,tty,lstart,etime,command   (lines=1134)
  [PASS]  _collect_posix_claude_sessions end-to-end   returned 6 session(s)   # was 0 before the fix
  [PASS]  _collect_health_data POSIX contract
  Results: 6 passed, 0 failed
```

`_collect_posix_claude_sessions end-to-end` goes from `0` to `6` live sessions detected
on the same machine, with no false matches against the desktop-app helpers.

## Scope / notes

- Touches only the matcher decision and adds a self-test; no behavior change for
  machines where bare-name matching already worked.
- Both git-tracked `measure.py` copies receive the identical change.
- Out of scope: the `node /path/to/cli.js`-style launch form is intentionally not matched
  (would require scanning args and risks false positives); the observed real-world launch
  is the resolved `claude`/`claude.exe` binary, which this fix covers.
