### PR TITLE
fix(opencode): use platform global data dir instead of project dir

### DIFF
--- a/opencode/bun.lock
+++ b/opencode/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "token-optimizer-opencode",

--- a/opencode/src/continuity/restore.ts
+++ b/opencode/src/continuity/restore.ts
@@ -16,6 +16,9 @@ export function restoreCheckpoint(
   userPrompt: string,
   currentSessionId: string,
   config: TokenOptimizerConfig,
+  /** Project slug for scoping session scans under sessions/{slug}/. Derived
+   *  from ctx.project.worktree by the caller (hashProjectDir). */
+  projectSlug?: string,
   /** Optional: when supplied and the prompt shows resume-intent, the lean
    *  reconstruction path fires and savings are credited to trends.db. */
   trendsStore?: TrendsStore,
@@ -25,7 +28,9 @@ export function restoreCheckpoint(
 ): CheckpointMatch | null {
   if (!config.features.continuity) return null;
 
-  const sessDir = join(dataDir, "token-optimizer", "sessions");
+  const sessDir = projectSlug
+    ? join(dataDir, "token-optimizer", "sessions", projectSlug)
+    : join(dataDir, "token-optimizer", "sessions");
   if (!existsSync(sessDir)) return null;
 
   // DB filenames are the sanitized session id, so compare like-for-like or a
@@ -44,6 +49,7 @@ export function restoreCheckpoint(
         userPrompt,
         dataDir,
         safeCurrentId,
+        projectSlug,
         cwd,
         config.checkpointRetentionDays,
         config.checkpointRetentionMax,

--- a/opencode/src/continuity/resume-lean.ts
+++ b/opencode/src/continuity/resume-lean.ts
@@ -410,13 +410,17 @@ export function buildResumeLeanBlock(
   userPrompt: string,
   dataDir: string,
   currentSessionId: string,
+  /** Project slug for scoping session scans under sessions/{slug}/. */
+  projectSlug: string | undefined,
   cwd: string,
   retentionDays: number = 7,
   maxCandidates: number = 50,
 ): [string, string] {
   if (!cwd) return ["", ""];
 
-  const sessDir = join(dataDir, "token-optimizer", "sessions");
+  const sessDir = projectSlug
+    ? join(dataDir, "token-optimizer", "sessions", projectSlug)
+    : join(dataDir, "token-optimizer", "sessions");
   if (!existsSync(sessDir)) return ["", ""];
 
   const candidates = loadSameProjectCheckpoints(

--- a/opencode/src/index.ts
+++ b/opencode/src/index.ts
@@ -2,7 +2,7 @@ import type { Plugin, Hooks, PluginInput, PluginOptions } from "@opencode-ai/plu
 import type { Event } from "@opencode-ai/sdk";
 import { SessionStore } from "./storage/session-store.js";
 import { TrendsStore } from "./storage/trends.js";
-import { resolveConfig } from "./util/env.js";
+import { resolveConfig, resolveDataDir, hashProjectDir } from "./util/env.js";
 import { contextWindowForModel } from "./util/context-window.js";
 import { computeQualityScore, enforceMonotonicity, type QualityResult } from "./quality/scoring.js";
 import {
@@ -95,7 +95,8 @@ export const TokenOptimizerPlugin: Plugin = async (
   options?: PluginOptions,
 ) => {
   const config = resolveConfig(options);
-  const dataDir = ctx.directory;
+  const dataDir = resolveDataDir(config);
+  const projectSlug = hashProjectDir(ctx.project.worktree ?? process.cwd());
 
   const sessions = new Map<string, SessionState>();
   let currentSessionId = "";
@@ -124,7 +125,7 @@ export const TokenOptimizerPlugin: Plugin = async (
       }
     }
 
-    const store = new SessionStore(dataDir, sessionId);
+    const store = new SessionStore(dataDir, sessionId, projectSlug);
     state = {
       store,
       sessionId,
@@ -561,6 +562,7 @@ export const TokenOptimizerPlugin: Plugin = async (
               firstMsg,
               input.sessionID,
               config,
+              projectSlug,
               // Pass trendsStore + cwd so the resume-lean path can credit savings
               // and scope the same-project filter. ctx.project.worktree is the
               // working directory of the project (the canonical cwd for this session).

--- a/opencode/src/storage/session-store.ts
+++ b/opencode/src/storage/session-store.ts
@@ -94,8 +94,9 @@ export class SessionStore {
   private db: Database | null = null;
   private dbPath: string;
 
-  constructor(dataDir: string, sessionId: string) {
-    const sessDir = join(dataDir, "token-optimizer", "sessions");
+  constructor(dataDir: string, sessionId: string, projectSlug?: string) {
+    const base = join(dataDir, "token-optimizer", "sessions");
+    const sessDir = projectSlug ? join(base, projectSlug) : base;
     if (!existsSync(sessDir)) {
       mkdirSync(sessDir, { recursive: true });
     }

--- a/opencode/src/util/env.ts
+++ b/opencode/src/util/env.ts
@@ -1,6 +1,15 @@
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
 import type { PluginOptions } from "@opencode-ai/plugin";
 
 export interface TokenOptimizerConfig {
+  /**
+   * Override the data directory. Defaults to the platform-appropriate global
+   * location (XDG_DATA_HOME on Linux, ~/Library/Application Support on macOS,
+   * %LOCALAPPDATA% on Windows). When unset, the resolved value is cached.
+   */
+  dataDir?: string;
+
   qualityWindow: number;
   toolCallWarnThreshold: number | null;
   toolCallCriticalThreshold: number | null;
@@ -51,6 +60,42 @@ function boolEnv(key: string, fallback: boolean): boolean {
   if (["0", "false", "no", "off"].includes(raw)) return false;
   if (["1", "true", "yes", "on"].includes(raw)) return true;
   return fallback;
+}
+
+export function resolveDataDir(config: TokenOptimizerConfig): string {
+  if (config.dataDir) return config.dataDir;
+  const env = process.env.TOKEN_OPTIMIZER_DATA_DIR;
+  if (env) return env;
+  const home = homedir();
+  switch (platform()) {
+    case "darwin":
+      return join(home, "Library", "Application Support", "token-optimizer");
+    case "win32":
+      return join(
+        process.env.LOCALAPPDATA ?? join(home, "AppData", "Local"),
+        "token-optimizer",
+      );
+    default:
+      return join(
+        process.env.XDG_DATA_HOME ?? join(home, ".local", "share"),
+        "token-optimizer",
+      );
+  }
+}
+
+/**
+ * Encode a project path the same way Claude Code does: replace every
+ * non-alphanumeric character with `-`. Matching this convention means the
+ * token-optimizer session directory structure follows the same project
+ * identity scheme as Claude Code's own `~/.claude/projects/` directories,
+ * making cross-tool project identification consistent.
+ *
+ * Examples:
+ *   /Users/alex/my project  →  -Users-alex-my-project
+ *   D:\\Code\\my app        →  D--Code-my-app
+ */
+export function hashProjectDir(worktree: string): string {
+  return worktree.replace(/[^A-Za-z0-9]/g, "-");
 }
 
 export function resolveConfig(options?: PluginOptions): TokenOptimizerConfig {

--- a/opencode/src/util/env.ts
+++ b/opencode/src/util/env.ts
@@ -63,22 +63,26 @@ function boolEnv(key: string, fallback: boolean): boolean {
 }
 
 export function resolveDataDir(config: TokenOptimizerConfig): string {
-  if (config.dataDir) return config.dataDir;
-  const env = process.env.TOKEN_OPTIMIZER_DATA_DIR;
-  if (env) return env;
+  const from = config.dataDir ?? process.env.TOKEN_OPTIMIZER_DATA_DIR;
+  if (from) {
+    // Strip trailing "token-optimizer" so storage code can safely
+    // join(dataDir, "token-optimizer", ...) without double nesting.
+    // ponytail: guard, remove when storage paths are refactored to take base dir once
+    if (from.endsWith("token-optimizer") || from.endsWith("token-optimizer/"))
+      return from.replace(/\/?token-optimizer\/?$/, "");
+    return from;
+  }
   const home = homedir();
   switch (platform()) {
     case "darwin":
-      return join(home, "Library", "Application Support", "token-optimizer");
+      return join(home, "Library", "Application Support");
     case "win32":
       return join(
         process.env.LOCALAPPDATA ?? join(home, "AppData", "Local"),
-        "token-optimizer",
       );
     default:
       return join(
         process.env.XDG_DATA_HOME ?? join(home, ".local", "share"),
-        "token-optimizer",
       );
   }
 }


### PR DESCRIPTION
Move token-optimizer data storage from project-local to platform global locations.

**Problem:** token-optimizer stored session DBs and trends in `{project}/token-optimizer/`, which polluted git and prevented cross-project trend aggregation.

**Solution:** 
- Data now lives at `~/.local/share/token-optimizer/` (Linux), `~/Library/Application Support/token-optimizer/` (macOS), or `%LOCALAPPDATA%/token-optimizer/` (Windows)
- Overridable via `TOKEN_OPTIMIZER_DATA_DIR` env var or `PluginOptions.dataDir`
- Session DBs scoped per project under `sessions/{project-slug}/` using Claude Code's path-encoding convention (`/Users/alex/my-project` → `-Users-alex-my-project`)
- Existing paths inside storage classes unchanged — just the base `dataDir` resolution changed

**Files changed:**
- `util/env.ts` — added `resolveDataDir()` + `hashProjectDir()`
- `index.ts` — use `resolveDataDir()` instead of `ctx.directory`
- `storage/session-store.ts` — accept `projectSlug` for scoped session dirs
- `continuity/restore.ts` — accept `projectSlug`, scope scan
- `continuity/resume-lean.ts` — accept `projectSlug`, scope scan

```
~/.local/share/token-optimizer/
├── trends.db
├── sessions/
│   ├── -Users-alex-my-project/
│   │   └── {sessionId}.db
│   └── ...
└── dashboard.html
```