### PR TITLE
audit: fix stale hardcoded date in backfill TTL test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ node_modules/
 venv/
 snapshots/
 .pytest_cache/
-tests/
 FIELD_NOTES.md
 compound-engineering.local.md
 private-review/

--- a/tests/test_cache_ttl_mix.py
+++ b/tests/test_cache_ttl_mix.py
@@ -1,0 +1,285 @@
+import importlib.util
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "token-optimizer"
+    / "scripts"
+    / "measure.py"
+)
+
+import sys as _sys
+_sys.path.insert(0, str(MODULE_PATH.parent))
+
+spec = importlib.util.spec_from_file_location("token_optimizer_measure", MODULE_PATH)
+measure = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(measure)
+
+
+class CacheTtlMixTests(unittest.TestCase):
+    def _with_temp_trends_db(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        original_snapshot_dir = measure.SNAPSHOT_DIR
+        original_trends_db = measure.TRENDS_DB
+        measure.SNAPSHOT_DIR = Path(tmpdir.name)
+        measure.TRENDS_DB = measure.SNAPSHOT_DIR / "trends.db"
+        return tmpdir, original_snapshot_dir, original_trends_db
+
+    def test_parse_session_jsonl_extracts_ttl_split(self):
+        records = [
+            {
+                "type": "user",
+                "timestamp": "2026-04-04T09:00:00Z",
+                "message": {"content": "Investigate cache behavior"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-04T09:01:00Z",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 300,
+                        "cache_creation_input_tokens": 90,
+                        "cache_creation": {
+                            "ephemeral_1h_input_tokens": 60,
+                            "ephemeral_5m_input_tokens": 30,
+                        },
+                    },
+                },
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_path = Path(tmpdir) / "session.jsonl"
+            session_path.write_text(
+                "\n".join(json.dumps(r) for r in records) + "\n",
+                encoding="utf-8",
+            )
+
+            parsed = measure._parse_session_jsonl(session_path)
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["total_cache_create"], 90)
+        self.assertEqual(parsed["total_cache_create_1h"], 60)
+        self.assertEqual(parsed["total_cache_create_5m"], 30)
+        self.assertAlmostEqual(parsed["cache_hit_rate"], 300 / 490, places=6)
+
+    def test_parse_session_turns_extracts_per_turn_ttl_split(self):
+        records = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-04T09:01:00Z",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [{"type": "tool_use", "name": "Read", "input": {}}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 300,
+                        "cache_creation_input_tokens": 90,
+                        "cache_creation": {
+                            "ephemeral_1h_input_tokens": 60,
+                            "ephemeral_5m_input_tokens": 30,
+                        },
+                    },
+                },
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_path = Path(tmpdir) / "session.jsonl"
+            session_path.write_text(
+                "\n".join(json.dumps(r) for r in records) + "\n",
+                encoding="utf-8",
+            )
+
+            turns = measure.parse_session_turns(session_path)
+
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0]["cache_creation"], 90)
+        self.assertEqual(turns[0]["cache_creation_1h"], 60)
+        self.assertEqual(turns[0]["cache_creation_5m"], 30)
+        self.assertEqual(turns[0]["tools_used"], ["Read"])
+
+    def test_parse_session_jsonl_computes_call_gap_stats(self):
+        records = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-04T09:00:00Z",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-04T09:00:30Z",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-04T09:02:00Z",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            },
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_path = Path(tmpdir) / "session.jsonl"
+            session_path.write_text(
+                "\n".join(json.dumps(r) for r in records) + "\n",
+                encoding="utf-8",
+            )
+
+            parsed = measure._parse_session_jsonl(session_path)
+
+        self.assertAlmostEqual(parsed["avg_call_gap_seconds"], 60.0, places=6)
+        self.assertEqual(parsed["max_call_gap_seconds"], 90.0)
+        self.assertEqual(parsed["p95_call_gap_seconds"], 90.0)
+
+    def test_make_session_key_is_stable_for_same_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_path = Path(tmpdir) / "nested" / "session.jsonl"
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text("", encoding="utf-8")
+
+            first = measure._make_session_key(session_path)
+            second = measure._make_session_key(Path(tmpdir) / "nested" / "." / "session.jsonl")
+
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 16)
+
+    def test_init_trends_db_migrates_ttl_columns(self):
+        tmpdir, original_snapshot_dir, original_trends_db = self._with_temp_trends_db()
+        try:
+            conn = sqlite3.connect(str(measure.TRENDS_DB))
+            conn.execute(
+                """CREATE TABLE session_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    jsonl_path TEXT UNIQUE,
+                    date TEXT NOT NULL
+                )"""
+            )
+            conn.commit()
+            conn.close()
+
+            migrated = measure._init_trends_db()
+            cols = {
+                row[1] for row in migrated.execute("PRAGMA table_info(session_log)").fetchall()
+            }
+            migrated.close()
+
+            self.assertIn("cache_create_1h_tokens", cols)
+            self.assertIn("cache_create_5m_tokens", cols)
+            self.assertIn("cache_ttl_scanned", cols)
+            self.assertIn("avg_call_gap_seconds", cols)
+            self.assertIn("max_call_gap_seconds", cols)
+            self.assertIn("p95_call_gap_seconds", cols)
+        finally:
+            measure.SNAPSHOT_DIR = original_snapshot_dir
+            measure.TRENDS_DB = original_trends_db
+            tmpdir.cleanup()
+
+    def test_backfill_cache_ttl_mix_updates_existing_rows(self):
+        records = [
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-04T09:01:00Z",
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "content": [],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_creation_input_tokens": 90,
+                        "cache_creation": {
+                            "ephemeral_1h_input_tokens": 60,
+                            "ephemeral_5m_input_tokens": 30,
+                        },
+                    },
+                },
+            }
+        ]
+
+        tmpdir, original_snapshot_dir, original_trends_db = self._with_temp_trends_db()
+        try:
+            session_path = Path(tmpdir.name) / "session.jsonl"
+            session_path.write_text(
+                "\n".join(json.dumps(r) for r in records) + "\n",
+                encoding="utf-8",
+            )
+
+            conn = measure._init_trends_db()
+            conn.execute(
+                """INSERT INTO session_log
+                   (jsonl_path, date, project, cache_hit_rate, cache_create_1h_tokens,
+                    cache_create_5m_tokens, cache_ttl_scanned)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (str(session_path), datetime.now().strftime("%Y-%m-%d"), "home", 0.0, 0, 0, 0),
+            )
+            conn.commit()
+
+            updated = measure._backfill_session_metrics(conn, days=30, limit=10)
+            row = conn.execute(
+                """SELECT cache_create_1h_tokens, cache_create_5m_tokens, cache_ttl_scanned,
+                          avg_call_gap_seconds, max_call_gap_seconds, p95_call_gap_seconds
+                   FROM session_log WHERE jsonl_path = ?""",
+                (str(session_path),),
+            ).fetchone()
+            conn.close()
+
+            self.assertEqual(updated, 1)
+            self.assertEqual(row[0], 60)
+            self.assertEqual(row[1], 30)
+            self.assertEqual(row[2], 1)
+            self.assertIsNone(row[3])
+            self.assertIsNone(row[4])
+            self.assertIsNone(row[5])
+        finally:
+            measure.SNAPSHOT_DIR = original_snapshot_dir
+            measure.TRENDS_DB = original_trends_db
+            tmpdir.cleanup()
+
+    def test_build_ttl_period_summary_formats_all_1h_only(self):
+        original_collect = measure._collect_trends_data
+        try:
+            measure._collect_trends_data = lambda days=30: {
+                "daily": [
+                    {
+                        "session_details": [
+                            {"cache_create_1h_tokens": 10, "cache_create_5m_tokens": 0},
+                            {"cache_create_1h_tokens": 20, "cache_create_5m_tokens": 0},
+                        ]
+                    }
+                ]
+            }
+            summary = measure._build_ttl_period_summary(7)
+            self.assertEqual(summary["label"], "7d: all 1h-only")
+            self.assertEqual(summary["mixed_sessions"], 0)
+            self.assertEqual(summary["five_only_sessions"], 0)
+            self.assertEqual(summary["one_hour_only_sessions"], 2)
+        finally:
+            measure._collect_trends_data = original_collect
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_claude_checkpoint_policy.py
+++ b/tests/test_claude_checkpoint_policy.py
@@ -1,0 +1,156 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "token-optimizer"
+    / "scripts"
+    / "measure.py"
+)
+
+spec = importlib.util.spec_from_file_location("token_optimizer_measure", MODULE_PATH)
+measure = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(measure)
+
+
+class ClaudeCheckpointPolicyTests(unittest.TestCase):
+    def test_list_checkpoints_parses_new_trigger_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_dir = Path(tmpdir)
+            files = [
+                "sess-20260403-120000-progressive-20.md",
+                "sess-20260403-120100-quality-70.md",
+                "sess-20260403-120200-milestone-edit-batch.md",
+                "sess-20260403-120300-end.md",
+            ]
+            for name in files:
+                (checkpoint_dir / name).write_text("# checkpoint\n", encoding="utf-8")
+
+            with mock.patch.object(measure, "CHECKPOINT_DIR", checkpoint_dir):
+                checkpoints = measure.list_checkpoints()
+
+            triggers = {cp["trigger"] for cp in checkpoints}
+            self.assertIn("progressive-20", triggers)
+            self.assertIn("quality-70", triggers)
+            self.assertIn("milestone-edit-batch", triggers)
+            self.assertIn("end", triggers)
+
+    def test_list_checkpoints_skips_symlinked_checkpoint_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            checkpoint_dir = Path(tmpdir)
+            outside = checkpoint_dir.parent / "outside-checkpoint.md"
+            outside.write_text("secret", encoding="utf-8")
+            (checkpoint_dir / "sess-20260403-120000-progressive-20.md").symlink_to(outside)
+
+            with mock.patch.object(measure, "CHECKPOINT_DIR", checkpoint_dir):
+                checkpoints = measure.list_checkpoints()
+
+            self.assertEqual(checkpoints, [])
+
+    def test_checkpoint_trigger_captures_pre_fanout_once(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            session_file = Path(tmpdir) / "session.jsonl"
+            session_file.write_text("", encoding="utf-8")
+            cache_path = Path(tmpdir) / "quality-cache-session.json"
+
+            with (
+                mock.patch.object(measure, "_quality_cache_path_for", return_value=cache_path),
+                mock.patch.object(measure, "_read_quality_cache", return_value={"score": 82, "fill_pct": 21.0}),
+                mock.patch.object(measure, "_checkpoint_cooldown_remaining", return_value=0),
+                mock.patch.object(measure, "compact_capture", return_value="/tmp/cp.md") as compact_capture,
+                mock.patch.object(measure, "_record_checkpoint_metadata") as record_meta,
+            ):
+                result = measure.checkpoint_trigger(
+                    milestone="pre-fanout",
+                    session_id="session",
+                    transcript_path=str(session_file),
+                    quiet=True,
+                )
+
+            self.assertEqual(result, "/tmp/cp.md")
+            compact_capture.assert_called_once()
+            record_meta.assert_called_once()
+
+            with (
+                mock.patch.object(measure, "_quality_cache_path_for", return_value=cache_path),
+                mock.patch.object(
+                    measure,
+                    "_read_quality_cache",
+                    return_value={"milestones_captured": ["pre-fanout"]},
+                ),
+                mock.patch.object(measure, "_checkpoint_cooldown_remaining", return_value=0),
+                mock.patch.object(measure, "compact_capture") as compact_capture,
+            ):
+                result = measure.checkpoint_trigger(
+                    milestone="pre-fanout",
+                    session_id="session",
+                    transcript_path=str(session_file),
+                    quiet=True,
+                )
+
+            self.assertIsNone(result)
+            compact_capture.assert_not_called()
+
+    def test_quality_threshold_checkpoint_fires_on_first_drop(self):
+        result = {"score": 69.0, "fill_pct": 24.0}
+        quality_data = {"writes": []}
+
+        with (
+            mock.patch.object(measure, "_checkpoint_cooldown_remaining", return_value=0),
+            mock.patch.object(measure, "compact_capture", return_value="/tmp/quality.md") as compact_capture,
+            mock.patch.object(measure, "_record_checkpoint_metadata") as record_meta,
+        ):
+            measure._maybe_checkpoint_on_quality_or_milestone(
+                quality_data=quality_data,
+                cache_path=Path("/tmp/cache.json"),
+                result=result,
+                filepath=Path("/tmp/session.jsonl"),
+            )
+
+        compact_capture.assert_called_once()
+        self.assertEqual(compact_capture.call_args.kwargs["trigger"], "quality-80")
+        self.assertEqual(result["quality_thresholds_captured"], [80])
+        record_meta.assert_called_once()
+
+    def test_edit_batch_checkpoint_uses_write_threshold(self):
+        result = {
+            "score": 92.0,
+            "fill_pct": 37.0,
+            "edit_batch_marker": {"write_count": 0, "unique_file_count": 0},
+        }
+        quality_data = {
+            "writes": [
+                (1, "/tmp/a.py", "t1"),
+                (2, "/tmp/b.py", "t2"),
+                (3, "/tmp/a.py", "t3"),
+                (4, "/tmp/c.py", "t4"),
+            ]
+        }
+
+        with (
+            mock.patch.object(measure, "_checkpoint_cooldown_remaining", return_value=0),
+            mock.patch.object(measure, "compact_capture", return_value="/tmp/edit-batch.md") as compact_capture,
+            mock.patch.object(measure, "_record_checkpoint_metadata") as record_meta,
+        ):
+            measure._maybe_checkpoint_on_quality_or_milestone(
+                quality_data=quality_data,
+                cache_path=Path("/tmp/cache.json"),
+                result=result,
+                filepath=Path("/tmp/session.jsonl"),
+            )
+
+        compact_capture.assert_called_once()
+        self.assertEqual(compact_capture.call_args.kwargs["trigger"], "milestone-edit-batch")
+        self.assertEqual(result["edit_batch_marker"]["write_count"], 4)
+        self.assertEqual(result["edit_batch_marker"]["unique_file_count"], 3)
+        record_meta.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- `test_backfill_cache_ttl_mix_updates_existing_rows` hardcoded `date = "2026-04-04"`, which is now > 30 days in the past
- `_backfill_session_metrics` filters `WHERE date >= cutoff` (today − 30 days ≈ 2026-05-23), so the row was silently skipped and `updated == 0 != 1`
- Fix: replace the literal with `datetime.now().strftime("%Y-%m-%d")` so the test row is always within the backfill window
- Also adds `sys.path` preamble so `measure.py`'s local imports (`hook_io`, `plugin_env`, etc.) resolve without an editable install
- Removes `tests/` from `.gitignore` so the test suite can be tracked

## Test plan

- [x] `python3 -m pytest tests/test_cache_ttl_mix.py -v` — all 7 tests pass
- [x] Confirmed `test_backfill_cache_ttl_mix_updates_existing_rows` was previously `FAILED: AssertionError: 0 != 1` and is now `PASSED`

STEWARD-RISK: low
STEWARD-CLASS: test