### PR TITLE
fix: correct CLAUDE.md line-limit citation to 200, drop unsourced token target

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -2666,14 +2666,22 @@ def quick_scan(as_json=False):
                 "detail": f"save ~{savings:,} tokens/session",
                 "extend": f"Improves stable prompt-cache prefix and extends peak quality by ~{savings:,} tokens",
             }
-    if not quick_win and claude_md_tokens > 5000:
-        savings = claude_md_tokens - 4500
-        quick_win = {
-            "action": f"Slim CLAUDE.md from {claude_md_lines} lines to ~300",
-            "savings": savings,
-            "detail": f"save ~{savings:,} tokens/session",
-            "extend": f"Extends peak quality zone by ~{savings:,} tokens",
-        }
+    if not quick_win and claude_md_tokens > 5000 and claude_md_lines > 200:
+        # Savings target = Anthropic's documented 200-line guidance. Compute
+        # tokens-per-line from the measured file so the savings figure matches
+        # the "to under 200" target in the action text, not the old ~4,500-token
+        # internal heuristic. Guard on claude_md_lines > 200 so we don't emit a
+        # no-op "save ~0 tokens" recommendation when a long-but-short file
+        # trips the token threshold but is already under the line guidance.
+        tokens_per_line = claude_md_tokens / max(claude_md_lines, 1)
+        savings = max(0, claude_md_tokens - int(200 * tokens_per_line))
+        if savings > 0:
+            quick_win = {
+                "action": f"Slim CLAUDE.md from {claude_md_lines} lines to under 200 (per Anthropic guidance)",
+                "savings": savings,
+                "detail": f"save ~{savings:,} tokens/session",
+                "extend": f"Extends peak quality zone by ~{savings:,} tokens",
+            }
 
     # Coaching insight
     coaching = None
@@ -6176,23 +6184,35 @@ def generate_auto_recommendations(components, trends=None, days=30):
         if key.startswith("claude_md") and components[key].get("exists"):
             claude_tokens += components[key].get("tokens", 0)
             claude_lines += components[key].get("lines", 0)
-    if claude_tokens > 6000:
-        quick.append(
-            f"**Slim CLAUDE.md ({claude_tokens:,} tokens, target ~4,500 / ~300 lines)**: "
-            f"Everything in CLAUDE.md loads every single message you send. "
-            f"Anthropic recommends under ~500 lines. The aggressive optimization target is ~300 lines (~4,500 tokens).\n"
-            f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
-            f"deployment procedures, detailed templates. "
-            f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
-            f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
-            f"and short pointers to skills and references. "
-            f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
-            f"the same content inline. ~{claude_tokens - 4500:,} tokens recoverable."
-        )
-    elif claude_tokens > 5000:
+    if claude_tokens > 6000 and claude_lines > 200:
+        # Savings target = Anthropic's documented 200-line guidance. Compute
+        # tokens-per-line from this file's own measurements so "tokens
+        # recoverable" actually corresponds to slimming to 200 lines, not to
+        # the old ~4,500-token internal heuristic. Guard on claude_lines > 200
+        # so a token-dense but short file doesn't get a "slim to 200 lines"
+        # recommendation with ~0 tokens recoverable (self-contradicting).
+        tokens_per_line = claude_tokens / max(claude_lines, 1)
+        target_tokens = int(200 * tokens_per_line)
+        recoverable = max(0, claude_tokens - target_tokens)
+        if recoverable > 0:
+            quick.append(
+                f"**Slim CLAUDE.md ({claude_tokens:,} tokens, target under 200 lines)**: "
+                f"Everything in CLAUDE.md loads every single message you send. "
+                f"Anthropic recommends under 200 lines per CLAUDE.md file (https://code.claude.com/docs/en/memory). "
+                f"The ~300 lines / ~4,500 tokens figure is an internal heuristic, not an Anthropic recommendation — "
+                f"Anthropic documents only the 200-line target, no token threshold.\n"
+                f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
+                f"deployment procedures, detailed templates. "
+                f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
+                f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
+                f"and short pointers to skills and references. "
+                f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
+                f"the same content inline. ~{recoverable:,} tokens recoverable (slimming to 200 lines at ~{tokens_per_line:.1f} tokens/line)."
+            )
+    elif claude_lines > 200 and claude_tokens > 5000:
         medium.append(
-            f"**Consider slimming CLAUDE.md ({claude_tokens:,} tokens)**: "
-            f"Your CLAUDE.md is above the ~4,500 token (~300 line) optimized target but not critically large. "
+            f"**Consider slimming CLAUDE.md ({claude_lines} lines, {claude_tokens:,} tokens)**: "
+            f"Your CLAUDE.md is over Anthropic's documented 200-line guidance (https://code.claude.com/docs/en/memory) but not critically large. "
             f"Review for any sections that could become skills or reference files. "
             f"Focus on content that's only relevant for specific workflows."
         )

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -2666,14 +2666,22 @@ def quick_scan(as_json=False):
                 "detail": f"save ~{savings:,} tokens/session",
                 "extend": f"Improves stable prompt-cache prefix and extends peak quality by ~{savings:,} tokens",
             }
