### PR TITLE
fix(hermes): avoid plugin sys.path shadowing

### DIFF
--- a/hermes/__init__.py
+++ b/hermes/__init__.py
@@ -34,9 +34,9 @@ hermes_hook_bridge reads it to shell into measure.py.
 At import time we add the plugin directory itself (``_PLUGIN_DIR``) to
 ``sys.path`` so the three sibling modules resolve correctly, whether the plugin
 is loaded from the install tree OR from the repo checkout (where scripts/ is the
-parent of all four files).  No Hermes modules are imported; we touch
-``agent.usage_pricing`` only for live per-call cost estimation, wrapped in
-try/except (fail-open).
+parent of all four files).  We append it so Hermes core modules keep import
+precedence. No Hermes modules are imported; we touch ``agent.usage_pricing``
+only for live per-call cost estimation, wrapped in try/except (fail-open).
 
 Activation: Hermes (v0.15.x) does NOT auto-discover plugins by directory
 presence — the plugin must be allow-listed in the Hermes config under
@@ -60,12 +60,14 @@ logger = logging.getLogger(__name__)
 # Strategy: We add the directory that contains THIS file to sys.path.
 # This works both from the install tree (~/.hermes/plugins/token-optimizer/)
 # and from the repo checkout (skills/token-optimizer/scripts/ is already on
-# sys.path via the test bootstrap; this is a no-op in that case).
+# sys.path via the test bootstrap). Keep it at the end so Hermes core modules
+# keep import precedence.
 # ---------------------------------------------------------------------------
 
 _PLUGIN_DIR = Path(__file__).parent.resolve()
-if str(_PLUGIN_DIR) not in sys.path:
-    sys.path.insert(0, str(_PLUGIN_DIR))
+_PLUGIN_DIR_STR = str(_PLUGIN_DIR)
+sys.path[:] = [p for p in sys.path if p != _PLUGIN_DIR_STR]
+sys.path.append(_PLUGIN_DIR_STR)
 
 # Lazy import so the plugin loads even if hermes_hook_bridge is not available
 # in the install tree at module-load time.  We cache ONLY on success so a


### PR DESCRIPTION
### What happened

I hit this on a live Hermes install with the Token Optimizer Hermes plugin enabled.

`hermes doctor` marked `session_search` as unavailable. The session database was present; the failure was import resolution.

The Hermes plugin currently prepends its install directory to `sys.path`. That directory contains Token Optimizer's helper module `hermes_state.py`. After the plugin has loaded, a later host-side import like this can resolve to Token Optimizer's helper instead of Hermes core's module:

```python
from hermes_state import DEFAULT_DB_PATH
```

Hermes' `session_search` availability check does exactly that. Token Optimizer's helper does not define `DEFAULT_DB_PATH`, so the availability check fails even though the Hermes state directory/database exists.

### The fix

This keeps the plugin directory importable for sibling modules, but appends it instead of prepending it:

- `hermes_hook_bridge`, `hermes_session`, and the local helper modules still resolve.
- Hermes core modules keep priority inside the host process.
- Existing copies of the plugin path are removed before appending, so a reloaded process gets one canonical path entry.

### Verification

I verified this against the actual source shape and with an import-precedence smoke test.

Source checks:

```text
core hermes_state.py defines DEFAULT_DB_PATH: True
session_search check imports DEFAULT_DB_PATH: True
TO helper hermes_state.py defines DEFAULT_DB_PATH: False
state.db exists: True
```

Import-precedence smoke test:

```text
upstream: hermes_state_from=upstream-plugin-... DEFAULT_DB_PATH=False bridge_import=True
patched:  hermes_state_from=patched-core-...   DEFAULT_DB_PATH=True  bridge_import=True
```

That is the behavior this PR needs to change: the patched plugin still imports its sibling bridge module, but a later `import hermes_state` resolves to Hermes core instead of Token Optimizer's helper.

I also ran:

```text
python3 -m py_compile hermes/__init__.py
```

### Why this shape

I did not rename the helper module in this PR because that is a larger install/update migration. Appending the plugin path is the smallest fix that preserves the current installed layout and removes the host-process shadowing risk.
