### PR TITLE
Redact credentials passed as URL query parameters

### DIFF
--- a/skills/token-optimizer/scripts/credential_patterns.py
+++ b/skills/token-optimizer/scripts/credential_patterns.py
@@ -34,6 +34,11 @@ CREDENTIAL_PATTERNS: List[Tuple[str, "re.Pattern[str]"]] = [
     ("PEM private key",         re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
     ("Database URI",            re.compile(r"(?:postgres|postgresql|mysql|mongodb|mongodb\+srv|redis)://[^:\s/]+:[^@\s]+@", re.I)),
     ("HTTP basic auth URL",     re.compile(r"https?://[^:\s/@]+:[^@\s]+@", re.I)),
+    # Credentials passed as URL query parameters (e.g. ?token=..., ?api_key=...).
+    # The named `keep` group captures the "?name=" prefix so redaction preserves the
+    # parameter name and blanks only the value (see redact_credentials). The value
+    # match stops at the next `&`, whitespace, or quote so following params survive.
+    ("URL auth param",          re.compile(r"(?P<keep>[?&](?:token|key|api[_-]?key|access[_-]?token|auth)=)[^&\s\"']+", re.I)),
 ]
 
 # Bare compiled patterns list for backward compat with bash_compress.py
@@ -52,7 +57,16 @@ def scan_for_credentials(text: str) -> List[Tuple[str, str, int]]:
 
 
 def redact_credentials(text: str) -> str:
-    """Replace credential matches with [CREDENTIAL REDACTED: <type>] placeholders."""
+    """Replace credential matches with [CREDENTIAL REDACTED: <type>] placeholders.
+
+    A pattern may define a named `keep` group for a non-secret prefix that should
+    survive redaction (e.g. the "?token=" part of a URL auth parameter); only the
+    value after it is replaced. Patterns without a `keep` group redact the whole
+    match, unchanged.
+    """
     for label, pat in CREDENTIAL_PATTERNS:
-        text = pat.sub(f"[CREDENTIAL REDACTED: {label}]", text)
+        if "keep" in pat.groupindex:
+            text = pat.sub(rf"\g<keep>[CREDENTIAL REDACTED: {label}]", text)
+        else:
+            text = pat.sub(f"[CREDENTIAL REDACTED: {label}]", text)
     return text

--- a/tests/test_credential_patterns.py
+++ b/tests/test_credential_patterns.py
@@ -1,0 +1,100 @@
+"""Credential redaction tests for credential_patterns.py.
+
+Focus: the URL auth-param class (credentials passed as URL query parameters such
+as ?token=... / ?api_key=...), which archive_result.py archives verbatim unless
+redacted. Also guards that adding this pattern does not regress the existing
+full-match patterns or over-match benign query parameters.
+
+All fixtures are invented; no real secret appears here.
+
+Run: python3 -m pytest tests/test_credential_patterns.py -v
+"""
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "skills", "token-optimizer", "scripts",
+)
+sys.path.insert(0, _SCRIPTS)
+
+from credential_patterns import (  # noqa: E402
+    CREDENTIAL_PATTERNS,
+    redact_credentials,
+    scan_for_credentials,
+)
+
+# Fake value substrings we assert never survive redaction.
+_FAKE_TOKEN = "FAKE_URL_TOKEN_123"
+_FAKE_API_KEY = "FAKE_API_KEY_456"
+_FAKE_ACCESS = "FAKE_ACCESS_789"
+_FAKE_AUTH = "FAKE_AUTH_000"
+
+
+@pytest.mark.parametrize(
+    "raw, secret",
+    [
+        (f"GET https://example.com/alerts?token={_FAKE_TOKEN} HTTP/1.1", _FAKE_TOKEN),
+        (f"curl https://api.example.com/v1/data?api_key={_FAKE_API_KEY}", _FAKE_API_KEY),
+        (f"https://x.example.com/p?access_token={_FAKE_ACCESS}&next=1", _FAKE_ACCESS),
+        (f"https://x.example.com/p?auth={_FAKE_AUTH}", _FAKE_AUTH),
+        (f"https://x.example.com/p?api-key={_FAKE_API_KEY}", _FAKE_API_KEY),
+        (f"wss://x.example.com/stream?key={_FAKE_TOKEN}", _FAKE_TOKEN),
+    ],
+)
+def test_url_auth_param_value_is_redacted(raw, secret):
+    out = redact_credentials(raw)
+    assert secret not in out, f"value leaked verbatim: {out!r}"
+    assert "[CREDENTIAL REDACTED: URL auth param]" in out
+
+
+def test_param_name_is_preserved():
+    """Only the value is blanked; the parameter name survives for context."""
+    out = redact_credentials(f"https://example.com/a?token={_FAKE_TOKEN}")
+    assert out == "https://example.com/a?token=[CREDENTIAL REDACTED: URL auth param]"
+
+
+def test_following_params_survive():
+    """The value match stops at '&' so subsequent params are not swallowed."""
+    out = redact_credentials(
+        f"https://example.com/a?access_token={_FAKE_ACCESS}&page=2&sort=asc"
+    )
+    assert _FAKE_ACCESS not in out
+    assert "&page=2&sort=asc" in out
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "https://example.com/list?page=2&sort=asc",
+        "https://example.com/items?monkey=1&donkey=2",  # 'key' only as a substring
+        "https://example.com/search?q=token+auth&lang=en",  # words, not param names
+        "https://example.com/x?tokenizer=fast",  # 'token' is a prefix of the name
+    ],
+)
+def test_benign_params_not_over_matched(raw):
+    assert redact_credentials(raw) == raw
+    assert "REDACTED" not in redact_credentials(raw)
+
+
+def test_existing_patterns_still_redact():
+    """Regression: representative pre-existing patterns still fully redact."""
+    samples = {
+        "AWS access key": "AKIA" + "A" * 16,
+        "GitHub OAuth token": "gho_" + "b" * 36,
+        "Bearer token": "Authorization: Bearer abc.def_ghi-123",
+        "Database URI": "postgres://user:s3cret@db.example.com/app",
+    }
+    for label, raw in samples.items():
+        out = redact_credentials(raw)
+        assert f"[CREDENTIAL REDACTED: {label}]" in out, (label, out)
+
+
+def test_pattern_registered_and_labelled():
+    labels = [label for label, _ in CREDENTIAL_PATTERNS]
+    assert "URL auth param" in labels
+    # scan surfaces the label too (used for coverage reporting).
+    hits = scan_for_credentials(f"https://example.com/a?token={_FAKE_TOKEN}")
+    assert any(label == "URL auth param" for label, _match, _ln in hits)


