### PR TITLE
fix(locks): sweep stale leases, release in finally, revive daemon before health budget

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/hook_runtime.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/hook_runtime.py
@@ -397,3 +397,122 @@ def lease_lock(path, **kwargs):
     finally:
         if acquired:
             lock.release()
+
+
+# --- Stale-lease sweeper -----------------------------------------------------
+# LeaseLock's release() leaves the canonical ``.qlease`` tombstone on disk for
+# the next contender to reclaim. Sessions are one-shot, so most tombstones get
+# no future contender and leak forever (one+ per session per user, unbounded).
+# This sweeper is the self-healing backstop: it removes ONLY lease artifacts
+# whose expiry is demonstrably far in the past, so no live locker can ever be
+# touched. It is fail-open by construction (whole body is try/except, never
+# raises) and must NEVER run on a hot per-tool-call path unthrottled.
+
+# A ``.qlease`` is long-expired once its parsed ``expires_wall`` is at least an
+# hour behind ``now``. The hour of slack absorbs clock skew and the
+# deadline-vs-lease rounding without ever reaching back into a live lease
+# (leases themselves are ~10s).
+_SWEEP_LEASE_EXPIRED_GRACE = 3600
+# Candidate/reclaim hard links and legacy ``.qlock`` files carry no parseable
+# expiry, so they are swept purely by mtime. 24h is far beyond any live lease
+# or reclaim-grace window, so a file this old is unambiguously orphaned.
+_SWEEP_MTIME_AGE = 86400
+
+
+def _sweep_stale_leases(directory, now=None, max_files=2000):
+    """Remove long-expired lease artifacts from ``directory``.
+
+    Scans ``directory`` (the quality-cache dir) and unlinks ONLY files whose
+    lease is demonstrably long-expired, so no live locker can be touched:
+
+      * ``*.qlease``: parse the JSON metadata and remove if ``expires_wall`` <
+        ``now - _SWEEP_LEASE_EXPIRED_GRACE`` (3600s). If the file is
+        unparseable/corrupt/partial, remove only when its mtime is older than
+        ``now - _SWEEP_MTIME_AGE`` (86400s) so a file mid-publication by an old
+        process is never torn down.
+      * ``.*.candidate-*`` and ``.*.reclaim-*``: remove when mtime is older
+        than ``now - _SWEEP_MTIME_AGE``.
+      * legacy ``*.qlock`` (pre-5.11 artifacts; the current code never writes
+        them): remove when mtime is older than ``now - _SWEEP_MTIME_AGE``.
+
+    The scan is capped at ``max_files`` entries per run so a pathological cache
+    dir cannot blow the hook budget. The whole function is wrapped in
+    try/except: it NEVER raises into a hook and NEVER blocks a session. Returns
+    the number of files removed (best-effort, 0 on any error).
+    """
+    removed = 0
+    try:
+        if directory is None:
+            return 0
+        dir_path = Path(directory) if not hasattr(directory, "iterdir") else directory
+        if not dir_path.is_dir():
+            return 0
+        now = time.time() if now is None else float(now)
+        lease_cutoff = now - _SWEEP_LEASE_EXPIRED_GRACE
+        mtime_cutoff = now - _SWEEP_MTIME_AGE
+        seen = 0
+        # ``scandir`` is one stat-free readdir; per-entry mtime comes from the
+        # DirEntry where available, falling back to os.stat only when needed.
+        try:
+            entries = list(os.scandir(dir_path))
+        except OSError:
+            return 0
+        for entry in entries:
+            if seen >= max_files:
+                break
+            seen += 1
+            name = entry.name
+            if not name:
+                continue
+            try:
+                # Skip non-files (subdirectories) cheaply via the scandir cache.
+                if entry.is_dir(follow_symlinks=False):
+                    continue
+                should_remove = False
+                if name.endswith(".qlease"):
+                    should_remove = _sweep_qlease_is_stale(
+                        dir_path / name, entry, lease_cutoff, mtime_cutoff
+                    )
+                elif name.startswith(".") and (
+                    ".candidate-" in name or ".reclaim-" in name
+                ):
+                    should_remove = _sweep_mtime_is_stale(entry, mtime_cutoff)
+                elif name.endswith(".qlock"):
+                    should_remove = _sweep_mtime_is_stale(entry, mtime_cutoff)
+                if should_remove:
+                    try:
+                        os.unlink(entry.path)
+                        removed += 1
+                    except OSError:
+                        pass
+            except OSError:
+                continue
+    except Exception:
+        # Fail-open: never propagate. A sweeper error must not break a hook.
+        return removed
+    return removed
+
+
+def _sweep_qlease_is_stale(path, entry, lease_cutoff, mtime_cutoff):
+    """True if a ``.qlease`` is long-expired (parseable) or long-dead (corrupt)."""
+    try:
+        raw = path.read_bytes()
+        owner = json.loads(raw)
+        expires = owner.get("expires_wall")
+        if isinstance(expires, (int, float)) and expires > 0:
+            return float(expires) < lease_cutoff
+        # Valid JSON but no usable expiry -> treat as corrupt (mtime gate).
+        return _sweep_mtime_is_stale(entry, mtime_cutoff)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        # Unparseable / partial / truncated JSON. A file mid-publication by an
+        # old process could be momentarily malformed, so gate on a 24h mtime
+        # age instead of removing a fresh malformed file immediately.
+        return _sweep_mtime_is_stale(entry, mtime_cutoff)
+
+
+def _sweep_mtime_is_stale(entry, mtime_cutoff):
+    """True if the entry's mtime is older than ``mtime_cutoff``."""
+    try:
+        return entry.stat(follow_symlinks=False).st_mtime < mtime_cutoff
+    except OSError:
+        return False

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -93,7 +93,13 @@ except ImportError:  # pragma: no cover - Python < 3.11 fallback
     tomllib = None
 
 from hook_io import read_stdin_hook_input as _read_stdin_hook_input_shared
