### PR TITLE
fix: report CLAUDE.md offenders per-file instead of summing across ancestors

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -2598,17 +2598,18 @@ def quick_scan(as_json=False):
         if eager > 0:
             detail += f" ({eager} with eager-loaded tools)"
         offenders.append(("mcp", mcp_count, mcp.get("tokens", 0), detail))
-    claude_md_tokens = sum(
-        components[k].get("tokens", 0)
-        for k in components if k.startswith("claude_md") and components[k].get("exists")
-    )
-    claude_md_lines = sum(
-        components[k].get("lines", 0)
-        for k in components if k.startswith("claude_md") and components[k].get("exists")
-    )
-    if claude_md_tokens > 0:
-        offenders.append(("claude_md", claude_md_lines, claude_md_tokens,
-                         f"CLAUDE.md ({claude_md_lines} lines)"))
+    # Per-file CLAUDE.md offenders (don't blend multiple ancestor files into
+    # one "CLAUDE.md" entry — measure_components keys each one separately).
+    for k in sorted(components):
+        if not k.startswith("claude_md") or not components[k].get("exists"):
+            continue
+        f_tokens = components[k].get("tokens", 0)
+        f_lines = components[k].get("lines", 0)
+        f_path = components[k].get("path", "") or k
+        f_label = f_path.replace(str(HOME), "~") if f_path else k
+        if f_tokens > 0:
+            offenders.append(("claude_md", f_lines, f_tokens,
+                             f"{f_label} ({f_lines} lines)"))
     if detect_runtime() == "codex":
         agents_md_tokens = sum(
             components[k].get("tokens", 0)
@@ -2666,14 +2667,31 @@ def quick_scan(as_json=False):
                 "detail": f"save ~{savings:,} tokens/session",
                 "extend": f"Improves stable prompt-cache prefix and extends peak quality by ~{savings:,} tokens",
             }
-    if not quick_win and claude_md_tokens > 5000:
-        savings = claude_md_tokens - 4500
-        quick_win = {
-            "action": f"Slim CLAUDE.md from {claude_md_lines} lines to ~300",
-            "savings": savings,
-            "detail": f"save ~{savings:,} tokens/session",
-            "extend": f"Extends peak quality zone by ~{savings:,} tokens",
-        }
+    if not quick_win:
+        # Pick the largest single CLAUDE.md file over the internal ~4,500-token
+        # heuristic (per-file, not blended across ancestor files).
+        largest_claude_md = max(
+            (
+                (k, components[k])
+                for k in components
+                if k.startswith("claude_md") and components[k].get("exists")
+            ),
+            key=lambda kv: kv[1].get("tokens", 0),
+            default=(None, None),
+        )
+        if largest_claude_md[1] is not None:
+            lc_path = largest_claude_md[1].get("path", "") or largest_claude_md[0]
+            lc_label = lc_path.replace(str(HOME), "~") if lc_path else largest_claude_md[0]
+            lc_tokens = largest_claude_md[1].get("tokens", 0)
+            lc_lines = largest_claude_md[1].get("lines", 0)
+            if lc_tokens > 5000:
+                savings = lc_tokens - 4500
+                quick_win = {
+                    "action": f"Slim {lc_label} from {lc_lines} lines to ~300",
+                    "savings": savings,
+                    "detail": f"save ~{savings:,} tokens/session",
+                    "extend": f"Extends peak quality zone by ~{savings:,} tokens",
+                }
 
     # Coaching insight
     coaching = None
@@ -6169,33 +6187,39 @@ def generate_auto_recommendations(components, trends=None, days=30):
             f"Keep MEMORY.md as an index of high-signal, frequently-referenced items."
         )
 
