### PR TITLE
fix(runtime): honor CLAUDE_CONFIG_DIR instead of hardcoding ~/.claude

### DIFF
--- a/hooks/run.py
+++ b/hooks/run.py
@@ -52,7 +52,16 @@ def _check_consent() -> bool:
                     return True
                 config_path = ch / "token-optimizer" / "config.json"
             else:
-                config_path = home / ".claude" / "token-optimizer" / "config.json"
+                # Honor CLAUDE_CONFIG_DIR (Claude Code's official config-dir
+                # override) before falling back to ~/.claude.
+                claude_config = os.environ.get("CLAUDE_CONFIG_DIR", "")
+                if claude_config:
+                    cc = Path(claude_config).resolve()
+                    if not str(cc).startswith(str(home)):
+                        return True  # Path outside home = skip (fail-open)
+                    config_path = cc / "token-optimizer" / "config.json"
+                else:
+                    config_path = home / ".claude" / "token-optimizer" / "config.json"
 
         if not config_path.exists() or config_path.is_symlink():
             return True  # No config or symlink = fail-open

--- a/plugins/token-optimizer/hooks/run.py
+++ b/plugins/token-optimizer/hooks/run.py
@@ -52,7 +52,16 @@ def _check_consent() -> bool:
                     return True
                 config_path = ch / "token-optimizer" / "config.json"
             else:
-                config_path = home / ".claude" / "token-optimizer" / "config.json"
+                # Honor CLAUDE_CONFIG_DIR (Claude Code's official config-dir
+                # override) before falling back to ~/.claude.
+                claude_config = os.environ.get("CLAUDE_CONFIG_DIR", "")
+                if claude_config:
+                    cc = Path(claude_config).resolve()
+                    if not str(cc).startswith(str(home)):
+                        return True  # Path outside home = skip (fail-open)
+                    config_path = cc / "token-optimizer" / "config.json"
+                else:
+                    config_path = home / ".claude" / "token-optimizer" / "config.json"
 
         if not config_path.exists() or config_path.is_symlink():
             return True  # No config or symlink = fail-open

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/archive_result.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/archive_result.py
@@ -37,6 +37,7 @@ except ImportError:
 from bash_compress import _TOKEN_PATTERNS
 from hook_io import read_stdin_hook_input
 from plugin_env import resolve_snapshot_dir
+from runtime_env import claude_home
 from session_store import SessionStore, _sanitize_session_id as sanitize_sid
 
 # ---------------------------------------------------------------------------
@@ -302,7 +303,7 @@ def _resolve_mcp_cap_tokens() -> int | None:
             pass
 
     # 2. settings.json "env" block — for out-of-process callers
-    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path = claude_home() / "settings.json"
     try:
         with open(settings_path, "r", encoding="utf-8") as f:
             settings = json.load(f)

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/compression_backfill.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/compression_backfill.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from runtime_env import claude_home  # noqa: E402
 from structure_map import (  # noqa: E402
     detect_structure_language,
     is_structure_supported_file,
@@ -566,7 +567,7 @@ def print_agent_report(report):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description="First-read shadow backfill analyzer")
-    ap.add_argument("--projects-dir", default=str(Path.home() / ".claude" / "projects"))
+    ap.add_argument("--projects-dir", default=str(claude_home() / "projects"))
     ap.add_argument("--edit-window", type=int, default=DEFAULT_EDIT_WINDOW_TURNS)
     ap.add_argument("--limit", type=int, default=None,
                     help="max sessions WITH reads to process (for a quick sample)")

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/hermes_hook_bridge.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/hermes_hook_bridge.py
@@ -26,6 +26,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from runtime_env import claude_home
+
 # Dashboard port constant — single source of truth.
 try:
     from hermes_doctor import DASHBOARD_PORT  # noqa: PLC0415
@@ -50,7 +52,7 @@ _MEASURE_LOCATOR = _SCRIPTS_DIR / "measure-path"
 # Fallback search paths if the primary location is missing (e.g. the bridge
 # is bundled into the install tree but measure.py is in the repo checkout).
 _FALLBACK_PATHS: list[Path] = [
-    Path.home() / ".claude" / "skills" / "token-optimizer" / "scripts" / "measure.py",
+    claude_home() / "skills" / "token-optimizer" / "scripts" / "measure.py",
     Path.home() / ".hermes" / "plugins" / "token-optimizer" / "measure.py",
 ]
 

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/runtime_env.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/runtime_env.py
@@ -37,6 +37,9 @@ _VALID_RUNTIMES = frozenset(
     {_RUNTIME_CLAUDE, _RUNTIME_CODEX, _RUNTIME_HERMES, _RUNTIME_OPENCODE, _RUNTIME_COPILOT}
 )
 _CLAUDE_PLUGIN_ENVS = ("CLAUDE_PLUGIN_ROOT", "CLAUDE_PLUGIN_DATA")
