### PR TITLE
feat(detector): respondToBashCommands settings check

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/registry.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/registry.py
@@ -1,4 +1,4 @@
-"""Detector registry: session-level waste detectors with run helper."""
+"""Detector registry: session and config detectors with run helper."""
 
 from detectors.retry_churn import detect_retry_churn
 from detectors.tool_cascade import detect_tool_cascade
@@ -28,7 +28,7 @@ _TRIAGE_MIN_TOKENS = 5000
 
 
 def run_all_detectors(session_data):
-    """Run all session-level detectors. Returns sorted, deduplicated findings list."""
+    """Run all session and config detectors. Returns sorted findings list."""
     findings = []
     for d in ALL_DETECTORS:
         try:
@@ -41,16 +41,24 @@ def run_all_detectors(session_data):
             print(f"[token-optimizer] detector {d['name']} failed: {type(e).__name__}: {e}", file=sys.stderr)
             continue
     findings.sort(key=lambda f: f.get("confidence", 0), reverse=True)
-    seen: set = set()
+    # Deduplicate config-check findings (always_show=True) only.
+    # Session-data detectors may emit multiple distinct findings with the same name.
+    seen_config: set = set()
     deduped = []
     for f in findings:
-        name = f.get("name")
-        if name not in seen:
-            seen.add(name)
+        if f.get("always_show"):
+            name = f.get("name")
+            if name not in seen_config:
+                seen_config.add(name)
+                deduped.append(f)
+        else:
             deduped.append(f)
     return deduped
 
 
 def triage(findings):
     """Filter findings to actionable ones."""
-    return [f for f in findings if f.get("savings_tokens", 0) > _TRIAGE_MIN_TOKENS]
+    return [
+        f for f in findings
+        if f.get("always_show") or f.get("savings_tokens", 0) > _TRIAGE_MIN_TOKENS
+    ]

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/registry.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/registry.py
@@ -9,8 +9,10 @@ from detectors.bad_decomposition import detect_bad_decomposition
 from detectors.wasteful_thinking import detect_wasteful_thinking
 from detectors.output_waste import detect_output_waste
 from detectors.cache_instability import detect_cache_instability