-    # --- Rule 2: CLAUDE.md too large ---
-    claude_tokens = 0
-    claude_lines = 0
-    for key in components:
-        if key.startswith("claude_md") and components[key].get("exists"):
-            claude_tokens += components[key].get("tokens", 0)
-            claude_lines += components[key].get("lines", 0)
-    if claude_tokens > 6000:
-        quick.append(
-            f"**Slim CLAUDE.md ({claude_tokens:,} tokens, target ~4,500 / ~300 lines)**: "
-            f"Everything in CLAUDE.md loads every single message you send. "
-            f"Anthropic recommends under ~500 lines. The aggressive optimization target is ~300 lines (~4,500 tokens).\n"
-            f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
-            f"deployment procedures, detailed templates. "
-            f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
-            f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
-            f"and short pointers to skills and references. "
-            f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
-            f"the same content inline. ~{claude_tokens - 4500:,} tokens recoverable."
-        )
-    elif claude_tokens > 5000:
-        medium.append(
-            f"**Consider slimming CLAUDE.md ({claude_tokens:,} tokens)**: "
-            f"Your CLAUDE.md is above the ~4,500 token (~300 line) optimized target but not critically large. "
-            f"Review for any sections that could become skills or reference files. "
-            f"Focus on content that's only relevant for specific workflows."
-        )
+    # --- Rule 2: CLAUDE.md too large (per-file) ---
+    # measure_components() keys each ancestor CLAUDE.md as its own component
+    # (claude_md_global, claude_md_home, claude_md_project_<dir>), mirroring how
+    # Claude Code loads CLAUDE.md files up the directory tree. Report per-file
+    # instead of blending N files into one "Slim CLAUDE.md" number — a summed
+    # count isn't actionable on any single file someone owns.
+    for key in sorted(components):
+        if not key.startswith("claude_md") or not components[key].get("exists"):
+            continue
+        file_path = components[key].get("path", "") or key
+        file_lines = components[key].get("lines", 0)
+        file_tokens = components[key].get("tokens", 0)
+        file_label = file_path.replace(str(HOME), "~") if file_path else key
+        if file_tokens > 6000:
+            quick.append(
+                f"**Slim {file_label} ({file_tokens:,} tokens, {file_lines} lines; target ~4,500 / ~300 lines)**: "
+                f"Everything in this CLAUDE.md loads every single message you send. "
+                f"Anthropic recommends under ~500 lines. The aggressive optimization target is ~300 lines (~4,500 tokens).\n"
+                f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
+                f"deployment procedures, detailed templates. "
+                f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
+                f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
+                f"and short pointers to skills and references. "
+                f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
+                f"the same content inline. ~{file_tokens - 4500:,} tokens recoverable."
+            )
+        elif file_tokens > 5000:
+            medium.append(
+                f"**Consider slimming {file_label} ({file_tokens:,} tokens, {file_lines} lines)**: "
+                f"This CLAUDE.md is above the ~4,500 token (~300 line) optimized target but not critically large. "
+                f"Review for any sections that could become skills or reference files. "
+                f"Focus on content that's only relevant for specific workflows."
+            )
 
     # --- Rule 3: Unused skills (requires trends data) ---
     # Use actual measured avg if available, else fallback to constant

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -2598,17 +2598,18 @@ def quick_scan(as_json=False):
         if eager > 0:
             detail += f" ({eager} with eager-loaded tools)"
         offenders.append(("mcp", mcp_count, mcp.get("tokens", 0), detail))
-    claude_md_tokens = sum(
-        components[k].get("tokens", 0)
-        for k in components if k.startswith("claude_md") and components[k].get("exists")
-    )
-    claude_md_lines = sum(
-        components[k].get("lines", 0)
-        for k in components if k.startswith("claude_md") and components[k].get("exists")
-    )
-    if claude_md_tokens > 0:
-        offenders.append(("claude_md", claude_md_lines, claude_md_tokens,
-                         f"CLAUDE.md ({claude_md_lines} lines)"))
+    # Per-file CLAUDE.md offenders (don't blend multiple ancestor files into
+    # one "CLAUDE.md" entry — measure_components keys each one separately).
+    for k in sorted(components):
+        if not k.startswith("claude_md") or not components[k].get("exists"):
+            continue
+        f_tokens = components[k].get("tokens", 0)
+        f_lines = components[k].get("lines", 0)
+        f_path = components[k].get("path", "") or k
+        f_label = f_path.replace(str(HOME), "~") if f_path else k
+        if f_tokens > 0:
+            offenders.append(("claude_md", f_lines, f_tokens,
+                             f"{f_label} ({f_lines} lines)"))
     if detect_runtime() == "codex":
         agents_md_tokens = sum(
             components[k].get("tokens", 0)
@@ -2666,14 +2667,31 @@ def quick_scan(as_json=False):
                 "detail": f"save ~{savings:,} tokens/session",
                 "extend": f"Improves stable prompt-cache prefix and extends peak quality by ~{savings:,} tokens",
             }