+# Claude Code's official config-dir override. When set, Claude stores
+# projects/, settings.json, etc. under this directory instead of ~/.claude.
+_CLAUDE_CONFIG_DIR_ENV = "CLAUDE_CONFIG_DIR"
 _CODEX_HOME_ENV = "CODEX_HOME"
 _HERMES_HOME_ENV = "HERMES_HOME"
 _COPILOT_HOME_ENV = "COPILOT_HOME"
@@ -219,8 +222,17 @@ def detect_runtime() -> str:
 
 
 def claude_home() -> Path:
-    """Return Claude Code's home directory."""
-    return Path.home() / ".claude"
+    """Return Claude Code's home directory.
+
+    Honors CLAUDE_CONFIG_DIR — Claude Code's official override for where it
+    stores projects/, settings.json, etc. — when it points at a safe directory
+    under the user home, matching how every other runtime honors its own home
+    env var (CODEX_HOME, HERMES_HOME, COPILOT_HOME, ...). Falls back to
+    ~/.claude. Without this, multi-config-dir users (CLAUDE_CONFIG_DIR set to a
+    non-default location) silently get session scans, the trends DB, and the
+    dashboard pinned to a stale ~/.claude that no longer receives sessions.
+    """
+    return _safe_home_from_env(_CLAUDE_CONFIG_DIR_ENV, Path.home() / ".claude")
 
 
 def codex_home() -> Path:

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/structure_replay.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/structure_replay.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
 