-    if not quick_win and claude_md_tokens > 5000:
-        savings = claude_md_tokens - 4500
-        quick_win = {
-            "action": f"Slim CLAUDE.md from {claude_md_lines} lines to ~300",
-            "savings": savings,
-            "detail": f"save ~{savings:,} tokens/session",
-            "extend": f"Extends peak quality zone by ~{savings:,} tokens",
-        }
+    if not quick_win and claude_md_tokens > 5000 and claude_md_lines > 200:
+        # Savings target = Anthropic's documented 200-line guidance. Compute
+        # tokens-per-line from the measured file so the savings figure matches
+        # the "to under 200" target in the action text, not the old ~4,500-token
+        # internal heuristic. Guard on claude_md_lines > 200 so we don't emit a
+        # no-op "save ~0 tokens" recommendation when a long-but-short file
+        # trips the token threshold but is already under the line guidance.
+        tokens_per_line = claude_md_tokens / max(claude_md_lines, 1)
+        savings = max(0, claude_md_tokens - int(200 * tokens_per_line))
+        if savings > 0:
+            quick_win = {
+                "action": f"Slim CLAUDE.md from {claude_md_lines} lines to under 200 (per Anthropic guidance)",
+                "savings": savings,
+                "detail": f"save ~{savings:,} tokens/session",
+                "extend": f"Extends peak quality zone by ~{savings:,} tokens",
+            }
 
     # Coaching insight
     coaching = None
@@ -6176,23 +6184,35 @@ def generate_auto_recommendations(components, trends=None, days=30):
         if key.startswith("claude_md") and components[key].get("exists"):
             claude_tokens += components[key].get("tokens", 0)
             claude_lines += components[key].get("lines", 0)
-    if claude_tokens > 6000:
-        quick.append(
-            f"**Slim CLAUDE.md ({claude_tokens:,} tokens, target ~4,500 / ~300 lines)**: "
-            f"Everything in CLAUDE.md loads every single message you send. "
-            f"Anthropic recommends under ~500 lines. The aggressive optimization target is ~300 lines (~4,500 tokens).\n"
-            f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
-            f"deployment procedures, detailed templates. "
-            f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
-            f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
-            f"and short pointers to skills and references. "
-            f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
-            f"the same content inline. ~{claude_tokens - 4500:,} tokens recoverable."
-        )
-    elif claude_tokens > 5000:
+    if claude_tokens > 6000 and claude_lines > 200:
+        # Savings target = Anthropic's documented 200-line guidance. Compute
+        # tokens-per-line from this file's own measurements so "tokens
+        # recoverable" actually corresponds to slimming to 200 lines, not to
+        # the old ~4,500-token internal heuristic. Guard on claude_lines > 200
+        # so a token-dense but short file doesn't get a "slim to 200 lines"
+        # recommendation with ~0 tokens recoverable (self-contradicting).
+        tokens_per_line = claude_tokens / max(claude_lines, 1)
+        target_tokens = int(200 * tokens_per_line)
+        recoverable = max(0, claude_tokens - target_tokens)
+        if recoverable > 0:
+            quick.append(
+                f"**Slim CLAUDE.md ({claude_tokens:,} tokens, target under 200 lines)**: "
+                f"Everything in CLAUDE.md loads every single message you send. "
+                f"Anthropic recommends under 200 lines per CLAUDE.md file (https://code.claude.com/docs/en/memory). "
+                f"The ~300 lines / ~4,500 tokens figure is an internal heuristic, not an Anthropic recommendation — "
+                f"Anthropic documents only the 200-line target, no token threshold.\n"
+                f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
+                f"deployment procedures, detailed templates. "
+                f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
+                f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
+                f"and short pointers to skills and references. "
+                f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
+                f"the same content inline. ~{recoverable:,} tokens recoverable (slimming to 200 lines at ~{tokens_per_line:.1f} tokens/line)."
+            )
+    elif claude_lines > 200 and claude_tokens > 5000:
         medium.append(
-            f"**Consider slimming CLAUDE.md ({claude_tokens:,} tokens)**: "
-            f"Your CLAUDE.md is above the ~4,500 token (~300 line) optimized target but not critically large. "
+            f"**Consider slimming CLAUDE.md ({claude_lines} lines, {claude_tokens:,} tokens)**: "
+            f"Your CLAUDE.md is over Anthropic's documented 200-line guidance (https://code.claude.com/docs/en/memory) but not critically large. "
             f"Review for any sections that could become skills or reference files. "
             f"Focus on content that's only relevant for specific workflows."
         )