-    if not quick_win and claude_md_tokens > 5000:
-        savings = claude_md_tokens - 4500
-        quick_win = {
-            "action": f"Slim CLAUDE.md from {claude_md_lines} lines to ~300",
-            "savings": savings,
-            "detail": f"save ~{savings:,} tokens/session",
-            "extend": f"Extends peak quality zone by ~{savings:,} tokens",
-        }
+    if not quick_win:
+        # Pick the largest single CLAUDE.md file over the internal ~4,500-token
+        # heuristic (per-file, not blended across ancestor files).
+        largest_claude_md = max(
+            (
+                (k, components[k])
+                for k in components
+                if k.startswith("claude_md") and components[k].get("exists")
+            ),
+            key=lambda kv: kv[1].get("tokens", 0),
+            default=(None, None),
+        )
+        if largest_claude_md[1] is not None:
+            lc_path = largest_claude_md[1].get("path", "") or largest_claude_md[0]
+            lc_label = lc_path.replace(str(HOME), "~") if lc_path else largest_claude_md[0]
+            lc_tokens = largest_claude_md[1].get("tokens", 0)
+            lc_lines = largest_claude_md[1].get("lines", 0)
+            if lc_tokens > 5000:
+                savings = lc_tokens - 4500
+                quick_win = {
+                    "action": f"Slim {lc_label} from {lc_lines} lines to ~300",
+                    "savings": savings,
+                    "detail": f"save ~{savings:,} tokens/session",
+                    "extend": f"Extends peak quality zone by ~{savings:,} tokens",
+                }
 
     # Coaching insight
     coaching = None
@@ -6169,33 +6187,39 @@ def generate_auto_recommendations(components, trends=None, days=30):
             f"Keep MEMORY.md as an index of high-signal, frequently-referenced items."
         )
 
-    # --- Rule 2: CLAUDE.md too large ---
-    claude_tokens = 0
-    claude_lines = 0
-    for key in components:
-        if key.startswith("claude_md") and components[key].get("exists"):
-            claude_tokens += components[key].get("tokens", 0)
-            claude_lines += components[key].get("lines", 0)
-    if claude_tokens > 6000:
-        quick.append(
-            f"**Slim CLAUDE.md ({claude_tokens:,} tokens, target ~4,500 / ~300 lines)**: "
-            f"Everything in CLAUDE.md loads every single message you send. "
-            f"Anthropic recommends under ~500 lines. The aggressive optimization target is ~300 lines (~4,500 tokens).\n"
-            f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
-            f"deployment procedures, detailed templates. "
-            f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
-            f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
-            f"and short pointers to skills and references. "
-            f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
-            f"the same content inline. ~{claude_tokens - 4500:,} tokens recoverable."
-        )
-    elif claude_tokens > 5000:
-        medium.append(
-            f"**Consider slimming CLAUDE.md ({claude_tokens:,} tokens)**: "
-            f"Your CLAUDE.md is above the ~4,500 token (~300 line) optimized target but not critically large. "
-            f"Review for any sections that could become skills or reference files. "
-            f"Focus on content that's only relevant for specific workflows."
-        )
+    # --- Rule 2: CLAUDE.md too large (per-file) ---
+    # measure_components() keys each ancestor CLAUDE.md as its own component
+    # (claude_md_global, claude_md_home, claude_md_project_<dir>), mirroring how
+    # Claude Code loads CLAUDE.md files up the directory tree. Report per-file
+    # instead of blending N files into one "Slim CLAUDE.md" number — a summed
+    # count isn't actionable on any single file someone owns.
+    for key in sorted(components):
+        if not key.startswith("claude_md") or not components[key].get("exists"):
+            continue
+        file_path = components[key].get("path", "") or key
+        file_lines = components[key].get("lines", 0)
+        file_tokens = components[key].get("tokens", 0)
+        file_label = file_path.replace(str(HOME), "~") if file_path else key
+        if file_tokens > 6000:
+            quick.append(
+                f"**Slim {file_label} ({file_tokens:,} tokens, {file_lines} lines; target ~4,500 / ~300 lines)**: "
+                f"Everything in this CLAUDE.md loads every single message you send. "
+                f"Anthropic recommends under ~500 lines. The aggressive optimization target is ~300 lines (~4,500 tokens).\n"
+                f"  Move to skills (loaded on-demand, ~100 tokens in menu): workflow guides, coding standards, "
+                f"deployment procedures, detailed templates. "
+                f"Move to reference files (zero cost until read): API docs, config examples, architecture notes. "
+                f"Keep in CLAUDE.md: identity/personality, critical behavioral rules, key file paths, "
+                f"and short pointers to skills and references. "
+                f"Don't delete content, reorganize it. A 2-line pointer to a skill costs 100x less than "
+                f"the same content inline. ~{file_tokens - 4500:,} tokens recoverable."
+            )
+        elif file_tokens > 5000:
+            medium.append(
+                f"**Consider slimming {file_label} ({file_tokens:,} tokens, {file_lines} lines)**: "
+                f"This CLAUDE.md is above the ~4,500 token (~300 line) optimized target but not critically large. "
+                f"Review for any sections that could become skills or reference files. "
+                f"Focus on content that's only relevant for specific workflows."
+            )
 
     # --- Rule 3: Unused skills (requires trends data) ---
     # Use actual measured avg if available, else fallback to constant