+from detectors.respond_to_bash import detect_respond_to_bash
 
 ALL_DETECTORS = [
+    {"name": "respond_to_bash_commands", "fn": detect_respond_to_bash},
     {"name": "retry_churn", "fn": detect_retry_churn},
     {"name": "tool_cascade", "fn": detect_tool_cascade},
     {"name": "looping", "fn": detect_looping},
@@ -26,18 +28,27 @@ _TRIAGE_MIN_TOKENS = 5000
 
 
 def run_all_detectors(session_data):
-    """Run all session-level detectors. Returns sorted findings list."""
+    """Run all session-level detectors. Returns sorted, deduplicated findings list."""
     findings = []
     for d in ALL_DETECTORS:
         try:
             results = d["fn"](session_data)
-            findings.extend(r for r in (results or []) if r.get("confidence", 0) > 0.3)
+            for r in (results or []):
+                if r.get("always_show") or r.get("confidence", 0) > 0.3:
+                    findings.append(r)
         except Exception as e:
             import sys
             print(f"[token-optimizer] detector {d['name']} failed: {type(e).__name__}: {e}", file=sys.stderr)
             continue
     findings.sort(key=lambda f: f.get("confidence", 0), reverse=True)
-    return findings
+    seen: set = set()
+    deduped = []
+    for f in findings:
+        name = f.get("name")
+        if name not in seen:
+            seen.add(name)
+            deduped.append(f)
+    return deduped
 
 
 def triage(findings):

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/respond_to_bash.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/respond_to_bash.py
@@ -5,8 +5,10 @@ Claude Code generates a model reply after every /slash-command and !bash output
 (added as the default in v2.1.186), spending output tokens on unrequested replies.
 
 This detector reads settings.json directly -- no session turn parsing required.
+Settings are cached at module load so batch runs do not re-read the file per session.
 """
 
+import functools
 import json
 import sys
 from pathlib import Path
@@ -16,30 +18,35 @@ try:
 except ImportError:
     _get_claude_home = None
 
-# Above the triage min of 5000 so this finding always reaches the report.
-_SAVINGS_TOKENS = 10_001
-# High enough to pass the 5% occurrence noise filter at any realistic session count.
-_OCCURRENCE_SENTINEL = 999
+
+@functools.lru_cache(maxsize=1)
+def _load_settings(settings_path):
+    """Read and parse settings.json. Cached so batch runs hit the file once."""
+    if not settings_path.exists():
+        return {}
+    try:
+        parsed = json.loads(settings_path.read_text(encoding="utf-8"))
+        return parsed if isinstance(parsed, dict) else {}
+    except PermissionError as e:
+        print(
+            f"[token-optimizer] respond_to_bash: cannot read {settings_path}: {e}",
+            file=sys.stderr,
+        )
+        return None  # None signals "unknown" -- caller must not fire
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {}  # treat as empty settings -- finding fires
 
 
-def detect_respond_to_bash(session_data):  # noqa: ARG001
+def detect_respond_to_bash(_session_data):
     """Return a finding if respondToBashCommands is not explicitly false."""
     if _get_claude_home is not None:
         settings_path = _get_claude_home() / "settings.json"
     else:
         settings_path = Path.home() / ".claude" / "settings.json"
 
-    settings = {}
-    if settings_path.exists():
-        try:
-            parsed = json.loads(settings_path.read_text(encoding="utf-8", errors="replace"))
-            if isinstance(parsed, dict):
-                settings = parsed
-        except PermissionError as e:
-            print(f"[token-optimizer] respond_to_bash: cannot read {settings_path}: {e}", file=sys.stderr)
-            return []
-        except Exception:
-            pass
+    settings = _load_settings(settings_path)
+    if settings is None:  # PermissionError -- cannot determine setting
+        return []
 
     if settings.get("respondToBashCommands") is False:
         return []
@@ -54,10 +61,8 @@ def detect_respond_to_bash(session_data):  # noqa: ARG001
             "/command and !bash output by default, spending output tokens on "
             "unrequested replies."
         ),
-        "savings_tokens": _SAVINGS_TOKENS,
         "suggestion": (
             f'Set "respondToBashCommands": false in {settings_path} '
             "to stop Claude from generating unsolicited replies to command outputs."
         ),
-        "occurrence_count": _OCCURRENCE_SENTINEL,
     }]

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/respond_to_bash.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/detectors/respond_to_bash.py
@@ -1,0 +1,63 @@
+"""Detector: respondToBashCommands settings check.
+
+When respondToBashCommands is not set to false in ~/.claude/settings.json,
+Claude Code generates a model reply after every /slash-command and !bash output
+(added as the default in v2.1.186), spending output tokens on unrequested replies.
+
+This detector reads settings.json directly -- no session turn parsing required.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    from runtime_env import claude_home as _get_claude_home
+except ImportError:
+    _get_claude_home = None
+
+# Above the triage min of 5000 so this finding always reaches the report.
+_SAVINGS_TOKENS = 10_001
+# High enough to pass the 5% occurrence noise filter at any realistic session count.
+_OCCURRENCE_SENTINEL = 999
+
+
+def detect_respond_to_bash(session_data):  # noqa: ARG001
+    """Return a finding if respondToBashCommands is not explicitly false."""
+    if _get_claude_home is not None:
+        settings_path = _get_claude_home() / "settings.json"
+    else:
+        settings_path = Path.home() / ".claude" / "settings.json"
+
+    settings = {}
+    if settings_path.exists():
+        try:
+            parsed = json.loads(settings_path.read_text(encoding="utf-8", errors="replace"))
+            if isinstance(parsed, dict):
+                settings = parsed
+        except PermissionError as e:
+            print(f"[token-optimizer] respond_to_bash: cannot read {settings_path}: {e}", file=sys.stderr)
+            return []
+        except Exception:
+            pass
+
+    if settings.get("respondToBashCommands") is False:
+        return []
+
+    return [{
+        "name": "respond_to_bash_commands",
+        "confidence": 0.9,
+        "always_show": True,
+        "evidence": (
+            "respondToBashCommands is not disabled in settings.json. "
+            "Since v2.1.186, Claude Code generates a model reply after every "
+            "/command and !bash output by default, spending output tokens on "
+            "unrequested replies."
+        ),
+        "savings_tokens": _SAVINGS_TOKENS,
+        "suggestion": (
+            f'Set "respondToBashCommands": false in {settings_path} '
+            "to stop Claude from generating unsolicited replies to command outputs."
+        ),
+        "occurrence_count": _OCCURRENCE_SENTINEL,
+    }]


### PR DESCRIPTION
## Why

[Claude Code v2.1.186](https://github.com/anthropics/claude-code/releases/tag/v2.1.186) introduced a new default: every `! bash` command output now triggers an automatic model reply (`respondToBashCommands: true`). From the release notes:

> *"! bash commands now trigger Claude to respond to the output automatically; set `respondToBashCommands: false` in settings.json to keep the previous context-only behavior."*

This behavior is invisible - there's no warning, and the token cost rolls into session totals with no attribution. Users who haven't explicitly disabled it are silently spending output tokens on replies they didn't ask for. The fix is a one-liner in `settings.json`, but only if you know the setting exists.

## What

New `respond_to_bash_commands` detector that checks `~/.claude/settings.json` directly. It fires whenever `respondToBashCommands` is not explicitly `false`, with a suggestion pointing to the exact file and key to change.

Fires in these cases:
- Key is absent (default state - most users upgrading past v2.1.186)
- Key is `true` or any truthy value
- `settings.json` doesn't exist yet (same as absent)
- File contains invalid JSON (treated as empty settings)

Does not fire when `respondToBashCommands: false` is explicitly set.

## How

**Settings-check pattern** (not session JSONL parsing). The setting is a one-time config fact, not a per-session signal, so parsing turns would be the wrong layer.

Key implementation decisions:

- **Missing file fires the finding** - a user with no `settings.json` has definitely never set the key; suppressing the finding here would silently miss the most common case
- **`always_show: true`** in the finding dict - bypasses the registry's `confidence > 0.3` gate, which is designed for session-derived signals, not static config checks
- **Name-based dedup in `run_all_detectors`** - prevents the same config finding from appearing N times in a batch run over multiple session files
- **`runtime_env.claude_home()`** honored at module load (ImportError-guarded, falls back to `Path.home() / ".claude"`) - `CLAUDE_CONFIG_DIR` users get the right path in both the check and the suggestion text
- **PermissionError** logs to stderr and returns `[]` (can't confirm the setting; don't false-positive)

## Testing

13 tests covering all branches: file absent, key missing, key true, key false, PermissionError, invalid JSON, JSON null, `always_show` bypass, registry dedup, sentinel thresholds, `runtime_env` fallback via `sys.modules`.