### PR DESCRIPTION
## Problem

The credential redactor in `credential_patterns.py` ships 22 patterns (Bearer tokens, key-shaped strings, DB URIs, HTTP basic-auth URLs, etc.), but none of them match a credential passed as a **URL query parameter**. Tool output frequently contains such URLs, and `archive_result.py` archives it verbatim after redaction, so a query-param secret lands unredacted in both the tool-archive JSON and the SQLite preview.

### Repro (before this change)

```python
from credential_patterns import redact_credentials
redact_credentials("GET https://example.com/alerts?token=SECRETVALUE HTTP/1.1")
# -> 'GET https://example.com/alerts?token=SECRETVALUE HTTP/1.1'   (unchanged!)
```

The same holds for `?api_key=`, `?access_token=`, `?auth=`, etc. Because `archive_result._redact_credentials` delegates to this function, the value is written to the archive as-is.

## Fix

Add a 23rd pattern for the URL auth-param class, matching the common credential-bearing parameter names case-insensitively:

```
?token= | ?key= | ?api_key= | ?api-key= | ?access_token= | ?auth=
```

A named `keep` group captures the `?name=` prefix so redaction **preserves the parameter name and blanks only the value**, and the value match stops at the next `&`, whitespace, or quote so any following parameters survive:

```python
redact_credentials("https://example.com/a?access_token=SECRET&page=2")
# -> 'https://example.com/a?access_token=[CREDENTIAL REDACTED: URL auth param]&page=2'
```

`redact_credentials` now honors a `keep` group generically; **the existing 22 patterns are unchanged** (they have no `keep` group and continue to redact the whole match). This complements the existing redactor rather than altering it, and stays within `SECURITY.md`'s redact-before-write model (the value is blanked before it is ever persisted).

## Tests

Adds `tests/test_credential_patterns.py` (force-added past the `tests/` gitignore rule, matching the existing test files) covering:

- value redaction across `token` / `api_key` / `api-key` / `access_token` / `auth` / `key`
- parameter-name preservation (only the value is blanked)
- following params surviving (`&page=2&sort=asc` is not swallowed)
- **negative cases** that must NOT be redacted: `?page=2`, `?monkey=1` (contains `key` only as a substring), `?tokenizer=fast` (`token` only as a name prefix), and query values that merely contain the words `token`/`auth`
- a regression check that representative existing patterns still fully redact

All fixtures are fake (e.g. `FAKE_URL_TOKEN_123`); no real secret appears anywhere.

```
$ python3 -m pytest tests/ -v
53 passed
```

(39 pre-existing tests + 14 new; the full suite is green.)

## Notes

- Single file of production change (`credential_patterns.py`), 16 insertions / 2 changed lines; no change to the public `CREDENTIAL_PATTERNS` tuple shape, so `measure.py`, `bash_compress.py`, and `read_cache.py` consumers are unaffected (the security-report credential count simply goes 22 -> 23).
- I did not touch `CHECKSUMS.sha256`, since that is regenerated at release time.