-from hook_runtime import HookDeadline, LeaseLock, current_deadline, lease_lock
+from hook_runtime import (
+    HookDeadline,
+    LeaseLock,
+    current_deadline,
+    lease_lock,
+    _sweep_stale_leases,
+)
 import plugin_env
 from plugin_env import (
     _all_plugin_data_dirs,
@@ -30116,6 +30122,49 @@ def _quality_cache_tick_due(
         return False
 
 
+# --- Stale-lease sweeper throttle (FIX B) ------------------------------------
+# The sweeper itself lives in hook_runtime._sweep_stale_leases (fail-open, never
+# raises). It is invoked here OPPORTUNISTICALLY + THROTTLED to at most once per
+# 24h via a one-stat marker, mirroring the quality-cache throttle pattern. It is
+# wired into ensure-health (SessionStart), NEVER the hot per-tool-call path, so
+# the scan cost never lands on PostToolUse. The marker is touched AFTER a run so
+# a sweeper crash/timeout retries next session rather than waiting a full day.
+_QLEASE_SWEEP_THROTTLE_SECONDS = 86400
+_QLEASE_SWEEP_MARKER = QUALITY_CACHE_DIR / ".qlease-sweep-throttle"
+
+
+def _qlease_sweep_due():
+    """One-stat gate: True when the last sweep is older than 24h (or never ran)."""
+    try:
+        age = time.time() - _QLEASE_SWEEP_MARKER.stat().st_mtime
+        return age >= _QLEASE_SWEEP_THROTTLE_SECONDS
+    except OSError:
+        return True
+
+
+def maybe_sweep_stale_leases(directory=None):
+    """Throttled, fail-open invocation of the stale-lease sweeper.
+
+    Runs at most once per 24h per install. Wrapped end-to-end in try/except so
+    it can NEVER raise into a hook or block a session. Returns the number of
+    files removed (0 on any error / throttle skip). Exposed for tests.
+    """
+    try:
+        if not _qlease_sweep_due():
+            return 0
+        target = Path(directory) if directory is not None else QUALITY_CACHE_DIR
+        removed = _sweep_stale_leases(target)
+        # Stamp AFTER a successful run so a mid-sweep crash retries next session.
+        try:
+            _QLEASE_SWEEP_MARKER.parent.mkdir(parents=True, exist_ok=True)
+            _QLEASE_SWEEP_MARKER.touch()
+        except OSError:
+            pass
+        return removed
+    except Exception:
+        return 0
+
+
 def _write_checkpoint_atomic(checkpoint_path, content):
     """Atomically write a checkpoint markdown file. Returns True on success.
 
@@ -31071,243 +31120,243 @@ def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_
                 pass
         return None
 
-    # Run quality analysis
-    quality_data = _parse_jsonl_for_quality(filepath)
-    if not quality_data:
-        # New/empty session - write a clean score to cache so stale score doesn't persist
-        result = {
-            "score": 100,
-            "grade": "S",
-            "signals": {},
-            "breakdown": {},
-            "total_messages": 0,
-            "decisions_found": 0,
-            "compactions": 0,
-            "turns": 0,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "session_file": Path(filepath).name,
-            "model_context_window": detect_context_window()[0],
-        }
-        _write_quality_cache(cache_path, result)
-        _release_quality_lock(_qlock)
-        return 100
-
-    # Carry forward nudge/loop state from previous cache (survives across
-    # UserPromptSubmit → PostCompact boundary for follow-through measurement)
-    prev_result = {}
-    if cache_path.exists():
-        try:
-            prev_result = _read_quality_cache(cache_path) or {}
-        except Exception:
-            prev_result = {}
-
-    _session_id = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
-    result = compute_quality_score(quality_data, session_id=_session_id)
-    for carry_key in _CARRY_KEYS:
-        if carry_key in prev_result and carry_key not in result:
-            result[carry_key] = prev_result[carry_key]
-    result["total_messages"] = len(quality_data["messages"])
-    result["decisions_found"] = len(quality_data["decisions"])
-    result["compactions"] = quality_data["compactions"]
-    result["turns"] = len([m for m in quality_data["messages"] if m[1] == "user"])
-    result["timestamp"] = datetime.now(timezone.utc).isoformat()
-    result["session_file"] = Path(filepath).name
-    result["model"] = quality_data.get("model")
-    result["topic"] = quality_data.get("topic")
-    # Add degradation band for status line
-    cfd = result.get("breakdown", {}).get("context_fill_degradation", {})
-    result["degradation_band"] = cfd.get("band", "")
-    result["fill_pct"] = cfd.get("fill_pct", 0)
-    # Surface the resolved context window at the TOP LEVEL of the cache. Consumers
-    # that compute fill from raw transcript tokens (the VS Code companion's
-    # cacheReader, the dashboard) read `model_context_window` here; without it they
-    # fall back to a 200k guess and inflate every 1M-context session ~5x.
-    result["model_context_window"] = cfd.get("model_context_window") or detect_context_window()[0]
-    # The window alone cannot be sanity-checked by a reader; the source can.
-    result["model_context_window_source"] = (
-        cfd.get("model_context_window_source") or detect_context_window()[1]
-    )
-    result["context_window_contradicted"] = bool(cfd.get("window_contradicted"))
-
-    # Dampen ResourceHealth swings within a session.
-    # Fill_pct fluctuates between measurements (context adds/removes, compaction).
-    # Allow recovery but dampen: drops are immediate, recovery moves 30% toward
-    # the new value per measurement to prevent wild upward swings.
-    prev_rh = prev_result.get("resource_health")
-    current_rh = result.get("resource_health")
-    if prev_rh is not None and current_rh is not None:
-        if current_rh >= prev_rh:
-            result["resource_health"] = round(prev_rh + (current_rh - prev_rh) * 0.3, 1)
-        result["score"] = result["resource_health"]
-        result["grade"] = score_to_grade(round(result["resource_health"]))
-        result["resource_health_grade"] = result["grade"]
-
-    # Session duration + active agents for statusline (v2.6)
-    result["session_start_ts"] = _extract_session_start_ts(filepath)
-    result["active_agents"] = _extract_active_agents(filepath)
-
-    # Cache hit rate for statusline (v5.4.27)
     try:
-        total_input_all = 0
-        total_cache_read = 0
-        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                try:
-                    rec = json.loads(line)
-                    usage = rec.get("message", {}).get("usage", {}) if rec.get("type") == "assistant" else {}
-                    if usage:
-                        total_input_all += usage.get("input_tokens", 0) + usage.get("cache_read_input_tokens", 0) + usage.get("cache_creation_input_tokens", 0)
-                        total_cache_read += usage.get("cache_read_input_tokens", 0)
-                except (json.JSONDecodeError, AttributeError):
-                    continue
-        result["cache_hit_rate"] = round(total_cache_read / total_input_all, 3) if total_input_all > 0 else 0
-    except (OSError, ZeroDivisionError):
-        result["cache_hit_rate"] = 0
+        # Run quality analysis
+        quality_data = _parse_jsonl_for_quality(filepath)
+        if not quality_data:
+            # New/empty session - write a clean score to cache so stale score doesn't persist
+            result = {
+                "score": 100,
+                "grade": "S",
+                "signals": {},
+                "breakdown": {},
+                "total_messages": 0,
+                "decisions_found": 0,
+                "compactions": 0,
+                "turns": 0,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "session_file": Path(filepath).name,
+                "model_context_window": detect_context_window()[0],
+            }
+            _write_quality_cache(cache_path, result)
+            return 100
 
-    if not _write_quality_cache(cache_path, result):
-        _release_quality_lock(_qlock)
-        return None
+        # Carry forward nudge/loop state from previous cache (survives across
+        # UserPromptSubmit → PostCompact boundary for follow-through measurement)
+        prev_result = {}
+        if cache_path.exists():
+            try:
+                prev_result = _read_quality_cache(cache_path) or {}
+            except Exception:
+                prev_result = {}
 
-    # v5.0: Quality nudges + loop detection
-    # These always run regardless of --quiet, because they emit systemMessage JSON
-    # that Claude Code injects into context. Suppressing them defeats their purpose.
-    system_messages = []
+        _session_id = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
+        result = compute_quality_score(quality_data, session_id=_session_id)
+        for carry_key in _CARRY_KEYS:
+            if carry_key in prev_result and carry_key not in result:
+                result[carry_key] = prev_result[carry_key]
+        result["total_messages"] = len(quality_data["messages"])
+        result["decisions_found"] = len(quality_data["decisions"])
+        result["compactions"] = quality_data["compactions"]
+        result["turns"] = len([m for m in quality_data["messages"] if m[1] == "user"])
+        result["timestamp"] = datetime.now(timezone.utc).isoformat()
+        result["session_file"] = Path(filepath).name
+        result["model"] = quality_data.get("model")
+        result["topic"] = quality_data.get("topic")
+        # Add degradation band for status line
+        cfd = result.get("breakdown", {}).get("context_fill_degradation", {})
+        result["degradation_band"] = cfd.get("band", "")
+        result["fill_pct"] = cfd.get("fill_pct", 0)
+        # Surface the resolved context window at the TOP LEVEL of the cache. Consumers
+        # that compute fill from raw transcript tokens (the VS Code companion's
+        # cacheReader, the dashboard) read `model_context_window` here; without it they
+        # fall back to a 200k guess and inflate every 1M-context session ~5x.
+        result["model_context_window"] = cfd.get("model_context_window") or detect_context_window()[0]
+        # The window alone cannot be sanity-checked by a reader; the source can.
+        result["model_context_window_source"] = (
+            cfd.get("model_context_window_source") or detect_context_window()[1]
+        )
+        result["context_window_contradicted"] = bool(cfd.get("window_contradicted"))
 
-    # Fill warnings fire independently of composite score (Tier 1 monotonicity fix).
-    # These cannot be masked by improving ratio signals. Deduplicated per level
-    # so the same threshold doesn't fire every prompt.
-    fill_warning = result.get("fill_warning")
-    if fill_warning and fill_warning["level"] in ("WARNING", "CRITICAL"):
-        prev_fill_warn_level = prev_result.get("_last_fill_warn_level")
-        if fill_warning["level"] != prev_fill_warn_level:
-            result["_last_fill_warn_level"] = fill_warning["level"]
-            system_messages.append(
-                f"[Token Optimizer] {fill_warning['level']}: {fill_warning['message']}"
+        # Dampen ResourceHealth swings within a session.
+        # Fill_pct fluctuates between measurements (context adds/removes, compaction).
+        # Allow recovery but dampen: drops are immediate, recovery moves 30% toward
+        # the new value per measurement to prevent wild upward swings.
+        prev_rh = prev_result.get("resource_health")
+        current_rh = result.get("resource_health")
+        if prev_rh is not None and current_rh is not None:
+            if current_rh >= prev_rh:
+                result["resource_health"] = round(prev_rh + (current_rh - prev_rh) * 0.3, 1)
+            result["score"] = result["resource_health"]
+            result["grade"] = score_to_grade(round(result["resource_health"]))
+            result["resource_health_grade"] = result["grade"]
+
+        # Session duration + active agents for statusline (v2.6)
+        result["session_start_ts"] = _extract_session_start_ts(filepath)
+        result["active_agents"] = _extract_active_agents(filepath)
+
+        # Cache hit rate for statusline (v5.4.27)
+        try:
+            total_input_all = 0
+            total_cache_read = 0
+            with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    try:
+                        rec = json.loads(line)
+                        usage = rec.get("message", {}).get("usage", {}) if rec.get("type") == "assistant" else {}
+                        if usage:
+                            total_input_all += usage.get("input_tokens", 0) + usage.get("cache_read_input_tokens", 0) + usage.get("cache_creation_input_tokens", 0)
+                            total_cache_read += usage.get("cache_read_input_tokens", 0)
+                    except (json.JSONDecodeError, AttributeError):
+                        continue
+            result["cache_hit_rate"] = round(total_cache_read / total_input_all, 3) if total_input_all > 0 else 0
+        except (OSError, ZeroDivisionError):
+            result["cache_hit_rate"] = 0
+
+        if not _write_quality_cache(cache_path, result):
+            return None
+
+        # v5.0: Quality nudges + loop detection
+        # These always run regardless of --quiet, because they emit systemMessage JSON
+        # that Claude Code injects into context. Suppressing them defeats their purpose.
+        system_messages = []
+
+        # Fill warnings fire independently of composite score (Tier 1 monotonicity fix).
+        # These cannot be masked by improving ratio signals. Deduplicated per level
+        # so the same threshold doesn't fire every prompt.
+        fill_warning = result.get("fill_warning")
+        if fill_warning and fill_warning["level"] in ("WARNING", "CRITICAL"):
+            prev_fill_warn_level = prev_result.get("_last_fill_warn_level")
+            if fill_warning["level"] != prev_fill_warn_level:
+                result["_last_fill_warn_level"] = fill_warning["level"]
+                system_messages.append(
+                    f"[Token Optimizer] {fill_warning['level']}: {fill_warning['message']}"
+                )
+
+        # Tool call fatigue warnings (independent of composite score)
+        tool_call_warning = result.get("tool_call_warning")
+        if tool_call_warning and tool_call_warning["level"] in ("WARNING", "CRITICAL"):
+            prev_tc_level = prev_result.get("_last_tool_call_warn_level")
+            if tool_call_warning["level"] != prev_tc_level:
+                result["_last_tool_call_warn_level"] = tool_call_warning["level"]
+                system_messages.append(
+                    f"[Token Optimizer] {tool_call_warning['level']}: {tool_call_warning['message']}"
+                )
+
+        # Fresh-session nudge takes precedence: when a session is long AND degraded,
+        # "start fresh (context is preserved)" is the stronger remedy than /compact, and
+        # firing both would be noise. Only fall back to the /compact nudge if it didn't fire.
+        fresh_msg = _maybe_fresh_session_nudge(result, cache_path, quality_data)
+        if not fresh_msg:
+            nudge_msg = _maybe_nudge(result, cache_path, quality_data)
+            if nudge_msg:
+                system_messages.append(nudge_msg)
+        loop_msg = _maybe_loop_warning(result, cache_path, quality_data)
+        if loop_msg:
+            system_messages.append(loop_msg)
+        # Persist nudge/loop/fresh state (the once-per-session _fresh_nudge_fired flag
+        # must survive even if only the fresh nudge fired this turn).
+        if system_messages or fresh_msg:
+            _write_quality_cache(cache_path, result)
+        if system_messages:
+            # Gate the routine informational batch (quality/loop/fill warnings) under
+            # context pressure.
+            _emit_msgs = True
+            try:
+                from context_pressure import should_inject, get_pressure_level, log_suppression
+                _sf = str(filepath) if filepath else None
+                _sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
+                if not should_inject(_sf, session_id=_sid, priority="informational"):
+                    log_suppression("quality_system_messages", get_pressure_level(_sf, session_id=_sid))
+                    _emit_msgs = False
+            except Exception:
+                pass
+            if _emit_msgs:
+                for msg in system_messages:
+                    try:
+                        print(json.dumps({"systemMessage": msg}))
+                    except Exception:
+                        pass
+        # The fresh-session nudge BYPASSES pressure suppression on purpose: it fires at
+        # most once per session and is most relevant precisely when the session is
+        # degraded (i.e. under pressure). Suppressing it would defeat its purpose and
+        # silently burn the one-shot -- the exact bug where users never saw it.
+        if fresh_msg:
+            try:
+                print(json.dumps({"systemMessage": fresh_msg}))
+            except Exception:
+                pass
+
+        # Nudge follow-through: if PostCompact triggered this run (force=True)
+        # and a nudge preceded the compact, measure the actual fill_pct recovery.
+        if force and result.get("fill_pct", 0) > 0:
+            # A6: the nudge fires during a prior UserPromptSubmit process; this
+            # follow-through runs in a SEPARATE PostCompact process. Fire-state reaches
+            # us via the atomic per-session quality cache (carried forward at the top of
+            # this function). Fall back to prev_result directly in case the carry did not
+            # run, so a heeded session is never misclassified as ignored. Wrapped so a
+            # corrupt cache value can never crash the host hook — it degrades to "no
+            # credit", not a traceback.
+            try:
+                nudge_fill = result.get("_nudge_fill_pct_at_fire") or prev_result.get("_nudge_fill_pct_at_fire", 0)
+                if nudge_fill > 0:
+                    current_fill = result["fill_pct"]
+                    fill_delta = nudge_fill - current_fill
+                    ft_sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
+                    # A2 temporal gate: only credit a compaction that followed the nudge
+                    # within the window. A compaction long after the nudge was not its
+                    # follow-through, so it must not borrow the nudge's credit.
+                    fire_epoch = result.get("_nudge_fire_epoch") or prev_result.get("_nudge_fire_epoch", 0)
+                    within_window = fire_epoch and (time.time() - fire_epoch) <= _NUDGE_FOLLOWTHROUGH_WINDOW_SECONDS
+                    # A2 dedup: if a checkpoint_restore already credited this session's
+                    # recovery for this compaction (same SessionStart cycle), the nudge
+                    # must not double-credit the same tokens.
+                    already_credited = _checkpoint_restore_credited_recently(ft_sid)
+                    should_credit = fill_delta > 5 and within_window and not already_credited
+                    # Consume the fire-state FIRST, then credit only if the consume was
+                    # actually persisted. The fire-state lives in exactly one place (this
+                    # per-session cache), so once it is cleared from disk no later
+                    # PostCompact can re-enter this block for the same nudge — that makes
+                    # the credit idempotent without a second DB query. If the process
+                    # dies between here and the credit, or the clear-write fails, we skip
+                    # the credit (a conservative under-count) rather than risk a
+                    # double-count that would inflate the savings number.
+                    result.pop("_nudge_fill_pct_at_fire", None)
+                    result.pop("_nudge_fire_epoch", None)
+                    consumed = _write_quality_cache(cache_path, result)
+                    if should_credit and consumed:
+                        context_size = detect_context_window()[0]
+                        measured_tokens_recovered = int(context_size * fill_delta / 100)
+                        _log_compression_event(
+                            feature="quality_nudge",
+                            original_text=" " * (measured_tokens_recovered * 4),
+                            compressed_text=f"nudge_followthrough:fill={nudge_fill}->{current_fill}",
+                            session_id=ft_sid,
+                            detail=f"measured_recovery: fill {nudge_fill}%->{current_fill}% = {measured_tokens_recovered} tokens on {context_size} context",
+                            verified=True,
+                        )
+            except Exception:
+                pass
+
+        # Progressive checkpoints (v3.0)
+        if _PROGRESSIVE_ENABLED and result.get("fill_pct", 0) > 0:
+            _maybe_progressive_checkpoint(
+                fill_pct=result["fill_pct"],
+                cache_path=cache_path,
+                result=result,
+                filepath=filepath,
             )
 
-    # Tool call fatigue warnings (independent of composite score)
-    tool_call_warning = result.get("tool_call_warning")
-    if tool_call_warning and tool_call_warning["level"] in ("WARNING", "CRITICAL"):
-        prev_tc_level = prev_result.get("_last_tool_call_warn_level")
-        if tool_call_warning["level"] != prev_tc_level:
-            result["_last_tool_call_warn_level"] = tool_call_warning["level"]
-            system_messages.append(
-                f"[Token Optimizer] {tool_call_warning['level']}: {tool_call_warning['message']}"
-            )
-
-    # Fresh-session nudge takes precedence: when a session is long AND degraded,
-    # "start fresh (context is preserved)" is the stronger remedy than /compact, and
-    # firing both would be noise. Only fall back to the /compact nudge if it didn't fire.
-    fresh_msg = _maybe_fresh_session_nudge(result, cache_path, quality_data)
-    if not fresh_msg:
-        nudge_msg = _maybe_nudge(result, cache_path, quality_data)
-        if nudge_msg:
-            system_messages.append(nudge_msg)
-    loop_msg = _maybe_loop_warning(result, cache_path, quality_data)
-    if loop_msg:
-        system_messages.append(loop_msg)
-    # Persist nudge/loop/fresh state (the once-per-session _fresh_nudge_fired flag
-    # must survive even if only the fresh nudge fired this turn).
-    if system_messages or fresh_msg:
-        _write_quality_cache(cache_path, result)
-    if system_messages:
-        # Gate the routine informational batch (quality/loop/fill warnings) under
-        # context pressure.
-        _emit_msgs = True
-        try:
-            from context_pressure import should_inject, get_pressure_level, log_suppression
-            _sf = str(filepath) if filepath else None
-            _sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
-            if not should_inject(_sf, session_id=_sid, priority="informational"):
-                log_suppression("quality_system_messages", get_pressure_level(_sf, session_id=_sid))
-                _emit_msgs = False
-        except Exception:
-            pass
-        if _emit_msgs:
-            for msg in system_messages:
-                try:
-                    print(json.dumps({"systemMessage": msg}))
-                except Exception:
-                    pass
-    # The fresh-session nudge BYPASSES pressure suppression on purpose: it fires at
-    # most once per session and is most relevant precisely when the session is
-    # degraded (i.e. under pressure). Suppressing it would defeat its purpose and
-    # silently burn the one-shot -- the exact bug where users never saw it.
-    if fresh_msg:
-        try:
-            print(json.dumps({"systemMessage": fresh_msg}))
-        except Exception:
-            pass
-
-    # Nudge follow-through: if PostCompact triggered this run (force=True)
-    # and a nudge preceded the compact, measure the actual fill_pct recovery.
-    if force and result.get("fill_pct", 0) > 0:
-        # A6: the nudge fires during a prior UserPromptSubmit process; this
-        # follow-through runs in a SEPARATE PostCompact process. Fire-state reaches
-        # us via the atomic per-session quality cache (carried forward at the top of
-        # this function). Fall back to prev_result directly in case the carry did not
-        # run, so a heeded session is never misclassified as ignored. Wrapped so a
-        # corrupt cache value can never crash the host hook — it degrades to "no
-        # credit", not a traceback.
-        try:
-            nudge_fill = result.get("_nudge_fill_pct_at_fire") or prev_result.get("_nudge_fill_pct_at_fire", 0)
-            if nudge_fill > 0:
-                current_fill = result["fill_pct"]
-                fill_delta = nudge_fill - current_fill
-                ft_sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
-                # A2 temporal gate: only credit a compaction that followed the nudge
-                # within the window. A compaction long after the nudge was not its
-                # follow-through, so it must not borrow the nudge's credit.
-                fire_epoch = result.get("_nudge_fire_epoch") or prev_result.get("_nudge_fire_epoch", 0)
-                within_window = fire_epoch and (time.time() - fire_epoch) <= _NUDGE_FOLLOWTHROUGH_WINDOW_SECONDS
-                # A2 dedup: if a checkpoint_restore already credited this session's
-                # recovery for this compaction (same SessionStart cycle), the nudge
-                # must not double-credit the same tokens.
-                already_credited = _checkpoint_restore_credited_recently(ft_sid)
-                should_credit = fill_delta > 5 and within_window and not already_credited
-                # Consume the fire-state FIRST, then credit only if the consume was
-                # actually persisted. The fire-state lives in exactly one place (this
-                # per-session cache), so once it is cleared from disk no later
-                # PostCompact can re-enter this block for the same nudge — that makes
-                # the credit idempotent without a second DB query. If the process
-                # dies between here and the credit, or the clear-write fails, we skip
-                # the credit (a conservative under-count) rather than risk a
-                # double-count that would inflate the savings number.
-                result.pop("_nudge_fill_pct_at_fire", None)
-                result.pop("_nudge_fire_epoch", None)
-                consumed = _write_quality_cache(cache_path, result)
-                if should_credit and consumed:
-                    context_size = detect_context_window()[0]
-                    measured_tokens_recovered = int(context_size * fill_delta / 100)
-                    _log_compression_event(
-                        feature="quality_nudge",
-                        original_text=" " * (measured_tokens_recovered * 4),
-                        compressed_text=f"nudge_followthrough:fill={nudge_fill}->{current_fill}",
-                        session_id=ft_sid,
-                        detail=f"measured_recovery: fill {nudge_fill}%->{current_fill}% = {measured_tokens_recovered} tokens on {context_size} context",
-                        verified=True,
-                    )
-        except Exception:
-            pass
-
-    # Progressive checkpoints (v3.0)
-    if _PROGRESSIVE_ENABLED and result.get("fill_pct", 0) > 0:
-        _maybe_progressive_checkpoint(
-            fill_pct=result["fill_pct"],
+        _maybe_checkpoint_on_quality_or_milestone(
+            quality_data=quality_data,
             cache_path=cache_path,
             result=result,
             filepath=filepath,
         )
 
-    _maybe_checkpoint_on_quality_or_milestone(
-        quality_data=quality_data,
-        cache_path=cache_path,
-        result=result,
-        filepath=filepath,
-    )
-
-    _release_quality_lock(_qlock)
-    return result.get("score")
+        return result.get("score")
+    finally:
+        _release_quality_lock(_qlock)
 
 
 def _stable_marketplace_script_path(script_name):
@@ -36498,6 +36547,18 @@ def run_ensure_health():
     except Exception as _e:
         print(f"  [Token Optimizer] dashboard daemon self-heal failed: {_e}", file=sys.stderr)
 
+    # FIX B: bounded stale-lease sweeper. Self-heals the unbounded ``.qlease``
+    # tombstone / orphan candidate / legacy ``.qlock`` litter that release()
+    # intentionally leaves for the next contender (most sessions get none, so
+    # they leak forever). Throttled to once per 24h via a one-stat marker, capped
+    # at max_files per run, and fail-open -- it NEVER raises into the hook and
+    # runs AFTER the daemon revive so it can never starve it. Not on the hot
+    # per-tool-call path (this is the SessionStart ensure-health path only).
+    try:
+        maybe_sweep_stale_leases()
+    except Exception:
+        pass
+
     # VS Code-family status-bar extension auto-install. Only meaningful for the
     # Claude runtime running inside a VS Code/Cursor/Windsurf editor; the detector
     # no-ops everywhere else (plain terminal, foreign runtimes). Default-on with a
@@ -36833,6 +36894,51 @@ def run_ensure_health():
             _write_config_flag("autoupdate_nudge_shown", True)
     except Exception:
         pass
+
+
+# FIX C: the dashboard-daemon ensure/revive must run BEFORE the rest of the
+# health work and under its own short independent wall-clock guard, so a slow
+# health scan that later trips the 8s SessionStart budget can never skip
+# reinstalling a missing launchd plist / dead daemon. ``_ensure_dashboard_daemon``
+# is idempotent + internally throttled (cheap-gate-first), so the second call
+# inside ``run_ensure_health`` below is a cheap no-op (the attempt timestamp is
+# already stamped). launchd KeepAlive+RunAtLoad persists a once-installed daemon;
+# the requirement here is only that a MISSING plist is reliably reinstalled even
+# under time pressure. Fail-open: never raises into the hook.
+_ENSURE_HEALTH_DAEMON_REVIVE_BUDGET = 6
+
+
+def _ensure_health_daemon_revive_first():
+    """Run the dashboard-daemon ensure/revive FIRST, under its own short guard.
+
+    Distinct from the daemon AUTO-UPDATE block inside run_ensure_health: that
+    block refreshes a stale script for an already-installed daemon and runs
+    AFTER the cheap writes; this runs FIRST so a missing/dead daemon is restored
+    before any health work can exhaust the budget. Idempotent + fail-open.
+    """
+    _daemon_deadline = _install_hook_budget(_ENSURE_HEALTH_DAEMON_REVIVE_BUDGET)
+    try:
+        _status = _ensure_dashboard_daemon()
+        if _status == "installed":
+            print("  [Token Optimizer] Installed the dashboard daemon. "
+                  f"Bookmark this exact URL: http://localhost:{DAEMON_PORT}/token-optimizer "
+                  "(the /token-optimizer path is required -- the bare host:port won't load it). "
+                  "Opt out anytime: measure.py setup-daemon --uninstall")
+        elif _status == "restarted":
+            print("  [Token Optimizer] Restarted the dashboard daemon.")
+        elif _status == "restart-stale":
+            print("  [Token Optimizer] dashboard daemon restarted but still "
+                  "serving a stale version; run: measure.py setup-daemon",
+                  file=sys.stderr)
+    except _HookTimeout:
+        # Test-injected timeout sentinel (production watchdog hard-exits). Swallow
+        # so the remaining health work still runs under its own 8s guard.
+        pass
+    except Exception:
+        # Fail-open: a daemon-revive error must never break SessionStart.
+        pass
+    finally:
+        _clear_hook_budget(_daemon_deadline)
 
 
 # The provenance label is untrusted input rendered into the model's context.
@@ -38996,6 +39102,14 @@ if __name__ == "__main__":
         # new session indefinitely. Handler exits 0 gracefully on timeout;
         # the 24h throttle on internal self-heal paths means the next
         # SessionStart is typically a no-op anyway.
+        #
+        # FIX C: the dashboard-daemon ensure/revive runs FIRST, under its own
+        # short independent guard, BEFORE the 8s health budget is armed. A slow
+        # health scan that later trips the 8s watchdog can therefore never skip
+        # reinstalling a missing launchd plist / dead daemon. The daemon ensure
+        # is idempotent + internally throttled, so the second call inside
+        # run_ensure_health is a cheap no-op. Fail-open: never raises.
+        _ensure_health_daemon_revive_first()
         _tok_hook_old_sig = _install_hook_budget(8)
         try:
             run_ensure_health()

--- a/skills/token-optimizer/scripts/hook_runtime.py
+++ b/skills/token-optimizer/scripts/hook_runtime.py
@@ -397,3 +397,122 @@ def lease_lock(path, **kwargs):
     finally:
         if acquired:
             lock.release()
+
+
+# --- Stale-lease sweeper -----------------------------------------------------
+# LeaseLock's release() leaves the canonical ``.qlease`` tombstone on disk for
+# the next contender to reclaim. Sessions are one-shot, so most tombstones get
+# no future contender and leak forever (one+ per session per user, unbounded).
+# This sweeper is the self-healing backstop: it removes ONLY lease artifacts
+# whose expiry is demonstrably far in the past, so no live locker can ever be
+# touched. It is fail-open by construction (whole body is try/except, never
+# raises) and must NEVER run on a hot per-tool-call path unthrottled.
+
+# A ``.qlease`` is long-expired once its parsed ``expires_wall`` is at least an
+# hour behind ``now``. The hour of slack absorbs clock skew and the
+# deadline-vs-lease rounding without ever reaching back into a live lease
+# (leases themselves are ~10s).
+_SWEEP_LEASE_EXPIRED_GRACE = 3600
+# Candidate/reclaim hard links and legacy ``.qlock`` files carry no parseable
+# expiry, so they are swept purely by mtime. 24h is far beyond any live lease
+# or reclaim-grace window, so a file this old is unambiguously orphaned.
+_SWEEP_MTIME_AGE = 86400
+
+
+def _sweep_stale_leases(directory, now=None, max_files=2000):
+    """Remove long-expired lease artifacts from ``directory``.
+
+    Scans ``directory`` (the quality-cache dir) and unlinks ONLY files whose
+    lease is demonstrably long-expired, so no live locker can be touched:
+
+      * ``*.qlease``: parse the JSON metadata and remove if ``expires_wall`` <
+        ``now - _SWEEP_LEASE_EXPIRED_GRACE`` (3600s). If the file is
+        unparseable/corrupt/partial, remove only when its mtime is older than
+        ``now - _SWEEP_MTIME_AGE`` (86400s) so a file mid-publication by an old
+        process is never torn down.
+      * ``.*.candidate-*`` and ``.*.reclaim-*``: remove when mtime is older
+        than ``now - _SWEEP_MTIME_AGE``.
+      * legacy ``*.qlock`` (pre-5.11 artifacts; the current code never writes
+        them): remove when mtime is older than ``now - _SWEEP_MTIME_AGE``.
+
+    The scan is capped at ``max_files`` entries per run so a pathological cache
+    dir cannot blow the hook budget. The whole function is wrapped in
+    try/except: it NEVER raises into a hook and NEVER blocks a session. Returns
+    the number of files removed (best-effort, 0 on any error).
+    """
+    removed = 0
+    try:
+        if directory is None:
+            return 0
+        dir_path = Path(directory) if not hasattr(directory, "iterdir") else directory
+        if not dir_path.is_dir():
+            return 0
+        now = time.time() if now is None else float(now)
+        lease_cutoff = now - _SWEEP_LEASE_EXPIRED_GRACE
+        mtime_cutoff = now - _SWEEP_MTIME_AGE
+        seen = 0
+        # ``scandir`` is one stat-free readdir; per-entry mtime comes from the
+        # DirEntry where available, falling back to os.stat only when needed.
+        try:
+            entries = list(os.scandir(dir_path))
+        except OSError:
+            return 0
+        for entry in entries:
+            if seen >= max_files:
+                break
+            seen += 1
+            name = entry.name
+            if not name:
+                continue
+            try:
+                # Skip non-files (subdirectories) cheaply via the scandir cache.
+                if entry.is_dir(follow_symlinks=False):
+                    continue
+                should_remove = False
+                if name.endswith(".qlease"):
+                    should_remove = _sweep_qlease_is_stale(
+                        dir_path / name, entry, lease_cutoff, mtime_cutoff
+                    )
+                elif name.startswith(".") and (
+                    ".candidate-" in name or ".reclaim-" in name
+                ):
+                    should_remove = _sweep_mtime_is_stale(entry, mtime_cutoff)
+                elif name.endswith(".qlock"):
+                    should_remove = _sweep_mtime_is_stale(entry, mtime_cutoff)
+                if should_remove:
+                    try:
+                        os.unlink(entry.path)
+                        removed += 1
+                    except OSError:
+                        pass
+            except OSError:
+                continue
+    except Exception:
+        # Fail-open: never propagate. A sweeper error must not break a hook.
+        return removed
+    return removed
+
+
+def _sweep_qlease_is_stale(path, entry, lease_cutoff, mtime_cutoff):
+    """True if a ``.qlease`` is long-expired (parseable) or long-dead (corrupt)."""
+    try:
+        raw = path.read_bytes()
+        owner = json.loads(raw)
+        expires = owner.get("expires_wall")
+        if isinstance(expires, (int, float)) and expires > 0:
+            return float(expires) < lease_cutoff
+        # Valid JSON but no usable expiry -> treat as corrupt (mtime gate).
+        return _sweep_mtime_is_stale(entry, mtime_cutoff)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        # Unparseable / partial / truncated JSON. A file mid-publication by an
+        # old process could be momentarily malformed, so gate on a 24h mtime
+        # age instead of removing a fresh malformed file immediately.
+        return _sweep_mtime_is_stale(entry, mtime_cutoff)
+
+
+def _sweep_mtime_is_stale(entry, mtime_cutoff):
+    """True if the entry's mtime is older than ``mtime_cutoff``."""
+    try:
+        return entry.stat(follow_symlinks=False).st_mtime < mtime_cutoff
+    except OSError:
+        return False

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -93,7 +93,13 @@ except ImportError:  # pragma: no cover - Python < 3.11 fallback
     tomllib = None
 
 from hook_io import read_stdin_hook_input as _read_stdin_hook_input_shared
-from hook_runtime import HookDeadline, LeaseLock, current_deadline, lease_lock
+from hook_runtime import (
+    HookDeadline,
+    LeaseLock,
+    current_deadline,
+    lease_lock,
+    _sweep_stale_leases,
+)
 import plugin_env
 from plugin_env import (
     _all_plugin_data_dirs,
@@ -30116,6 +30122,49 @@ def _quality_cache_tick_due(
         return False
 
 
+# --- Stale-lease sweeper throttle (FIX B) ------------------------------------
+# The sweeper itself lives in hook_runtime._sweep_stale_leases (fail-open, never
+# raises). It is invoked here OPPORTUNISTICALLY + THROTTLED to at most once per
+# 24h via a one-stat marker, mirroring the quality-cache throttle pattern. It is
+# wired into ensure-health (SessionStart), NEVER the hot per-tool-call path, so
+# the scan cost never lands on PostToolUse. The marker is touched AFTER a run so
+# a sweeper crash/timeout retries next session rather than waiting a full day.
+_QLEASE_SWEEP_THROTTLE_SECONDS = 86400
+_QLEASE_SWEEP_MARKER = QUALITY_CACHE_DIR / ".qlease-sweep-throttle"
+
+
+def _qlease_sweep_due():
+    """One-stat gate: True when the last sweep is older than 24h (or never ran)."""
+    try:
+        age = time.time() - _QLEASE_SWEEP_MARKER.stat().st_mtime
+        return age >= _QLEASE_SWEEP_THROTTLE_SECONDS
+    except OSError:
+        return True
+
+
+def maybe_sweep_stale_leases(directory=None):
+    """Throttled, fail-open invocation of the stale-lease sweeper.
+
+    Runs at most once per 24h per install. Wrapped end-to-end in try/except so
+    it can NEVER raise into a hook or block a session. Returns the number of
+    files removed (0 on any error / throttle skip). Exposed for tests.
+    """
+    try:
+        if not _qlease_sweep_due():
+            return 0
+        target = Path(directory) if directory is not None else QUALITY_CACHE_DIR
+        removed = _sweep_stale_leases(target)
+        # Stamp AFTER a successful run so a mid-sweep crash retries next session.
+        try:
+            _QLEASE_SWEEP_MARKER.parent.mkdir(parents=True, exist_ok=True)
+            _QLEASE_SWEEP_MARKER.touch()
+        except OSError:
+            pass
+        return removed
+    except Exception:
+        return 0
+
+
 def _write_checkpoint_atomic(checkpoint_path, content):
     """Atomically write a checkpoint markdown file. Returns True on success.
 
@@ -31071,243 +31120,243 @@ def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_
                 pass
         return None
 
-    # Run quality analysis
-    quality_data = _parse_jsonl_for_quality(filepath)
-    if not quality_data:
-        # New/empty session - write a clean score to cache so stale score doesn't persist
-        result = {
-            "score": 100,
-            "grade": "S",
-            "signals": {},
-            "breakdown": {},
-            "total_messages": 0,
-            "decisions_found": 0,
-            "compactions": 0,
-            "turns": 0,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "session_file": Path(filepath).name,
-            "model_context_window": detect_context_window()[0],
-        }
-        _write_quality_cache(cache_path, result)
-        _release_quality_lock(_qlock)
-        return 100
-
-    # Carry forward nudge/loop state from previous cache (survives across
-    # UserPromptSubmit → PostCompact boundary for follow-through measurement)
-    prev_result = {}
-    if cache_path.exists():
-        try:
-            prev_result = _read_quality_cache(cache_path) or {}
-        except Exception:
-            prev_result = {}
-
-    _session_id = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
-    result = compute_quality_score(quality_data, session_id=_session_id)
-    for carry_key in _CARRY_KEYS:
-        if carry_key in prev_result and carry_key not in result:
-            result[carry_key] = prev_result[carry_key]
-    result["total_messages"] = len(quality_data["messages"])
-    result["decisions_found"] = len(quality_data["decisions"])
-    result["compactions"] = quality_data["compactions"]
-    result["turns"] = len([m for m in quality_data["messages"] if m[1] == "user"])
-    result["timestamp"] = datetime.now(timezone.utc).isoformat()
-    result["session_file"] = Path(filepath).name
-    result["model"] = quality_data.get("model")
-    result["topic"] = quality_data.get("topic")
-    # Add degradation band for status line
-    cfd = result.get("breakdown", {}).get("context_fill_degradation", {})
-    result["degradation_band"] = cfd.get("band", "")
-    result["fill_pct"] = cfd.get("fill_pct", 0)
-    # Surface the resolved context window at the TOP LEVEL of the cache. Consumers
-    # that compute fill from raw transcript tokens (the VS Code companion's
-    # cacheReader, the dashboard) read `model_context_window` here; without it they
-    # fall back to a 200k guess and inflate every 1M-context session ~5x.
-    result["model_context_window"] = cfd.get("model_context_window") or detect_context_window()[0]
-    # The window alone cannot be sanity-checked by a reader; the source can.
-    result["model_context_window_source"] = (
-        cfd.get("model_context_window_source") or detect_context_window()[1]
-    )
-    result["context_window_contradicted"] = bool(cfd.get("window_contradicted"))
-
-    # Dampen ResourceHealth swings within a session.
-    # Fill_pct fluctuates between measurements (context adds/removes, compaction).
-    # Allow recovery but dampen: drops are immediate, recovery moves 30% toward
-    # the new value per measurement to prevent wild upward swings.
-    prev_rh = prev_result.get("resource_health")
-    current_rh = result.get("resource_health")
-    if prev_rh is not None and current_rh is not None:
-        if current_rh >= prev_rh:
-            result["resource_health"] = round(prev_rh + (current_rh - prev_rh) * 0.3, 1)
-        result["score"] = result["resource_health"]
-        result["grade"] = score_to_grade(round(result["resource_health"]))
-        result["resource_health_grade"] = result["grade"]
-
-    # Session duration + active agents for statusline (v2.6)
-    result["session_start_ts"] = _extract_session_start_ts(filepath)
-    result["active_agents"] = _extract_active_agents(filepath)
-
-    # Cache hit rate for statusline (v5.4.27)
     try:
-        total_input_all = 0
-        total_cache_read = 0
-        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
-            for line in f:
-                try:
-                    rec = json.loads(line)
-                    usage = rec.get("message", {}).get("usage", {}) if rec.get("type") == "assistant" else {}
-                    if usage:
-                        total_input_all += usage.get("input_tokens", 0) + usage.get("cache_read_input_tokens", 0) + usage.get("cache_creation_input_tokens", 0)
-                        total_cache_read += usage.get("cache_read_input_tokens", 0)
-                except (json.JSONDecodeError, AttributeError):
-                    continue
-        result["cache_hit_rate"] = round(total_cache_read / total_input_all, 3) if total_input_all > 0 else 0
-    except (OSError, ZeroDivisionError):
-        result["cache_hit_rate"] = 0
+        # Run quality analysis
+        quality_data = _parse_jsonl_for_quality(filepath)
+        if not quality_data:
+            # New/empty session - write a clean score to cache so stale score doesn't persist
+            result = {
+                "score": 100,
+                "grade": "S",
+                "signals": {},
+                "breakdown": {},
+                "total_messages": 0,
+                "decisions_found": 0,
+                "compactions": 0,
+                "turns": 0,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "session_file": Path(filepath).name,
+                "model_context_window": detect_context_window()[0],
+            }
+            _write_quality_cache(cache_path, result)
+            return 100
 
-    if not _write_quality_cache(cache_path, result):
-        _release_quality_lock(_qlock)
-        return None
+        # Carry forward nudge/loop state from previous cache (survives across
+        # UserPromptSubmit → PostCompact boundary for follow-through measurement)
+        prev_result = {}
+        if cache_path.exists():
+            try:
+                prev_result = _read_quality_cache(cache_path) or {}
+            except Exception:
+                prev_result = {}
 
-    # v5.0: Quality nudges + loop detection
-    # These always run regardless of --quiet, because they emit systemMessage JSON
-    # that Claude Code injects into context. Suppressing them defeats their purpose.
-    system_messages = []
+        _session_id = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
+        result = compute_quality_score(quality_data, session_id=_session_id)
+        for carry_key in _CARRY_KEYS:
+            if carry_key in prev_result and carry_key not in result:
+                result[carry_key] = prev_result[carry_key]
+        result["total_messages"] = len(quality_data["messages"])
+        result["decisions_found"] = len(quality_data["decisions"])
+        result["compactions"] = quality_data["compactions"]
+        result["turns"] = len([m for m in quality_data["messages"] if m[1] == "user"])
+        result["timestamp"] = datetime.now(timezone.utc).isoformat()
+        result["session_file"] = Path(filepath).name
+        result["model"] = quality_data.get("model")
+        result["topic"] = quality_data.get("topic")
+        # Add degradation band for status line
+        cfd = result.get("breakdown", {}).get("context_fill_degradation", {})
+        result["degradation_band"] = cfd.get("band", "")
+        result["fill_pct"] = cfd.get("fill_pct", 0)
+        # Surface the resolved context window at the TOP LEVEL of the cache. Consumers
+        # that compute fill from raw transcript tokens (the VS Code companion's
+        # cacheReader, the dashboard) read `model_context_window` here; without it they
+        # fall back to a 200k guess and inflate every 1M-context session ~5x.
+        result["model_context_window"] = cfd.get("model_context_window") or detect_context_window()[0]
+        # The window alone cannot be sanity-checked by a reader; the source can.
+        result["model_context_window_source"] = (
+            cfd.get("model_context_window_source") or detect_context_window()[1]
+        )
+        result["context_window_contradicted"] = bool(cfd.get("window_contradicted"))
 
-    # Fill warnings fire independently of composite score (Tier 1 monotonicity fix).
-    # These cannot be masked by improving ratio signals. Deduplicated per level
-    # so the same threshold doesn't fire every prompt.
-    fill_warning = result.get("fill_warning")
-    if fill_warning and fill_warning["level"] in ("WARNING", "CRITICAL"):
-        prev_fill_warn_level = prev_result.get("_last_fill_warn_level")
-        if fill_warning["level"] != prev_fill_warn_level:
-            result["_last_fill_warn_level"] = fill_warning["level"]
-            system_messages.append(
-                f"[Token Optimizer] {fill_warning['level']}: {fill_warning['message']}"
+        # Dampen ResourceHealth swings within a session.
+        # Fill_pct fluctuates between measurements (context adds/removes, compaction).
+        # Allow recovery but dampen: drops are immediate, recovery moves 30% toward
+        # the new value per measurement to prevent wild upward swings.
+        prev_rh = prev_result.get("resource_health")
+        current_rh = result.get("resource_health")
+        if prev_rh is not None and current_rh is not None:
+            if current_rh >= prev_rh:
+                result["resource_health"] = round(prev_rh + (current_rh - prev_rh) * 0.3, 1)
+            result["score"] = result["resource_health"]
+            result["grade"] = score_to_grade(round(result["resource_health"]))
+            result["resource_health_grade"] = result["grade"]
+
+        # Session duration + active agents for statusline (v2.6)
+        result["session_start_ts"] = _extract_session_start_ts(filepath)
+        result["active_agents"] = _extract_active_agents(filepath)
+
+        # Cache hit rate for statusline (v5.4.27)
+        try:
+            total_input_all = 0
+            total_cache_read = 0
+            with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    try:
+                        rec = json.loads(line)
+                        usage = rec.get("message", {}).get("usage", {}) if rec.get("type") == "assistant" else {}
+                        if usage:
+                            total_input_all += usage.get("input_tokens", 0) + usage.get("cache_read_input_tokens", 0) + usage.get("cache_creation_input_tokens", 0)
+                            total_cache_read += usage.get("cache_read_input_tokens", 0)
+                    except (json.JSONDecodeError, AttributeError):
+                        continue
+            result["cache_hit_rate"] = round(total_cache_read / total_input_all, 3) if total_input_all > 0 else 0
+        except (OSError, ZeroDivisionError):
+            result["cache_hit_rate"] = 0
+
+        if not _write_quality_cache(cache_path, result):
+            return None
+
+        # v5.0: Quality nudges + loop detection
+        # These always run regardless of --quiet, because they emit systemMessage JSON
+        # that Claude Code injects into context. Suppressing them defeats their purpose.
+        system_messages = []
+
+        # Fill warnings fire independently of composite score (Tier 1 monotonicity fix).
+        # These cannot be masked by improving ratio signals. Deduplicated per level
+        # so the same threshold doesn't fire every prompt.
+        fill_warning = result.get("fill_warning")
+        if fill_warning and fill_warning["level"] in ("WARNING", "CRITICAL"):
+            prev_fill_warn_level = prev_result.get("_last_fill_warn_level")
+            if fill_warning["level"] != prev_fill_warn_level:
+                result["_last_fill_warn_level"] = fill_warning["level"]
+                system_messages.append(
+                    f"[Token Optimizer] {fill_warning['level']}: {fill_warning['message']}"
+                )
+
+        # Tool call fatigue warnings (independent of composite score)
+        tool_call_warning = result.get("tool_call_warning")
+        if tool_call_warning and tool_call_warning["level"] in ("WARNING", "CRITICAL"):
+            prev_tc_level = prev_result.get("_last_tool_call_warn_level")
+            if tool_call_warning["level"] != prev_tc_level:
+                result["_last_tool_call_warn_level"] = tool_call_warning["level"]
+                system_messages.append(
+                    f"[Token Optimizer] {tool_call_warning['level']}: {tool_call_warning['message']}"
+                )
+
+        # Fresh-session nudge takes precedence: when a session is long AND degraded,
+        # "start fresh (context is preserved)" is the stronger remedy than /compact, and
+        # firing both would be noise. Only fall back to the /compact nudge if it didn't fire.
+        fresh_msg = _maybe_fresh_session_nudge(result, cache_path, quality_data)
+        if not fresh_msg:
+            nudge_msg = _maybe_nudge(result, cache_path, quality_data)
+            if nudge_msg:
+                system_messages.append(nudge_msg)
+        loop_msg = _maybe_loop_warning(result, cache_path, quality_data)
+        if loop_msg:
+            system_messages.append(loop_msg)
+        # Persist nudge/loop/fresh state (the once-per-session _fresh_nudge_fired flag
+        # must survive even if only the fresh nudge fired this turn).
+        if system_messages or fresh_msg:
+            _write_quality_cache(cache_path, result)
+        if system_messages:
+            # Gate the routine informational batch (quality/loop/fill warnings) under
+            # context pressure.
+            _emit_msgs = True
+            try:
+                from context_pressure import should_inject, get_pressure_level, log_suppression
+                _sf = str(filepath) if filepath else None
+                _sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
+                if not should_inject(_sf, session_id=_sid, priority="informational"):
+                    log_suppression("quality_system_messages", get_pressure_level(_sf, session_id=_sid))
+                    _emit_msgs = False
+            except Exception:
+                pass
+            if _emit_msgs:
+                for msg in system_messages:
+                    try:
+                        print(json.dumps({"systemMessage": msg}))
+                    except Exception:
+                        pass
+        # The fresh-session nudge BYPASSES pressure suppression on purpose: it fires at
+        # most once per session and is most relevant precisely when the session is
+        # degraded (i.e. under pressure). Suppressing it would defeat its purpose and
+        # silently burn the one-shot -- the exact bug where users never saw it.
+        if fresh_msg:
+            try:
+                print(json.dumps({"systemMessage": fresh_msg}))
+            except Exception:
+                pass
+
+        # Nudge follow-through: if PostCompact triggered this run (force=True)
+        # and a nudge preceded the compact, measure the actual fill_pct recovery.
+        if force and result.get("fill_pct", 0) > 0:
+            # A6: the nudge fires during a prior UserPromptSubmit process; this
+            # follow-through runs in a SEPARATE PostCompact process. Fire-state reaches
+            # us via the atomic per-session quality cache (carried forward at the top of
+            # this function). Fall back to prev_result directly in case the carry did not
+            # run, so a heeded session is never misclassified as ignored. Wrapped so a
+            # corrupt cache value can never crash the host hook — it degrades to "no
+            # credit", not a traceback.
+            try:
+                nudge_fill = result.get("_nudge_fill_pct_at_fire") or prev_result.get("_nudge_fill_pct_at_fire", 0)
+                if nudge_fill > 0:
+                    current_fill = result["fill_pct"]
+                    fill_delta = nudge_fill - current_fill
+                    ft_sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
+                    # A2 temporal gate: only credit a compaction that followed the nudge
+                    # within the window. A compaction long after the nudge was not its
+                    # follow-through, so it must not borrow the nudge's credit.
+                    fire_epoch = result.get("_nudge_fire_epoch") or prev_result.get("_nudge_fire_epoch", 0)
+                    within_window = fire_epoch and (time.time() - fire_epoch) <= _NUDGE_FOLLOWTHROUGH_WINDOW_SECONDS
+                    # A2 dedup: if a checkpoint_restore already credited this session's
+                    # recovery for this compaction (same SessionStart cycle), the nudge
+                    # must not double-credit the same tokens.
+                    already_credited = _checkpoint_restore_credited_recently(ft_sid)
+                    should_credit = fill_delta > 5 and within_window and not already_credited
+                    # Consume the fire-state FIRST, then credit only if the consume was
+                    # actually persisted. The fire-state lives in exactly one place (this
+                    # per-session cache), so once it is cleared from disk no later
+                    # PostCompact can re-enter this block for the same nudge — that makes
+                    # the credit idempotent without a second DB query. If the process
+                    # dies between here and the credit, or the clear-write fails, we skip
+                    # the credit (a conservative under-count) rather than risk a
+                    # double-count that would inflate the savings number.
+                    result.pop("_nudge_fill_pct_at_fire", None)
+                    result.pop("_nudge_fire_epoch", None)
+                    consumed = _write_quality_cache(cache_path, result)
+                    if should_credit and consumed:
+                        context_size = detect_context_window()[0]
+                        measured_tokens_recovered = int(context_size * fill_delta / 100)
+                        _log_compression_event(
+                            feature="quality_nudge",
+                            original_text=" " * (measured_tokens_recovered * 4),
+                            compressed_text=f"nudge_followthrough:fill={nudge_fill}->{current_fill}",
+                            session_id=ft_sid,
+                            detail=f"measured_recovery: fill {nudge_fill}%->{current_fill}% = {measured_tokens_recovered} tokens on {context_size} context",
+                            verified=True,
+                        )
+            except Exception:
+                pass
+
+        # Progressive checkpoints (v3.0)
+        if _PROGRESSIVE_ENABLED and result.get("fill_pct", 0) > 0:
+            _maybe_progressive_checkpoint(
+                fill_pct=result["fill_pct"],
+                cache_path=cache_path,
+                result=result,
+                filepath=filepath,
             )
 
-    # Tool call fatigue warnings (independent of composite score)
-    tool_call_warning = result.get("tool_call_warning")
-    if tool_call_warning and tool_call_warning["level"] in ("WARNING", "CRITICAL"):
-        prev_tc_level = prev_result.get("_last_tool_call_warn_level")
-        if tool_call_warning["level"] != prev_tc_level:
-            result["_last_tool_call_warn_level"] = tool_call_warning["level"]
-            system_messages.append(
-                f"[Token Optimizer] {tool_call_warning['level']}: {tool_call_warning['message']}"
-            )
-
-    # Fresh-session nudge takes precedence: when a session is long AND degraded,
-    # "start fresh (context is preserved)" is the stronger remedy than /compact, and
-    # firing both would be noise. Only fall back to the /compact nudge if it didn't fire.
-    fresh_msg = _maybe_fresh_session_nudge(result, cache_path, quality_data)
-    if not fresh_msg:
-        nudge_msg = _maybe_nudge(result, cache_path, quality_data)
-        if nudge_msg:
-            system_messages.append(nudge_msg)
-    loop_msg = _maybe_loop_warning(result, cache_path, quality_data)
-    if loop_msg:
-        system_messages.append(loop_msg)
-    # Persist nudge/loop/fresh state (the once-per-session _fresh_nudge_fired flag
-    # must survive even if only the fresh nudge fired this turn).
-    if system_messages or fresh_msg:
-        _write_quality_cache(cache_path, result)
-    if system_messages:
-        # Gate the routine informational batch (quality/loop/fill warnings) under
-        # context pressure.
-        _emit_msgs = True
-        try:
-            from context_pressure import should_inject, get_pressure_level, log_suppression
-            _sf = str(filepath) if filepath else None
-            _sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
-            if not should_inject(_sf, session_id=_sid, priority="informational"):
-                log_suppression("quality_system_messages", get_pressure_level(_sf, session_id=_sid))
-                _emit_msgs = False
-        except Exception:
-            pass
-        if _emit_msgs:
-            for msg in system_messages:
-                try:
-                    print(json.dumps({"systemMessage": msg}))
-                except Exception:
-                    pass
-    # The fresh-session nudge BYPASSES pressure suppression on purpose: it fires at
-    # most once per session and is most relevant precisely when the session is
-    # degraded (i.e. under pressure). Suppressing it would defeat its purpose and
-    # silently burn the one-shot -- the exact bug where users never saw it.
-    if fresh_msg:
-        try:
-            print(json.dumps({"systemMessage": fresh_msg}))
-        except Exception:
-            pass
-
-    # Nudge follow-through: if PostCompact triggered this run (force=True)
-    # and a nudge preceded the compact, measure the actual fill_pct recovery.
-    if force and result.get("fill_pct", 0) > 0:
-        # A6: the nudge fires during a prior UserPromptSubmit process; this
-        # follow-through runs in a SEPARATE PostCompact process. Fire-state reaches
-        # us via the atomic per-session quality cache (carried forward at the top of
-        # this function). Fall back to prev_result directly in case the carry did not
-        # run, so a heeded session is never misclassified as ignored. Wrapped so a
-        # corrupt cache value can never crash the host hook — it degrades to "no
-        # credit", not a traceback.
-        try:
-            nudge_fill = result.get("_nudge_fill_pct_at_fire") or prev_result.get("_nudge_fill_pct_at_fire", 0)
-            if nudge_fill > 0:
-                current_fill = result["fill_pct"]
-                fill_delta = nudge_fill - current_fill
-                ft_sid = Path(cache_path).stem.replace("quality-cache-", "", 1) if cache_path else None
-                # A2 temporal gate: only credit a compaction that followed the nudge
-                # within the window. A compaction long after the nudge was not its
-                # follow-through, so it must not borrow the nudge's credit.
-                fire_epoch = result.get("_nudge_fire_epoch") or prev_result.get("_nudge_fire_epoch", 0)
-                within_window = fire_epoch and (time.time() - fire_epoch) <= _NUDGE_FOLLOWTHROUGH_WINDOW_SECONDS
-                # A2 dedup: if a checkpoint_restore already credited this session's
-                # recovery for this compaction (same SessionStart cycle), the nudge
-                # must not double-credit the same tokens.
-                already_credited = _checkpoint_restore_credited_recently(ft_sid)
-                should_credit = fill_delta > 5 and within_window and not already_credited
-                # Consume the fire-state FIRST, then credit only if the consume was
-                # actually persisted. The fire-state lives in exactly one place (this
-                # per-session cache), so once it is cleared from disk no later
-                # PostCompact can re-enter this block for the same nudge — that makes
-                # the credit idempotent without a second DB query. If the process
-                # dies between here and the credit, or the clear-write fails, we skip
-                # the credit (a conservative under-count) rather than risk a
-                # double-count that would inflate the savings number.
-                result.pop("_nudge_fill_pct_at_fire", None)
-                result.pop("_nudge_fire_epoch", None)
-                consumed = _write_quality_cache(cache_path, result)
-                if should_credit and consumed:
-                    context_size = detect_context_window()[0]
-                    measured_tokens_recovered = int(context_size * fill_delta / 100)
-                    _log_compression_event(
-                        feature="quality_nudge",
-                        original_text=" " * (measured_tokens_recovered * 4),
-                        compressed_text=f"nudge_followthrough:fill={nudge_fill}->{current_fill}",
-                        session_id=ft_sid,
-                        detail=f"measured_recovery: fill {nudge_fill}%->{current_fill}% = {measured_tokens_recovered} tokens on {context_size} context",
-                        verified=True,
-                    )
-        except Exception:
-            pass
-
-    # Progressive checkpoints (v3.0)
-    if _PROGRESSIVE_ENABLED and result.get("fill_pct", 0) > 0:
-        _maybe_progressive_checkpoint(
-            fill_pct=result["fill_pct"],
+        _maybe_checkpoint_on_quality_or_milestone(
+            quality_data=quality_data,
             cache_path=cache_path,
             result=result,
             filepath=filepath,
         )
 
-    _maybe_checkpoint_on_quality_or_milestone(
-        quality_data=quality_data,
-        cache_path=cache_path,
-        result=result,
-        filepath=filepath,
-    )
-
-    _release_quality_lock(_qlock)
-    return result.get("score")
+        return result.get("score")
+    finally:
+        _release_quality_lock(_qlock)
 
 
 def _stable_marketplace_script_path(script_name):
@@ -36498,6 +36547,18 @@ def run_ensure_health():
     except Exception as _e:
         print(f"  [Token Optimizer] dashboard daemon self-heal failed: {_e}", file=sys.stderr)
 
+    # FIX B: bounded stale-lease sweeper. Self-heals the unbounded ``.qlease``
+    # tombstone / orphan candidate / legacy ``.qlock`` litter that release()
+    # intentionally leaves for the next contender (most sessions get none, so
+    # they leak forever). Throttled to once per 24h via a one-stat marker, capped
+    # at max_files per run, and fail-open -- it NEVER raises into the hook and
+    # runs AFTER the daemon revive so it can never starve it. Not on the hot
+    # per-tool-call path (this is the SessionStart ensure-health path only).
+    try:
+        maybe_sweep_stale_leases()
+    except Exception:
+        pass
+
     # VS Code-family status-bar extension auto-install. Only meaningful for the
     # Claude runtime running inside a VS Code/Cursor/Windsurf editor; the detector
     # no-ops everywhere else (plain terminal, foreign runtimes). Default-on with a
@@ -36833,6 +36894,51 @@ def run_ensure_health():
             _write_config_flag("autoupdate_nudge_shown", True)
     except Exception:
         pass
+
+
+# FIX C: the dashboard-daemon ensure/revive must run BEFORE the rest of the
+# health work and under its own short independent wall-clock guard, so a slow
+# health scan that later trips the 8s SessionStart budget can never skip
+# reinstalling a missing launchd plist / dead daemon. ``_ensure_dashboard_daemon``
+# is idempotent + internally throttled (cheap-gate-first), so the second call
+# inside ``run_ensure_health`` below is a cheap no-op (the attempt timestamp is
+# already stamped). launchd KeepAlive+RunAtLoad persists a once-installed daemon;
+# the requirement here is only that a MISSING plist is reliably reinstalled even
+# under time pressure. Fail-open: never raises into the hook.
+_ENSURE_HEALTH_DAEMON_REVIVE_BUDGET = 6
+
+
+def _ensure_health_daemon_revive_first():
+    """Run the dashboard-daemon ensure/revive FIRST, under its own short guard.
+
+    Distinct from the daemon AUTO-UPDATE block inside run_ensure_health: that
+    block refreshes a stale script for an already-installed daemon and runs
+    AFTER the cheap writes; this runs FIRST so a missing/dead daemon is restored
+    before any health work can exhaust the budget. Idempotent + fail-open.
+    """
+    _daemon_deadline = _install_hook_budget(_ENSURE_HEALTH_DAEMON_REVIVE_BUDGET)
+    try:
+        _status = _ensure_dashboard_daemon()
+        if _status == "installed":
+            print("  [Token Optimizer] Installed the dashboard daemon. "
+                  f"Bookmark this exact URL: http://localhost:{DAEMON_PORT}/token-optimizer "
+                  "(the /token-optimizer path is required -- the bare host:port won't load it). "
+                  "Opt out anytime: measure.py setup-daemon --uninstall")
+        elif _status == "restarted":
+            print("  [Token Optimizer] Restarted the dashboard daemon.")
+        elif _status == "restart-stale":
+            print("  [Token Optimizer] dashboard daemon restarted but still "
+                  "serving a stale version; run: measure.py setup-daemon",
+                  file=sys.stderr)
+    except _HookTimeout:
+        # Test-injected timeout sentinel (production watchdog hard-exits). Swallow
+        # so the remaining health work still runs under its own 8s guard.
+        pass
+    except Exception:
+        # Fail-open: a daemon-revive error must never break SessionStart.
+        pass
+    finally:
+        _clear_hook_budget(_daemon_deadline)
 
 
 # The provenance label is untrusted input rendered into the model's context.
@@ -38996,6 +39102,14 @@ if __name__ == "__main__":
         # new session indefinitely. Handler exits 0 gracefully on timeout;
         # the 24h throttle on internal self-heal paths means the next
         # SessionStart is typically a no-op anyway.
+        #
+        # FIX C: the dashboard-daemon ensure/revive runs FIRST, under its own
+        # short independent guard, BEFORE the 8s health budget is armed. A slow
+        # health scan that later trips the 8s watchdog can therefore never skip
+        # reinstalling a missing launchd plist / dead daemon. The daemon ensure
+        # is idempotent + internally throttled, so the second call inside
+        # run_ensure_health is a cheap no-op. Fail-open: never raises.
+        _ensure_health_daemon_revive_first()
         _tok_hook_old_sig = _install_hook_budget(8)
         try:
             run_ensure_health()

--- a/tests/test_ensure_health_daemon_revive_first.py
+++ b/tests/test_ensure_health_daemon_revive_first.py
@@ -1,0 +1,149 @@
+"""FIX C: the dashboard-daemon ensure/revive must run FIRST, under its own
+short independent guard, BEFORE the 8s SessionStart health budget is armed.
+
+Before the fix, ``run_ensure_health`` ran under ``_install_hook_budget(8)`` and
+the daemon self-heal lived partway down the function. A health scan that
+exceeded 8s raised ``_HookTimeout`` (or tripped the watchdog) BEFORE the daemon
+revive, so a missing launchd plist / dead daemon on port 24842 was never
+restored. The fix extracts ``_ensure_health_daemon_revive_first()`` and calls
+it BEFORE the 8s budget in the ensure-health dispatch, so a missing plist is
+reliably reinstalled even when the later health scan times out.
+
+These tests prove:
+  * ``_ensure_health_daemon_revive_first`` runs ``_ensure_dashboard_daemon`` and
+    reports an install/restart, never raising (fail-open).
+  * The daemon revive completes BEFORE the health scan that later times out --
+    i.e. a missing plist is reinstalled even when ``run_ensure_health`` raises
+    ``_HookTimeout``.
+  * The ensure-health dispatch source calls ``_ensure_health_daemon_revive_first``
+    BEFORE ``_install_hook_budget(8)`` / ``run_ensure_health`` (reorder guard).
+
+Run: python3 -m pytest tests/test_ensure_health_daemon_revive_first.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+@pytest.fixture()
+def m(monkeypatch):
+    tmp = tempfile.mkdtemp(prefix="to-daemon-revive-first-")
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", tmp)
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    monkeypatch.setattr(mod, "_is_foreign_runtime", lambda: False)
+    monkeypatch.setattr(mod, "detect_runtime", lambda: "claude")
+    monkeypatch.setattr(mod, "_normalized_platform", lambda: "Darwin")
+    # No real watchdog threads: stub the budget primitives.
+    monkeypatch.setattr(mod, "_install_hook_budget", lambda s: object())
+    monkeypatch.setattr(mod, "_clear_hook_budget", lambda d: None)
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+def test_revive_first_installs_missing_daemon(m, monkeypatch, capsys):
+    """A missing daemon (-> 'installed') is reinstalled by the first-step helper."""
+    monkeypatch.setattr(m, "_ensure_dashboard_daemon", lambda *a, **k: "installed")
+    m._ensure_health_daemon_revive_first()
+    out = capsys.readouterr().out
+    assert "Installed the dashboard daemon" in out
+    assert "localhost:" in out
+
+
+def test_revive_first_restarts_dead_daemon(m, monkeypatch, capsys):
+    monkeypatch.setattr(m, "_ensure_dashboard_daemon", lambda *a, **k: "restarted")
+    m._ensure_health_daemon_revive_first()
+    assert "Restarted the dashboard daemon" in capsys.readouterr().out
+
+
+def test_revive_first_never_raises_on_inner_error(m, monkeypatch):
+    """Fail-open: an exception inside _ensure_dashboard_daemon must not escape."""
+
+    def boom(*a, **k):
+        raise RuntimeError("daemon explode")
+
+    monkeypatch.setattr(m, "_ensure_dashboard_daemon", boom)
+    # Must not raise into the hook.
+    m._ensure_health_daemon_revive_first()
+
+
+def test_revive_first_swallows_injected_hook_timeout(m, monkeypatch):
+    """A test-injected _HookTimeout inside the revive is swallowed so the rest
+    of ensure-health still gets its own 8s guard."""
+
+    def boom(*a, **k):
+        raise m._HookTimeout()
+
+    monkeypatch.setattr(m, "_ensure_dashboard_daemon", boom)
+    m._ensure_health_daemon_revive_first()  # must not raise
+
+
+def test_daemon_revive_runs_before_health_budget_timeout(m, monkeypatch):
+    """THE FIX C contract: the daemon revive completes (installs the missing
+    plist) BEFORE the health scan that later trips the 8s budget. Reproduces the
+    ensure-health dispatch ordering: revive-first, then run_ensure_health under
+    its 8s guard. A timeout in the health scan must not skip the revive."""
+    log: list[str] = []
+
+    monkeypatch.setattr(
+        m, "_ensure_dashboard_daemon", lambda *a, **k: log.append("daemon") or "installed"
+    )
+
+    def slow_health():
+        log.append("health")
+        raise m._HookTimeout()
+
+    monkeypatch.setattr(m, "run_ensure_health", slow_health)
+
+    # Mirror the ensure-health dispatch exactly (FIX C ordering):
+    #   _ensure_health_daemon_revive_first()
+    #   _install_hook_budget(8); try: run_ensure_health() except _HookTimeout: ...
+    m._ensure_health_daemon_revive_first()
+    try:
+        m.run_ensure_health()
+    except m._HookTimeout:
+        pass
+
+    # Daemon revive ran first and completed; the health scan timed out AFTER.
+    assert log == ["daemon", "health"], (
+        f"daemon revive must precede the (timing-out) health scan; got {log}"
+    )
+
+
+def test_dispatch_source_calls_revive_first_before_budget():
+    """Reorder guard: in the ensure-health dispatch block, the call to
+    ``_ensure_health_daemon_revive_first()`` must appear BEFORE
+    ``_install_hook_budget(8)`` and ``run_ensure_health()`` so a future edit
+    cannot silently revert FIX C."""
+    src = (SCRIPTS / "measure.py").read_text(encoding="utf-8")
+    # Isolate the ensure-health dispatch arm.
+    m = re.search(
+        r'elif args\[0\] == "ensure-health":(?P<body>.*?)(?=\n    elif args\[0\] ==)',
+        src,
+        re.S,
+    )
+    assert m, "could not locate the ensure-health dispatch block"
+    body = m.group("body")
+    i_revive = body.find("_ensure_health_daemon_revive_first()")
+    i_budget = body.find("_install_hook_budget(8)")
+    i_health = body.find("run_ensure_health()")
+    assert i_revive != -1, "dispatch no longer calls _ensure_health_daemon_revive_first()"
+    assert i_budget != -1, "dispatch no longer arms the 8s budget"
+    assert i_health != -1, "dispatch no longer calls run_ensure_health"
+    assert i_revive < i_budget < i_health, (
+        "FIX C ordering broken: revive-first must precede the 8s budget and "
+        "run_ensure_health"
+    )

--- a/tests/test_quality_cache_release_on_timeout.py
+++ b/tests/test_quality_cache_release_on_timeout.py
@@ -1,0 +1,136 @@
+"""FIX A: ``quality_cache`` releases its lease lock even when the wall-clock
+deadline fires mid-computation.
+
+``_HookTimeout`` inherits from ``BaseException`` so inner ``except Exception``
+blocks cannot swallow it. Before the fix, ``_release_quality_lock`` was called
+only at explicit returns, NOT in a ``finally``; a ``_HookTimeout`` raised
+between acquire and release skipped release entirely, leaking the per-nonce
+candidate hard link too. The fix wraps the locked region in ``try/finally`` so
+``_release_quality_lock`` (idempotent + guarded) runs on every exit, including
+the ``BaseException`` path.
+
+This test injects ``_HookTimeout`` at ``compute_quality_score`` (mid-compute,
+after acquire, before any inline release) and asserts the candidate is unlinked
+in the finally.
+
+Run: python3 -m pytest tests/test_quality_cache_release_on_timeout.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+@pytest.fixture()
+def m(monkeypatch):
+    tmp = tempfile.mkdtemp(prefix="to-qcache-release-")
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", tmp)
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+def _candidate_files(cache_dir: Path):
+    return list(cache_dir.glob(".*.candidate-*"))
+
+
+def test_quality_cache_releases_lock_on_hook_timeout(m, monkeypatch, tmp_path):
+    cache_dir = tmp_path / "to-cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(m, "QUALITY_CACHE_DIR", cache_dir)
+
+    # A real session jsonl filepath so quality_cache resolves a per-session path.
+    session = tmp_path / "sess-abc.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00Z"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # _parse_jsonl_for_quality returns truthy data so we pass the empty-session
+    # branch and reach compute_quality_score (the mid-compute injection point).
+    monkeypatch.setattr(
+        m,
+        "_parse_jsonl_for_quality",
+        lambda fp: {"messages": [], "decisions": [], "compactions": 0},
+    )
+
+    # Inject the deadline firing mid-computation (after acquire, before release).
+    def _boom(*a, **k):
+        raise m._HookTimeout()
+
+    monkeypatch.setattr(m, "compute_quality_score", _boom)
+
+    # No inline release exists on this path pre-fix; the finally is the only
+    # release. The BaseException propagates out of quality_cache.
+    with pytest.raises(m._HookTimeout):
+        m.quality_cache(
+            throttle_seconds=120,
+            quiet=True,
+            session_jsonl=str(session),
+            force=True,
+        )
+
+    # The per-nonce candidate hard link MUST be unlinked by the finally release.
+    # Pre-fix this leaked forever (the candidate stayed on disk).
+    candidates = _candidate_files(cache_dir)
+    assert candidates == [], (
+        f"lock candidate leaked on _HookTimeout: {[p.name for p in candidates]}"
+    )
+
+    # The canonical .qlease tombstone is left by release() on purpose (reclaim
+    # protocol) -- but it MUST be marked released:1, proving release() ran.
+    qleases = list(cache_dir.glob("*.qlease"))
+    assert qleases, "expected the .qlease tombstone to exist after release"
+    released_seen = False
+    for q in qleases:
+        try:
+            meta = json.loads(q.read_text(encoding="utf-8"))
+            if meta.get("released") in (1, True):
+                released_seen = True
+        except (OSError, ValueError, json.JSONDecodeError):
+            pass
+    assert released_seen, (
+        ".qlease tombstone was not marked released:1 -- release() did not run"
+    )
+
+
+def test_quality_cache_releases_lock_on_normal_return(m, monkeypatch, tmp_path):
+    """Sanity: the finally release also covers the normal return path, so a
+    successful run does not leak the candidate either."""
+    cache_dir = tmp_path / "to-cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(m, "QUALITY_CACHE_DIR", cache_dir)
+
+    session = tmp_path / "sess-ok.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        m,
+        "_parse_jsonl_for_quality",
+        lambda fp: {},
+    )
+    # Force the empty-session branch (returns 100) without touching real scoring.
+    monkeypatch.setattr(m, "_parse_jsonl_for_quality", lambda fp: {})
+
+    score = m.quality_cache(
+        throttle_seconds=120, quiet=True, session_jsonl=str(session), force=True
+    )
+    assert score == 100
+    assert _candidate_files(cache_dir) == [], "candidate leaked on normal return"

--- a/tests/test_stale_lease_sweeper.py
+++ b/tests/test_stale_lease_sweeper.py
@@ -1,0 +1,219 @@
+"""FIX B: bounded stale-lease sweeper.
+
+``hook_runtime.LeaseLock.release()`` leaves the canonical ``.qlease`` tombstone
+on disk for the next contender to reclaim, and a ``_HookTimeout`` between acquire
+and release can also leak the per-nonce candidate. Sessions are one-shot, so most
+tombstones get no future contender and leak forever. ``_sweep_stale_leases`` is
+the self-healing backstop: it removes ONLY lease artifacts whose expiry is
+demonstrably long in the past, so no live locker can ever be touched.
+
+These tests prove:
+  * an expired ``.qlease`` (``expires_wall`` in the past) is removed;
+  * a day-old ``.candidate-*`` / ``.reclaim-*`` / legacy ``.qlock`` is removed;
+  * a fresh/live ``.qlease`` (``expires_wall`` in the future) is NOT removed;
+  * a recent ``.candidate-*`` is NOT removed (live acquisition in flight);
+  * a corrupt/partial ``.qlease`` never raises and is removed only past 24h mtime;
+  * the scan is capped at ``max_files``;
+  * the measure-side ``maybe_sweep_stale_leases`` throttle runs once then skips.
+
+Run: python3 -m pytest tests/test_stale_lease_sweeper.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import hook_runtime  # noqa: E402
+
+
+def _qlease(path: Path, expires_wall: float, released: int = 0) -> Path:
+    """Write a minimal valid ``.qlease`` metadata file."""
+    path.write_text(
+        json.dumps(
+            {
+                "pid": os.getpid(),
+                "nonce": "deadbeef" * 4,
+                "released": released,
+                "reuse_wall": expires_wall,
+                "created_wall": expires_wall - 10,
+                "expires_wall": expires_wall,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _age(path: Path, seconds_old: float) -> None:
+    ts = time.time() - seconds_old
+    os.utime(path, (ts, ts))
+
+
+def test_expired_qlease_is_removed(tmp_path):
+    now = time.time()
+    stale = _qlease(tmp_path / "quality-cache-dead.qlease", expires_wall=now - 7200)
+    removed = hook_runtime._sweep_stale_leases(tmp_path, now=now)
+    assert not stale.exists(), "expired .qlease survived the sweep"
+    assert removed >= 1
+
+
+def test_live_qlease_is_not_removed(tmp_path):
+    now = time.time()
+    live = _qlease(tmp_path / "quality-cache-live.qlease", expires_wall=now + 60)
+    removed = hook_runtime._sweep_stale_leases(tmp_path, now=now)
+    assert live.exists(), "live .qlease was reaped (false positive on a live locker)"
+    assert removed == 0
+
+
+def test_day_old_candidate_and_qlock_removed(tmp_path):
+    now = time.time()
+    old_candidate = tmp_path / ".quality-cache-x.candidate-abc"
+    old_candidate.write_bytes(b"orphan")
+    _age(old_candidate, 86400 + 3600)
+
+    old_reclaim = tmp_path / ".quality-cache-x.reclaim-dead"
+    old_reclaim.write_bytes(b"orphan")
+    _age(old_reclaim, 86400 + 3600)
+
+    old_qlock = tmp_path / "quality-cache-y.qlock"
+    old_qlock.write_bytes(b"legacy")
+    _age(old_qlock, 86400 + 3600)
+
+    hook_runtime._sweep_stale_leases(tmp_path, now=now)
+    assert not old_candidate.exists(), "day-old candidate survived"
+    assert not old_reclaim.exists(), "day-old reclaim survived"
+    assert not old_qlock.exists(), "day-old legacy .qlock survived"
+
+
+def test_recent_candidate_is_not_removed(tmp_path):
+    now = time.time()
+    young = tmp_path / ".quality-cache-live.candidate-fresh"
+    young.write_bytes(b"live-acquirer")
+    # just-created mtime
+    hook_runtime._sweep_stale_leases(tmp_path, now=now)
+    assert young.exists(), "recent live candidate was reaped (false positive)"
+
+
+def test_corrupt_qlease_never_raises_and_only_removed_past_24h(tmp_path):
+    now = time.time()
+    corrupt_fresh = tmp_path / "quality-cache-fresh-corrupt.qlease"
+    corrupt_fresh.write_bytes(b"{not even json")
+    corrupt_old = tmp_path / "quality-cache-old-corrupt.qlease"
+    corrupt_old.write_bytes(b"\x00\x01partial")
+    _age(corrupt_old, 86400 + 3600)
+
+    # Must not raise on either file.
+    removed = hook_runtime._sweep_stale_leases(tmp_path, now=now)
+    # Fresh corrupt file is left alone (could be mid-publication).
+    assert corrupt_fresh.exists(), "fresh corrupt .qlease was removed too eagerly"
+    # Old corrupt file is reaped past the 24h mtime gate.
+    assert not corrupt_old.exists(), "old corrupt .qlease survived"
+    assert removed >= 1
+
+
+def test_sweep_caps_at_max_files(tmp_path):
+    now = time.time()
+    # Create 10 stale qlock files; cap the scan at 3 entries.
+    for i in range(10):
+        p = tmp_path / f"quality-cache-{i}.qlock"
+        p.write_bytes(b"legacy")
+        _age(p, 86400 + 3600)
+    removed = hook_runtime._sweep_stale_leases(tmp_path, now=now, max_files=3)
+    # At most 3 files inspected -> at most 3 removed; the rest survive this run.
+    assert removed <= 3
+    survivors = list(tmp_path.glob("*.qlock"))
+    assert len(survivors) >= 7, "max_files cap was not honored"
+
+
+def test_sweep_missing_dir_is_noop(tmp_path):
+    assert hook_runtime._sweep_stale_leases(tmp_path / "does-not-exist") == 0
+
+
+def test_sweep_skips_subdirectories(tmp_path):
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    (sub / "quality-cache-dead.qlease").write_text("x")
+    # A directory named like a lease must never be unlinked.
+    hook_runtime._sweep_stale_leases(tmp_path, now=time.time() + 9999)
+    assert sub.exists()
+
+
+# --- measure-side throttle wrapper -----------------------------------------
+
+
+def _load_measure(monkeypatch, tmp_path):
+    """Import measure with an isolated QUALITY_CACHE_DIR + sweep marker."""
+    import importlib
+
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", str(tmp_path / "snap"))
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    cache_dir = tmp_path / "to-cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(mod, "QUALITY_CACHE_DIR", cache_dir)
+    monkeypatch.setattr(
+        mod, "_QLEASE_SWEEP_MARKER", cache_dir / ".qlease-sweep-throttle"
+    )
+    return mod
+
+
+def test_maybe_sweep_throttles_to_once_per_day(monkeypatch, tmp_path):
+    mod = _load_measure(monkeypatch, tmp_path)
+    now = time.time()
+    stale = mod.QUALITY_CACHE_DIR / "quality-cache-dead.qlease"
+    stale.write_text(
+        json.dumps(
+            {
+                "pid": 1,
+                "nonce": "n",
+                "released": 0,
+                "reuse_wall": now - 7200,
+                "created_wall": now - 7210,
+                "expires_wall": now - 7200,
+            }
+        )
+    )
+    # First run sweeps.
+    first = mod.maybe_sweep_stale_leases()
+    assert first >= 1
+    assert not stale.exists()
+    # Re-create a stale file; the second call within 24h must be throttled out.
+    stale.write_text(
+        json.dumps(
+            {
+                "pid": 1,
+                "nonce": "n",
+                "released": 0,
+                "reuse_wall": now - 7200,
+                "created_wall": now - 7210,
+                "expires_wall": now - 7200,
+            }
+        )
+    )
+    second = mod.maybe_sweep_stale_leases()
+    assert second == 0, "sweeper ran twice inside the 24h throttle window"
+    assert stale.exists(), "throttled run must not touch the dir"
+
+
+def test_maybe_sweep_never_raises_on_sweeper_error(monkeypatch, tmp_path):
+    mod = _load_measure(monkeypatch, tmp_path)
+
+    def boom(_dir):
+        raise RuntimeError("sweeper explosion")
+
+    monkeypatch.setattr(mod, "_sweep_stale_leases", boom)
+    # Must swallow and return 0, never raise into a hook.
+    assert mod.maybe_sweep_stale_leases() == 0


### PR DESCRIPTION
## Summary

Three additive, fail-open fixes for the quality-cache lease lock and the `ensure-health` SessionStart path. No change to the `LeaseLock` reclaim/hardlink/tombstone protocol (`_try_create`, `_reclaim_path`, `_reclaim_if_expired`, `released:1` semantics untouched). Every new code path is wrapped in try/except and never raises into a hook or blocks a session.

### FIX B (primary): bounded stale-lease sweeper
`LeaseLock.release()` intentionally leaves the canonical `.qlease` tombstone for the next contender to reclaim. Sessions are one-shot, so most tombstones get no future contender and leak forever (one+ per session per user, unbounded); a `_HookTimeout` between acquire and release could also leak the candidate.

- New `hook_runtime._sweep_stale_leases(directory, now=None, max_files=2000)` removes ONLY long-expired artifacts, so no live locker can be touched:
  - `*.qlease`: parse JSON, remove if `expires_wall < now - 3600`; corrupt/unparseable only if mtime < now - 86400.
  - `.*.candidate-*` / `.*.reclaim-*`: remove if mtime < now - 86400.
  - legacy `*.qlock` (pre-5.11; current code never writes them): remove if mtime < now - 86400.
  - Scan capped at `max_files`; whole function try/except, never raises.
- `measure.maybe_sweep_stale_leases` invokes it opportunistically, throttled to once/24h via a one-stat marker (touched after a successful run so a crash retries next session). Wired into `ensure-health` AFTER the daemon revive. Never on the hot per-tool-call path.

### FIX C: daemon revive must not be starved by the 8s budget
The `ensure-health` dispatch now calls `_ensure_health_daemon_revive_first()` under its own short 6s guard BEFORE arming the 8s budget + `run_ensure_health`. A slow health scan that later trips the watchdog can no longer skip reinstalling a missing launchd plist / dead daemon on port 24842. The second call inside `run_ensure_health` is a throttled no-op (idempotent + internally throttled).

### FIX A: release in finally
`quality_cache`'s locked region (from just after a successful acquire to the end) is wrapped in `try/finally` with `_release_quality_lock(_qlock)` in `finally`. `_release_quality_lock` / `LeaseLock.release()` are idempotent + guarded, so a `_HookTimeout` (BaseException) between acquire and release can no longer leak the candidate. The three inline releases are consolidated into the finally.

## Tests
- `test_stale_lease_sweeper.py`: expired `.qlease` removed; live `.qlease` (future `expires_wall`) kept; day-old candidate/reclaim/`.qlock` removed; recent candidate kept; corrupt `.qlease` never raises (fresh kept, old reaped); `max_files` cap honored; missing dir no-op; subdirs skipped; `maybe_sweep_stale_leases` throttles to once/24h and never raises on sweeper error.
- `test_quality_cache_release_on_timeout.py`: candidate is unlinked and `.qlease` marked `released:1` when `_HookTimeout` is injected mid-compute; normal return also leaks no candidate.
- `test_ensure_health_daemon_revive_first.py`: revive-first installs/restarts and never raises (incl. injected `_HookTimeout`); daemon revive runs before a timing-out health scan; dispatch source-ordering guard.

## Verification
- `python3 -m py_compile` on both edited files (skills/ and plugins/ mirror) — OK.
- Full suite: `python3 -m pytest -q` → **980 passed, 12 skipped** (incl. the 18 new tests and the dual-tree sync tests after resyncing the plugins/ mirror via `scripts/sync-codex-marketplace-plugin.sh`).

## Notes
- No merge to main, no tag, no release, no version bump. Draft PR only.
- `plugins/token-optimizer/` mirror resynced to stay byte-identical with `skills/` (enforced by `test_duplicate_script_sync.py`).

#### Test plan
- [x] New sweeper tests pass
- [x] New release-on-timeout tests pass
- [x] New daemon-revive-first tests pass
- [x] Existing lock/lease/daemon/health suites pass
- [x] Full pytest suite green (980 passed, 12 skipped)
- [x] `py_compile` clean on both edited files (both trees)

Generated with [Devin](https://devin.ai)