+from runtime_env import claude_home
 from structure_map import (
     StructureMapResult,
     estimate_tokens,
@@ -940,8 +941,8 @@ def _gather_input_paths(raw_paths: Sequence[str]) -> List[Path]:
     expanded: List[Path] = []
     if not raw_paths:
         defaults = [
-            Path.home() / ".claude" / "projects",
-            Path.home() / ".claude" / "_backups" / "token-optimizer" / "read-cache" / "decisions",
+            claude_home() / "projects",
+            claude_home() / "_backups" / "token-optimizer" / "read-cache" / "decisions",
         ]
         for root in defaults:
             if root.exists():
@@ -949,8 +950,8 @@ def _gather_input_paths(raw_paths: Sequence[str]) -> List[Path]:
         return expanded
 
     # Determine the safe root for glob expansion.
-    # TOKEN_OPTIMIZER_SAFE_ROOT overrides the default (~/.claude) for tests only.
-    _default_root = (Path.home() / ".claude").resolve()
+    # TOKEN_OPTIMIZER_SAFE_ROOT overrides the default (claude_home()) for tests only.
+    _default_root = claude_home().resolve()
     _safe_root_env = os.environ.get("TOKEN_OPTIMIZER_SAFE_ROOT", "").strip()
     if _safe_root_env:
         _candidate = Path(_safe_root_env).resolve()

--- a/skills/token-optimizer/scripts/archive_result.py
+++ b/skills/token-optimizer/scripts/archive_result.py
@@ -37,6 +37,7 @@ except ImportError:
 from bash_compress import _TOKEN_PATTERNS
 from hook_io import read_stdin_hook_input
 from plugin_env import resolve_snapshot_dir
+from runtime_env import claude_home
 from session_store import SessionStore, _sanitize_session_id as sanitize_sid
 
 # ---------------------------------------------------------------------------
@@ -302,7 +303,7 @@ def _resolve_mcp_cap_tokens() -> int | None:
             pass
 
     # 2. settings.json "env" block — for out-of-process callers
-    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path = claude_home() / "settings.json"
     try:
         with open(settings_path, "r", encoding="utf-8") as f:
             settings = json.load(f)

--- a/skills/token-optimizer/scripts/compression_backfill.py
+++ b/skills/token-optimizer/scripts/compression_backfill.py
@@ -34,6 +34,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from runtime_env import claude_home  # noqa: E402
 from structure_map import (  # noqa: E402
     detect_structure_language,
     is_structure_supported_file,
@@ -566,7 +567,7 @@ def print_agent_report(report):
 
 def main(argv=None):
     ap = argparse.ArgumentParser(description="First-read shadow backfill analyzer")
-    ap.add_argument("--projects-dir", default=str(Path.home() / ".claude" / "projects"))
+    ap.add_argument("--projects-dir", default=str(claude_home() / "projects"))
     ap.add_argument("--edit-window", type=int, default=DEFAULT_EDIT_WINDOW_TURNS)
     ap.add_argument("--limit", type=int, default=None,
                     help="max sessions WITH reads to process (for a quick sample)")

--- a/skills/token-optimizer/scripts/hermes_hook_bridge.py
+++ b/skills/token-optimizer/scripts/hermes_hook_bridge.py
@@ -26,6 +26,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from runtime_env import claude_home
+
 # Dashboard port constant — single source of truth.
 try:
     from hermes_doctor import DASHBOARD_PORT  # noqa: PLC0415
@@ -50,7 +52,7 @@ _MEASURE_LOCATOR = _SCRIPTS_DIR / "measure-path"
 # Fallback search paths if the primary location is missing (e.g. the bridge
 # is bundled into the install tree but measure.py is in the repo checkout).
 _FALLBACK_PATHS: list[Path] = [
-    Path.home() / ".claude" / "skills" / "token-optimizer" / "scripts" / "measure.py",
+    claude_home() / "skills" / "token-optimizer" / "scripts" / "measure.py",
     Path.home() / ".hermes" / "plugins" / "token-optimizer" / "measure.py",
 ]
 

--- a/skills/token-optimizer/scripts/runtime_env.py
+++ b/skills/token-optimizer/scripts/runtime_env.py
@@ -37,6 +37,9 @@ _VALID_RUNTIMES = frozenset(
     {_RUNTIME_CLAUDE, _RUNTIME_CODEX, _RUNTIME_HERMES, _RUNTIME_OPENCODE, _RUNTIME_COPILOT}
 )
 _CLAUDE_PLUGIN_ENVS = ("CLAUDE_PLUGIN_ROOT", "CLAUDE_PLUGIN_DATA")
+# Claude Code's official config-dir override. When set, Claude stores
+# projects/, settings.json, etc. under this directory instead of ~/.claude.
+_CLAUDE_CONFIG_DIR_ENV = "CLAUDE_CONFIG_DIR"
 _CODEX_HOME_ENV = "CODEX_HOME"
 _HERMES_HOME_ENV = "HERMES_HOME"
 _COPILOT_HOME_ENV = "COPILOT_HOME"
@@ -219,8 +222,17 @@ def detect_runtime() -> str:
 
 
 def claude_home() -> Path:
-    """Return Claude Code's home directory."""
-    return Path.home() / ".claude"
+    """Return Claude Code's home directory.
+
+    Honors CLAUDE_CONFIG_DIR — Claude Code's official override for where it
+    stores projects/, settings.json, etc. — when it points at a safe directory
+    under the user home, matching how every other runtime honors its own home
+    env var (CODEX_HOME, HERMES_HOME, COPILOT_HOME, ...). Falls back to
+    ~/.claude. Without this, multi-config-dir users (CLAUDE_CONFIG_DIR set to a
+    non-default location) silently get session scans, the trends DB, and the
+    dashboard pinned to a stale ~/.claude that no longer receives sessions.
+    """
+    return _safe_home_from_env(_CLAUDE_CONFIG_DIR_ENV, Path.home() / ".claude")
 
 
 def codex_home() -> Path:

--- a/skills/token-optimizer/scripts/structure_replay.py
+++ b/skills/token-optimizer/scripts/structure_replay.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
 
+from runtime_env import claude_home
 from structure_map import (
     StructureMapResult,
     estimate_tokens,
@@ -940,8 +941,8 @@ def _gather_input_paths(raw_paths: Sequence[str]) -> List[Path]:
     expanded: List[Path] = []
     if not raw_paths:
         defaults = [
-            Path.home() / ".claude" / "projects",
-            Path.home() / ".claude" / "_backups" / "token-optimizer" / "read-cache" / "decisions",
+            claude_home() / "projects",
+            claude_home() / "_backups" / "token-optimizer" / "read-cache" / "decisions",
         ]
         for root in defaults:
             if root.exists():
@@ -949,8 +950,8 @@ def _gather_input_paths(raw_paths: Sequence[str]) -> List[Path]:
         return expanded
 
     # Determine the safe root for glob expansion.
-    # TOKEN_OPTIMIZER_SAFE_ROOT overrides the default (~/.claude) for tests only.
-    _default_root = (Path.home() / ".claude").resolve()
+    # TOKEN_OPTIMIZER_SAFE_ROOT overrides the default (claude_home()) for tests only.
+    _default_root = claude_home().resolve()
     _safe_root_env = os.environ.get("TOKEN_OPTIMIZER_SAFE_ROOT", "").strip()
     if _safe_root_env:
         _candidate = Path(_safe_root_env).resolve()


### PR DESCRIPTION
`claude_home()` and a few scripts/hooks hardcoded `~/.claude` and ignored `CLAUDE_CONFIG_DIR` — Claude Code's official config-dir override. Every other runtime already honors its home env var via `_safe_home_from_env`; `claude_home()` was the lone exception. With a relocated config dir, this pins session scans, the trends DB, the dashboard, and config/hook paths to a stale `~/.claude`.

Routes `claude_home()` through the existing `_safe_home_from_env` helper (same safe-home confinement + symlink rejection as the other runtimes), and the direct callers through `claude_home()` (`run.py` honors it inline). Falls back to `~/.claude` when unset. Applied to both mirrored source trees (`skills/` and `plugins/`).

Files: `runtime_env.py` (keystone), `hooks/run.py`, `compression_backfill.py`, `archive_result.py`, `structure_replay.py`, `hermes_hook_bridge.py`.

Note: `_safe_home_from_env` confines the override to a non-symlink dir under `$HOME`; a `CLAUDE_CONFIG_DIR` outside `$HOME` is rejected with a warning and falls back. Kept for consistency with the other runtimes — happy to relax if you'd prefer full Claude-Code semantics.