--- a/tests/test_claude_md_recommendations.py
+++ b/tests/test_claude_md_recommendations.py
@@ -1,0 +1,122 @@
+"""Tests for the CLAUDE.md slim recommendation guards and savings math.
+
+Pins the behavior introduced in the citation-fix PR (issue #99):
+- The "Slim CLAUDE.md" quick-win only fires when the file is actually over
+  200 lines (Anthropic's documented guidance), not just when it's token-dense.
+- The "tokens recoverable" / "savings" figure is computed against the 200-line
+  target using measured tokens-per-line, not the old ~4,500-token heuristic.
+- The medium tier fires only when lines > 200 and tokens > 5000.
+
+Covers both generate_auto_recommendations() and quick_scan().
+
+Run: python3 -m pytest tests/test_claude_md_recommendations.py -v
+"""
+import importlib
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "skills" / "token-optimizer" / "scripts"
+
+
+@pytest.fixture
+def measure(monkeypatch):
+    """Import measure.py fresh under a temp snapshot dir (for _auto_snapshot)."""
+    tmp = tempfile.mkdtemp(prefix="to-claude-md-test-")
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", tmp)
+    sys.path.insert(0, str(SCRIPTS))
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    importlib.reload(mod)
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+def _claude_md_components(lines, tokens):
+    """Build a minimal components dict with a single CLAUDE.md file."""
+    return {
+        "claude_md_home": {
+            "path": "/fake/CLAUDE.md",
+            "exists": True,
+            "tokens": tokens,
+            "lines": lines,
+        }
+    }
+
+
+# --- generate_auto_recommendations: guard + math ---------------------------
+
+def test_no_slim_when_under_200_lines_even_if_token_dense(measure):
+    """A 150-line / 7000-token file must NOT trigger any slim recommendation.
+    The old code fired on tokens > 6000 alone; the guard on lines > 200 prevents
+    a self-contradicting 'slim to 200 lines' advice for a file already under 200."""
+    components = _claude_md_components(lines=150, tokens=7000)
+    plan, _ = measure.generate_auto_recommendations(components)
+    assert "Slim CLAUDE.md" not in plan
+    assert "Consider slimming CLAUDE.md" not in plan
+
+
+def test_quick_tier_recoverable_math(measure):
+    """A 400-line / 8000-token file: recoverable == 8000 - int(200 * 8000/400) == 4000.
+    The old heuristic would have reported 8000 - 4500 = 3500; the new math reports 4000."""
+    components = _claude_md_components(lines=400, tokens=8000)
+    plan, _ = measure.generate_auto_recommendations(components)
+    assert "Slim CLAUDE.md" in plan
+    # New math: 8000 - int(200 * 20.0) = 8000 - 4000 = 4000.
+    assert "~4,000 tokens recoverable" in plan
+    # Old heuristic figure must not appear.
+    assert "3,500 tokens recoverable" not in plan
+
+
+def test_medium_tier_fires_for_over_200_lines_and_over_5000_tokens(measure):
+    """A 250-line / 5500-token file: not quick tier (tokens <= 6000), but medium tier
+    fires (lines > 200 and tokens > 5000). Reports both line count and token count."""
+    components = _claude_md_components(lines=250, tokens=5500)
+    plan, _ = measure.generate_auto_recommendations(components)
+    assert "Consider slimming CLAUDE.md" in plan
+    assert "Slim CLAUDE.md" not in plan  # quick tier must not fire
+    assert "250 lines" in plan
+    assert "5,500 tokens" in plan
+
+
+def test_medium_tier_does_not_fire_when_under_200_lines(measure):
+    """A 150-line / 5500-token file: neither tier fires (lines <= 200)."""
+    components = _claude_md_components(lines=150, tokens=5500)
+    plan, _ = measure.generate_auto_recommendations(components)
+    assert "Slim CLAUDE.md" not in plan
+    assert "Consider slimming CLAUDE.md" not in plan
+
+
+# --- quick_scan: guard + savings math ---------------------------------------
+
+def _quick_scan_with_claude_md(measure, monkeypatch, lines, tokens):
+    """Run quick_scan(as_json=True) with a synthetic CLAUDE.md component.
+
+    Monkeypatches measure_components so no filesystem CLAUDE.md is read, and
+    _collect_trends_data so no trends db / JSONL scan runs.
+    """
+    components = _claude_md_components(lines=lines, tokens=tokens)
+    monkeypatch.setattr(measure, "measure_components", lambda: components)
+    monkeypatch.setattr(measure, "_collect_trends_data", lambda days=30: None)
+    return measure.quick_scan(as_json=True)
+
+
+def test_quick_scan_no_slim_when_under_200_lines(measure, monkeypatch):
+    """quick_scan must not emit a slim quick-win for a token-dense but short file
+    (150 lines, 7000 tokens). The old code fired on tokens > 5000 alone."""
+    result = _quick_scan_with_claude_md(measure, monkeypatch, lines=150, tokens=7000)
+    assert result["quick_win"] is None
+
+
+def test_quick_scan_slim_savings_math(measure, monkeypatch):
+    """quick_scan savings == tokens - int(200 * tokens/lines) for an over-200-line file.
+    For 400 lines / 8000 tokens: savings == 8000 - 4000 == 4000."""
+    result = _quick_scan_with_claude_md(measure, monkeypatch, lines=400, tokens=8000)
+    assert result["quick_win"] is not None
+    expected_savings = 8000 - int(200 * (8000 / 400))
+    assert result["quick_win"]["savings"] == expected_savings  # == 4000
+    assert "under 200" in result["quick_win"]["action"]


