### PR TITLE
fix: sync TOKEN_OPTIMIZER_VERSION constant to 5.11.53

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -18552,7 +18552,7 @@ def setup_hook(dry_run=False, uninstall=False):
 
 # ========== Persistent Dashboard Daemon ==========
 
-TOKEN_OPTIMIZER_VERSION = "5.11.50"  # Keep in sync with plugin.json + marketplace.json
+TOKEN_OPTIMIZER_VERSION = "5.11.53"  # Keep in sync with plugin.json + marketplace.json
 _DASHBOARD_CSP = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
 # Per-runtime daemon identity. Each runtime gets a distinct port + label so a
 # dashboard under one runtime never collides with another's. Copilot uses 24845

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -18552,7 +18552,7 @@ def setup_hook(dry_run=False, uninstall=False):
 
 # ========== Persistent Dashboard Daemon ==========
 
-TOKEN_OPTIMIZER_VERSION = "5.11.50"  # Keep in sync with plugin.json + marketplace.json
+TOKEN_OPTIMIZER_VERSION = "5.11.53"  # Keep in sync with plugin.json + marketplace.json
 _DASHBOARD_CSP = "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"
 # Per-runtime daemon identity. Each runtime gets a distinct port + label so a
 # dashboard under one runtime never collides with another's. Copilot uses 24845


### PR DESCRIPTION
Hey! Small one-line-times-two fix I noticed while poking at the dashboard today.

**What**
`TOKEN_OPTIMIZER_VERSION` inside `measure.py` (both copies — `skills/token-optimizer/scripts/measure.py` and `plugins/token-optimizer/skills/token-optimizer/scripts/measure.py`) is hardcoded to `"5.11.50"`, while `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` are both already at `"5.11.53"`. This PR just brings the constant back in sync — no behavior change, no other lines touched.

**Why**
That constant drives the dashboard header (`Token Overhead Analysis vX.X.X`), so right now a fresh 5.11.53 install still shows `v5.11.50` in the UI. Confirmed on a clean install today: `installed_plugins.json` said 5.11.53, the dashboard said 5.11.50. Also looks like a recurring release-process gap, not a one-off — I checked an older fork checkout at 5.11.37 and the constant was similarly behind (`5.11.35`) there too, so this has drifted across at least two releases. Might be worth a follow-up at some point to derive this from `plugin.json` instead of hand-maintaining a third copy (the comment on that line already says "Keep in sync with plugin.json + marketplace.json" — this makes it true again, at least for now).

**How**
Two-line diff, straight string swap, `"5.11.50"` → `"5.11.53"` in both copies. Nothing else in either file changed. Verified with `git diff` before pushing.

Thanks for building this, it's genuinely useful — figured I'd send the fix rather than just file an issue since it was this small. Happy to open a follow-up issue for the "derive it from plugin.json" idea if that's useful, or drop it if you'd rather keep it simple.