--- a/tests/test_claude_md_aggregation.py
+++ b/tests/test_claude_md_aggregation.py
@@ -18,7 +18,6 @@ misleading string.
 Run: python3 -m pytest tests/test_claude_md_aggregation.py -v
 """
 
-import importlib
 import sys
 from pathlib import Path
 
@@ -90,6 +89,17 @@ def test_quick_scan_offenders_split_per_file(monkeypatch):
     monkeypatch.setattr(measure, "measure_components", lambda: _COMPONENTS_TWO_LARGE)
     monkeypatch.setattr(measure, "detect_context_window", lambda: (200_000, "test"))
     monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+    # Stub the unmocked collaborators quick_scan() also calls so the test is
+    # hermetic: calculate_totals feeds overhead math, _collect_trends_data hits
+    # the real session/SQLite tree, and _auto_snapshot writes a real snap_*.json
+    # into SNAPSHOT_DIR/auto-snapshots/ on the host.
+    monkeypatch.setattr(
+        measure,
+        "calculate_totals",
+        lambda c: {"controllable_tokens": 0, "fixed_tokens": 0, "estimated_total": 0},
+    )
+    monkeypatch.setattr(measure, "_collect_trends_data", lambda *a, **k: None)
+    monkeypatch.setattr(measure, "_auto_snapshot", lambda *a, **k: None)
 
     result = measure.quick_scan(as_json=True)
 

--- a/tests/test_claude_md_aggregation.py
+++ b/tests/test_claude_md_aggregation.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Regression test: CLAUDE.md quick-win must report per-file, not blended.
+
+measure_components() keys each ancestor CLAUDE.md as its own component
+(claude_md_global, claude_md_home, claude_md_project_<dir>), mirroring how
+Claude Code loads CLAUDE.md files up the directory tree. The "Slim CLAUDE.md"
+quick win and the quick_scan offender list used to sum every claude_md*-prefixed
+key into one blended number and report it as if it were one file. On a layout
+with 2-3 CLAUDE.md files up the tree that produced a combined token/line count
+that wasn't any single file's size, plus a "slim to ~300 lines" recommendation
+that wasn't actionable on any one file.
+
+These tests assert the fix: each claude_md_* component over the threshold gets
+its own recommendation / offender entry naming the specific file and its own
+line count, and that two distinct components no longer collapse into one
+misleading string.
+
+Run: python3 -m pytest tests/test_claude_md_aggregation.py -v
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+if "measure" in sys.modules:
+    del sys.modules["measure"]
+import measure  # noqa: E402
+
+
+def _claude_md_component(path, tokens, lines):
+    return {"path": path, "exists": True, "tokens": tokens, "lines": lines}
+
+
+# Two distinct ancestor CLAUDE.md files, each independently over the 6,000-token
+# quick tier. Paths deliberately do NOT start with the test machine's HOME so
+# the ~-abbreviation in the label is a no-op and the test is hermetic.
+_COMPONENTS_TWO_LARGE = {
+    "claude_md_global": _claude_md_component("/workspace/CLAUDE.md", 7000, 420),
+    "claude_md_project_repo": _claude_md_component("/workspace/repo/CLAUDE.md", 6500, 390),
+}
+
+# Two files whose SUM (6,000) crosses the old quick threshold but neither file
+# alone does. Old blending code triggered a recommendation here; per-file code
+# must not.
+_COMPONENTS_SUM_ONLY = {
+    "claude_md_global": _claude_md_component("/workspace/CLAUDE.md", 3000, 200),
+    "claude_md_project_repo": _claude_md_component("/workspace/repo/CLAUDE.md", 3000, 200),
+}
+
+
+def test_generate_auto_recommendations_reports_per_file():
+    """Two large claude_md_* components -> two quick entries, each naming its file."""
+    plan_md, total = measure.generate_auto_recommendations(_COMPONENTS_TWO_LARGE)
+
+    # Two per-file "Slim" recommendations (one per offending file), not one blended.
+    slim_count = plan_md.count("**Slim ")
+    assert slim_count == 2, (
+        f"expected 2 per-file Slim entries, got {slim_count}:\n{plan_md}"
+    )
+
+    # Each entry names its specific file path and its OWN token count, not the sum.
+    assert "/workspace/CLAUDE.md" in plan_md and "7,000" in plan_md, plan_md
+    assert "/workspace/repo/CLAUDE.md" in plan_md and "6,500" in plan_md, plan_md
+
+    # The blended total (13,500) must not appear — that's the bug signature.
+    assert "13,500" not in plan_md, f"blended total leaked into per-file plan:\n{plan_md}"
+
+
+def test_generate_auto_recommendations_no_blended_trigger():
+    """Two files whose sum crosses the threshold but neither alone does -> no quick entry.
+
+    Old code summed to 6,000 and emitted one 'Slim CLAUDE.md' recommendation.
+    Per-file code must not trigger on either file (3,000 < 6,000 quick, < 5,000 medium).
+    """
+    plan_md, _ = measure.generate_auto_recommendations(_COMPONENTS_SUM_ONLY)
+    assert "**Slim " not in plan_md, (
+        f"per-file code must not trigger on a sum-only crossing:\n{plan_md}"
+    )
+    assert "Consider slimming" not in plan_md, (
+        f"per-file code must not medium-trigger on a sum-only crossing:\n{plan_md}"
+    )
+
+
+def test_quick_scan_offenders_split_per_file(monkeypatch):
+    """quick_scan's top_offenders lists each CLAUDE.md file separately, not blended."""
+    monkeypatch.setattr(measure, "measure_components", lambda: _COMPONENTS_TWO_LARGE)
+    monkeypatch.setattr(measure, "detect_context_window", lambda: (200_000, "test"))
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+
+    result = measure.quick_scan(as_json=True)
+
+    claude_offenders = [o for o in result["top_offenders"] if o["name"] == "claude_md"]
+    assert len(claude_offenders) == 2, (
+        f"expected 2 per-file claude_md offenders, got {len(claude_offenders)}: "
+        f"{claude_offenders}"
+    )
+    details = {o["detail"] for o in claude_offenders}
+    assert any("/workspace/CLAUDE.md" in d for d in details), details
+    assert any("/workspace/repo/CLAUDE.md" in d for d in details), details
+    # No blended "CLAUDE.md (810 lines)" entry collapsing both files.
+    for d in details:
+        assert "810 lines" not in d, f"blended line count leaked into offender: {d}"
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