### PR DESCRIPTION
## Problem

The "Slim CLAUDE.md" recommendation said "Anthropic recommends under ~500 lines" for CLAUDE.md. That is actually the SKILL.md limit, not CLAUDE.md's.

## Sources

- CLAUDE.md: "target under 200 lines per CLAUDE.md file. Longer files consume more context and reduce adherence." — https://code.claude.com/docs/en/memory, "Write effective instructions." Repeated under "My CLAUDE.md is too large": "Files over 200 lines consume more context and may reduce adherence."
- SKILL.md: "Keep SKILL.md under 500 lines. Move detailed reference material to separate files." — https://code.claude.com/docs/en/skills

No documented token-count threshold for CLAUDE.md exists on either page, so the "~4,500 tokens" target in the same message does not appear to be sourced from anything Anthropic publishes.

## What this PR changes

- **Citation**: 500 -> 200 lines, with the docs URL. The ~4,500-token / ~300-line figure is relabeled as an internal heuristic (Anthropic documents only the 200-line target, no token threshold). Touched in `generate_auto_recommendations()` (the "Rule 2: CLAUDE.md too large" block) and `quick_scan()`'s quick-win action string.
- **Savings math**: updated to compute against the 200-line target using measured tokens-per-line, so the "tokens recoverable" figure matches the "to under 200" action text. The old `tokens - 4500` math contradicted the cited target.
- **No-op guards**: both `quick_scan()` and `generate_auto_recommendations()` now gate on `claude_md_lines > 200` (and `savings > 0` / `recoverable > 0`) so a token-dense but short file (≤200 lines, >6000 tokens) doesn't get a "slim to 200 lines" recommendation with "~0 tokens recoverable" — that's self-contradicting. The "slim to 200 lines" advice only fires when the file is actually over 200 lines.
- **Medium tier**: gated on `claude_lines > 200` and reworded from "approaching 200-line guidance" to "over 200-line guidance" — accurate only when the file is actually over 200 lines. Now reports both line count and token count.
- `plugins/token-optimizer/` regenerated via `scripts/sync-codex-marketplace-plugin.sh`.

## Out of scope (tracked separately)

In `quick_scan()` and `generate_auto_recommendations()`, both functions sum every `claude_md*`-prefixed component into one blended `claude_tokens`/`claude_lines` figure, then emit a singular "Slim CLAUDE.md ... to under 200 lines" recommendation. Anthropic's 200-line guidance is *per CLAUDE.md file*, so a blended total gives misleading advice — e.g. three 100-line files sum to 300 and get flagged, while one 250-line file plus a small one might not. `measure_components()` already keys each ancestor file with its own identity (`claude_md_project_{parent.name}`), so the data model is fine; the bug is downstream, in the summarization.

This is out of scope for a citation-fix PR — it changes recommendation behavior/UX, not just copy. I'll open a separate draft PR for the per-file aggregation fix and reference it here once it's up.

## Untouched on purpose

- `measure_components()` ancestor walk (mirrors how Claude Code actually loads CLAUDE.md files, concatenated up the directory tree per https://code.claude.com/docs/en/memory, "How CLAUDE.md files load").

## Test plan

- [x] `python3 -m pytest tests/ -q` — 52 passing
- [x] Sanity check: a 400-line / 8000-token file now reports 4000 tokens recoverable (to 200 lines at 20.0 tokens/line), not the old 3500 (to 4500 tokens)
- [x] No-op guard: a 150-line / 7000-token file (token-dense but short) no longer triggers a "slim to 200 lines" recommendation
- [x] `plugins/token-optimizer/` regenerated, in sync with canonical source
