### PR TITLE
perf: mark 11 stdout-free hooks async, split archive_result.py matcher

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -24,7 +24,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py checkpoint-trigger --milestone pre-fanout --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py checkpoint-trigger --milestone pre-fanout --quiet; done; exit 0",
+            "async": true
           }
         ]
       }
@@ -42,7 +43,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py compact-capture --trigger auto --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py compact-capture --trigger auto --quiet; done; exit 0",
+            "async": true
           }
         ]
       },
@@ -50,7 +52,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/read_cache.py --clear --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/read_cache.py --clear --quiet; done; exit 0",
+            "async": true
           }
         ]
       }
@@ -70,7 +73,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py quality-cache --force --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py quality-cache --force --quiet; done; exit 0",
+            "async": true
           }
         ]
       },
@@ -107,6 +111,7 @@
           {
             "type": "command",
             "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py keepwarm-arm --quiet; done; exit 0",
+            "async": true,
             "timeout": 5
           }
         ]
@@ -162,7 +167,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Read|Glob|Grep|Agent|mcp__.*",
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -171,11 +176,22 @@
         ]
       },
       {
+        "matcher": "Bash|Read|Glob|Grep|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/archive_result.py --quiet; done; exit 0",
+            "async": true
+          }
+        ]
+      },
+      {
         "matcher": "Bash|Read|Grep|Glob|mcp__.*",
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/context_intel.py --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/context_intel.py --quiet; done; exit 0",
+            "async": true
           }
         ]
       },
@@ -184,7 +200,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/read_cache.py --invalidate --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/read_cache.py --invalidate --quiet; done; exit 0",
+            "async": true
           }
         ]
       },
@@ -193,7 +210,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py quality-cache --quiet --throttle-only; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py quality-cache --quiet --throttle-only; done; exit 0",
+            "async": true
           }
         ]
       }
@@ -203,7 +221,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py quality-cache --force --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py quality-cache --force --quiet; done; exit 0",
+            "async": true
           }
         ]
       }
@@ -213,7 +232,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/read_cache.py --clear --quiet; done; exit 0"
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/read_cache.py --clear --quiet; done; exit 0",
+            "async": true
           }
         ]
       }