The "Slim CLAUDE.md" quick win can report a token/line count that isn't any single file's size. On my own dashboard it showed "12,058 tokens, target ~4,500 / ~300 lines" as if one file were bloated. It wasn't one file — it was three separately-owned CLAUDE.md files summed together: my global ~/.claude/CLAUDE.md (1,254 tok), a workspace-root CLAUDE.md (1,149 tok), and a project's own CLAUDE.md pulled in because measure_components() walks cwd.parents[:3] (9,655 tok). 1254+1149+9655 = 12,058 exactly, confirmed against dashboard.html's window.__TOKEN_DATA__.

## Root cause

measure_components() (measure.py:1455-1476) already keys each ancestor file with its own identity: claude_md_project_{parent.name}. The data model is fine.

The bug is downstream: every consumer throws that identity away by summing indiscriminately over every claude_md*-prefixed key instead of using it:

- generate_auto_recommendations (6172-6198) — the quick win itself
- quick_scan (2601-2608, 2669-2676) — "top offenders" + the terse action text
- _auto_snapshot (2545-2548) — trend history
- claude_md_health (5684-5705) — the dashboard health card

Any monorepo/worktree layout with 2-3 CLAUDE.md files up the tree produces a combined number and a "slim CLAUDE.md to ~300 lines" recommendation that isn't actionable on any one file — you can't edit three files someone else may own down to a shared line target.

## What this changes

- generate_auto_recommendations and quick_scan's offender entry now report per-file: when a single claude_md_* component exceeds the threshold, the recommendation names that specific file and its own line count, instead of blending N files under one "Slim CLAUDE.md" label.
- No change to measure_components()'s ancestor walk itself — that mirrors how Claude Code actually loads CLAUDE.md files, so collecting per-ancestor data is correct. Only the summarization on top of it was wrong.

## Note

@alexgreensh , since this changes recommendation behavior/UX, not just a factual correction (that's PR #99). Flag if you'd rather go a different direction - e.g. only ever treating cwd's own file + global as "yours to slim," dropping ancestor files from the recommendation entirely instead of listing them per-file