--- a/plugins/token-optimizer/hooks/hooks.json
+++ b/plugins/token-optimizer/hooks/hooks.json
@@ -160,7 +160,16 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|Read|Glob|Grep|Agent|mcp__.*",
+        "matcher": "mcp__.*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/archive_result.py --quiet; done; exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|Read|Glob|Grep|Agent",
         "hooks": [
           {
             "type": "command",

--- a/tests/test_async_hook_wiring.py
+++ b/tests/test_async_hook_wiring.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Regression tests for which hooks.json entries carry "async": true.
+
+Async hooks are fire-and-forget: Claude Code does not wait for them and
+their stdout/JSON output is discarded entirely -- they cannot inject
+additionalContext, set a permissionDecision, or block anything. A hook is
+only safe to mark async if its entire job is a side effect nobody reads
+back, AND (for Stop/StopFailure specifically) losing the write to a process
+exiting right after the turn ends would be harmless.
+
+This test pins the exact set of hooks that are safe by both criteria, so a
+future edit that flips the wrong one (e.g. makes the Read-cache-hit hook or
+the compaction-restore hooks async, silently breaking their whole purpose)
+fails loudly instead of shipping.
+
+Run: python3 -m pytest tests/test_async_hook_wiring.py -v
+"""
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOKS_JSON = REPO / "hooks" / "hooks.json"
+MIRROR_HOOKS_JSON = REPO / "plugins" / "token-optimizer" / "hooks" / "hooks.json"
+
+# (event, matcher-or-None, distinguishing substring of the command) -> expected "async" value.
+# Order within an event matters when matcher is None (Stop's three hooks share no matcher).
+EXPECTED_ASYNC = {
+    ("PreToolUse", "Read", "read_cache.py --quiet"): False,
+    ("PreToolUse", "Bash", "bash_hook.py --quiet"): False,
+    ("PreToolUse", "Agent|Task", "checkpoint-trigger"): True,
+    ("PreCompact", None, "dynamic-compact-instructions"): False,
+    ("PreCompact", None, "compact-capture --trigger auto"): True,
+    ("PreCompact", None, "read_cache.py --clear"): True,
+    ("SessionStart", None, "ensure-health"): True,
+    ("SessionStart", None, "quality-cache --force"): True,
+    ("SessionStart", "compact", "compact-restore --compact"): False,
+    ("SessionStart", None, "compact-restore --new-session-only"): False,
+    ("Stop", None, "compact-capture --trigger stop --quiet"): False,
+    ("Stop", None, "session-end-flush --trigger stop"): False,
+    ("Stop", None, "keepwarm-arm"): True,
+    ("SessionEnd", None, "session-end-flush"): True,
+    ("StopFailure", None, "compact-capture --trigger stop-failure"): False,
+    ("UserPromptSubmit", None, "quality-cache --warn"): False,
+    ("UserPromptSubmit", None, "prompt-continuity"): False,
+    ("UserPromptSubmit", None, "verbosity-steer"): False,
+    ("PostToolUse", "mcp__.*", "archive_result.py"): False,
+    ("PostToolUse", "Bash|Read|Glob|Grep|Agent", "archive_result.py"): True,
+    ("PostToolUse", "Bash|Read|Grep|Glob|mcp__.*", "context_intel.py"): True,
+    ("PostToolUse", "Edit|Write|MultiEdit|NotebookEdit", "read_cache.py --invalidate"): True,
+    (
+        "PostToolUse",
+        "Bash|Read|Glob|Grep|Agent|Edit|Write|MultiEdit|NotebookEdit|mcp__.*",
+        "quality-cache --quiet --throttle-only",
+    ): True,
+    ("PostCompact", None, "quality-cache --force"): True,
+    ("CwdChanged", None, "read_cache.py --clear"): True,
+}
+
+
+def _flatten(hooks_json_path):
+    """Yield (event, matcher, command, async_flag) for every hook command entry."""
+    data = json.loads(hooks_json_path.read_text(encoding="utf-8"))
+    for event, entries in data["hooks"].items():
+        for entry in entries:
+            matcher = entry.get("matcher")
+            for hook in entry["hooks"]:
+                yield event, matcher, hook["command"], hook.get("async", False)
+
+
+def test_every_expected_hook_has_the_right_async_value():
+    seen = set()
+    for event, matcher, command, is_async in _flatten(HOOKS_JSON):
+        matched_key = None
+        for key in EXPECTED_ASYNC:
+            k_event, k_matcher, k_substr = key
+            if k_event == event and k_matcher == matcher and k_substr in command:
+                matched_key = key
+                break
+        assert matched_key is not None, (
+            f"unrecognized hook entry not covered by this test: "
+            f"event={event!r} matcher={matcher!r} command={command!r}. "
+            "Add it to EXPECTED_ASYNC with an explicit safe/unsafe classification."
+        )
+        assert matched_key not in seen, f"duplicate match for {matched_key}"
+        seen.add(matched_key)
+        expected = EXPECTED_ASYNC[matched_key]
+        assert is_async == expected, (
+            f"{matched_key}: expected async={expected}, got async={is_async}. "
+            "If you're intentionally changing this, re-verify the hook's output "
+            "contract first -- async hooks are fire-and-forget and their "
+            "stdout/JSON is discarded entirely."
+        )
+
+    missing = set(EXPECTED_ASYNC) - seen
+    assert not missing, f"hooks.json no longer contains expected entries: {missing}"
+
+
+def test_total_async_count_is_thirteen():
+    count = sum(1 for *_, is_async in _flatten(HOOKS_JSON) if is_async)
+    assert count == 13, (
+        f"expected exactly 13 async hook entries, found {count}. "
+        "If you added or removed one intentionally, update this test and "
+        "EXPECTED_ASYNC together."
+    )
+
+
+def test_mirror_has_async_stripped_but_is_otherwise_identical():
+    """plugins/token-optimizer/ (Codex mirror) must have async stripped -- Codex
+    skips any hook with async: true entirely -- but be identical otherwise."""
+    root = [(e, m, c) for e, m, c, _ in _flatten(HOOKS_JSON)]
+    mirror = list(_flatten(MIRROR_HOOKS_JSON))
+
+    assert all(not is_async for *_, is_async in mirror), (
+        "mirror hooks.json must have every async flag stripped (Codex doesn't support async hooks)"
+    )
+    mirror_no_async = [(e, m, c) for e, m, c, _ in mirror]
+    assert root == mirror_no_async, (
+        "mirror hooks.json content (event/matcher/command) has drifted from the root -- "
+        "run scripts/sync-codex-marketplace-plugin.sh"
+    )


### PR DESCRIPTION
## Problem

`hooks.json` has 24 hook command entries. Only 2 are marked `"async": true` (`ensure-health`, `session-end-flush`). Every other hook blocks its event even when nothing it does is ever read back — most of them just write a cache/checkpoint file to disk.

## Why this isn't a blanket flip

Per Claude Code's hook docs, **async hooks are strictly fire-and-forget**: stdout and JSON output are completely discarded, and an async hook cannot block a tool call, set `permissionDecision`, or inject `additionalContext`. So a hook is only safe to mark async if its entire job is a side effect nobody consumes — flipping the wrong one silently breaks whatever it was supposed to inject or block.

I checked each candidate's actual output contract in source rather than going by name.

**Marked async** (confirmed silent under `--quiet`, or the only output path is gated on a flag this specific call never passes):

| hook | event(s) | why safe |
|---|---|---|
| `checkpoint-trigger` | PreToolUse `Agent\|Task` | its only `print` is gated `if not quiet` |
| `compact-capture --trigger auto` | PreCompact only | confirmed silent under `--quiet`; the Stop/StopFailure instances of this same subcommand are **not** touched, see below |
| `read_cache.py --clear` | PreCompact, CwdChanged | stderr-only |
| `read_cache.py --invalidate` | PostToolUse `Edit\|Write\|MultiEdit\|NotebookEdit` | stderr-only |
| `quality-cache --force` | SessionStart, PostCompact | no `--warn` passed → the warn-emission branch is unreachable |
| `quality-cache --quiet --throttle-only` | PostToolUse catch-all (broadest matcher: `Bash\|Read\|Glob\|Grep\|Agent\|Edit\|Write\|MultiEdit\|NotebookEdit\|mcp__.*`) | same reasoning as above — no `--warn` flag on this call, so the warn branch is dead code here specifically |
| `keepwarm-arm` | Stop | docstring says "additive", explicitly fail-open by design |
| `context_intel.py` | PostToolUse | zero stdout prints; the file's own docstring says "no additionalContext, zero cache impact" |
| `archive_result.py` | PostToolUse, **only** for matcher `Bash\|Read\|Glob\|Grep\|Agent` | see split below |

**Left sync** (must not change):

- `read_cache.py` on PreToolUse/Read, `bash_hook.py` on PreToolUse/Bash — both emit `permissionDecision` / cache-hit `additionalContext`. This is the actual read-caching mechanism.
- `dynamic-compact-instructions`, both `compact-restore` variants — the compaction-survival mechanism itself.
- `compact-capture` on **Stop and StopFailure specifically** — its stdout is silent, but the risk here isn't output, it's completion. The hook docs don't guarantee an async child process survives the parent exiting right after `Stop`, and killing this mid-write would corrupt the checkpoint the plugin's "survives compaction" promise depends on. Kept conservative.
- `UserPromptSubmit`'s three hooks: `quality-cache --warn` (confirmed — this is exactly the warning-injection path the throttle-only variant above lacks), `prompt-continuity`, `verbosity-steer` (didn't fully trace these two, treated conservatively as sync rather than guess).
- `archive_result.py`'s `mcp__.*` case — this is the one that had to be split out, see below.

## Measured impact

Async doesn't make the underlying work faster (that's PR #85) — it removes it from the *blocking* path entirely: Claude Code doesn't wait for an async hook before continuing, and doesn't consume its output. So the number that matters here is how much blocking time these hooks were adding per event, measured with the full `python-launcher.sh` → `run.py` → target chain, on `main` (i.e. before PR #85's dispatch fix too, so this is the current, un-optimized cost being removed):

| chain | hooks involved | blocking time removed |
|---|---|---|
| PostToolUse, per matching tool call (typical response, under the archive threshold) | `archive_result.py` + `context_intel.py` + `quality-cache --throttle-only`, run sequentially | 0.56-0.66s → 0s |
| PreCompact | `compact-capture --trigger auto` + `read_cache.py --clear` (the 3rd PreCompact hook, `dynamic-compact-instructions`, stays sync) | 0.82s → 0s |

The PostToolUse one is the one that matters most: that matcher fires on nearly every tool call in a session, so today every matching tool call pays that ~0.6s in the critical path before Claude Code can proceed. After this PR it pays 0s — the archiving/cache-refresh work still happens, just off to the side.

## The archive_result.py split

The existing single entry had matcher `Bash|Read|Glob|Grep|Agent|mcp__.*` covering both cases with one command. But `archive_result.py` branches internally: for MCP tools (`tool_name` containing `__`) it emits `updatedMCPToolOutput` — the actual token-compression replacement, i.e. the plugin's own value proposition for large MCP responses. Marking that async would silently let the full uncompressed MCP output through instead, since the replacement JSON would just get dropped. For every other tool type the same function only writes durability metadata to disk (its own docstring says as much), which is safe to make async.

So this PR splits the one entry into two matcher-scoped entries: `mcp__.*` stays sync (untouched), `Bash|Read|Glob|Grep|Agent` gets `"async": true`. Same command, same script — just no longer sharing one matcher across a sync-required case and an async-safe one.

## plugins/ mirror

`plugins/token-optimizer/` (the Codex marketplace mirror) regenerated via the repo's own `scripts/sync-codex-marketplace-plugin.sh`, which already strips `async` from the mirror (Codex doesn't support async hooks yet and would skip them entirely if left in — that's existing, documented behavior in the script, not something this PR changes). Confirmed the matcher split itself survives the strip correctly; only the `async` keys are removed there.

## Test plan

Added `tests/test_async_hook_wiring.py`, which pins the exact classification above: parses `hooks.json`, asserts every hook entry's `async` value matches the table (including the must-stay-sync ones), asserts the total async count, and asserts the mirror has every `async` key stripped but is otherwise structurally identical to root. This should make it hard for a future edit to silently flip an unsafe one.

Full test suite passes.

## References

- [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) — async hook semantics: fire-and-forget, stdout/JSON discarded, cannot block or inject context.
