### PR TITLE
fix(windows): bash-safe hooks (#118) + fast process enum (#117) + mirror-sync CI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "token-optimizer",
       "source": "./",
       "description": "Audit, fix, and monitor Claude Code context window usage. Find the ghost tokens.",
-      "version": "5.11.80",
+      "version": "5.11.81",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.80",
+  "version": "5.11.81",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.80",
+  "version": "5.11.81",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Run tests
         run: python -m pytest tests/ -q
 
+  # plugins/token-optimizer/ is a generated mirror of root skills/ + hooks/
+  # (scripts/sync-codex-marketplace-plugin.sh). Until now drift was only
+  # caught at release-signing time, so a canonical-only edit could land on
+  # main and ship a stale mirror to Codex users until the next release.
+  # Regenerate and diff on every push/PR instead. ~5s, pure file copy + git.
+  mirror-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Verify Codex marketplace mirror is in sync
+        run: bash scripts/check-mirror-sync.sh
+
   # Windows leg: runs the same suite plus a real-spawn smoke test that
   # exercises spawn_utils.spawn_detached against an actual child process.
   # Catches console-flash regressions and CREATE_BREAKAWAY_FROM_JOB failures

--- a/plugins/token-optimizer/.codex-plugin/plugin.json
+++ b/plugins/token-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.80",
+  "version": "5.11.81",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/codex_install.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/codex_install.py
@@ -54,6 +54,14 @@ def _hook_command(script: str, *args: str, redirect_quiet: bool = False) -> str:
         # current interpreter directly so the hot path does not traverse MSYS
         # bash and python-launcher.sh (several CreateProcess calls per hook).
         # list2cmdline applies native Windows quoting for paths with spaces.
+        #
+        # Verified 2026-08-05 against Codex CLI source: codex-rs/hooks/src/
+        # engine/command_runner.rs default_shell_command() spawns hooks as
+        # `%COMSPEC% /C <command>` (fallback cmd.exe) on Windows unless the
+        # user overrides the hook shell in config. So the cmd.exe syntax below
+        # (setlocal, for /f, 2^>NUL, >NUL 2>&1) is CORRECT here — do NOT
+        # "bash-ify" it. #118 was the inverse bug: Claude Code runs hooks via
+        # Git Bash, so measure.py's Claude-facing commands are POSIX-shaped.
         if _SEMVER_DIR_RE.match(root.name):
             # CMD needs a Windows-native counterpart to the POSIX runtime
             # resolver below. Keep the baked path as a fail-open fallback when

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -17987,7 +17987,10 @@ def _windows_process_creation(pid):
             "| ForEach-Object { $_.ToString('o') }"
         )
         result = subprocess.run(
-            ["powershell", "-NoProfile", "-Command", ps_cmd],
+            # -ExecutionPolicy Bypass for parity with the other PowerShell
+            # spawns: an AllSigned host would otherwise block this per-PID
+            # fallback and leave the session flagged UNKNOWN_AGE.
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
             capture_output=True, text=True, timeout=10, errors="replace", creationflags=_NO_WINDOW,
         )
         if result.returncode == 0 and result.stdout.strip():
@@ -18001,19 +18004,30 @@ def _windows_process_creation(pid):
 
 
 def _collect_windows_claude_sessions():
-    """Collect running Claude CLI sessions on Windows via tasklist + wmic.
+    """Collect running Claude CLI sessions on Windows via PowerShell Get-Process.
 
     Safety invariants (per adversarial review 2026-04-13):
-    - Only matches on the Image Name column (claude.exe / claude-*.exe).
+    - Only matches on the process image name (claude / claude-*).
       Matching on Window Title would catch Chrome tabs viewing claude.ai,
       editors with 'claude' in the filename, etc. kill_stale_sessions
       would then TerminateProcess those apps -> unsaved-work data loss.
       POSIX parity: ps-based match requires command == 'claude'; Windows
-      requires the same strictness.
-    - Uses Session # column (numeric) to detect service-hosted processes.
-      Services run in session 0; literal 'Services' string localizes.
-    - subprocess calls use errors='replace' so non-ASCII tasklist output
+      requires the same strictness. The PowerShell-side wildcard pre-filter
+      is a performance optimization only; the strict matcher below is the
+      security layer.
+    - Uses SessionId (numeric) to detect service-hosted processes.
+      Services run in session 0; unlike the literal 'Services' string,
+      SessionId never localizes.
+    - subprocess calls use errors='replace' so non-ASCII PowerShell output
       on localized Windows can't raise UnicodeDecodeError.
+
+    #117: the previous `tasklist /v` enumeration was pathologically slow for
+    standard (non-elevated) users on Win11 -- /v queries verbose info (incl.
+    window titles) for EVERY process, hitting access-denied retries on
+    protected and other-user processes. Get-Process -Name 'claude*' filters
+    server-side, so only candidate processes are materialized, and StartTime
+    is dereferenced inside a try/catch so protected processes can't fail the
+    query.
 
     Returns a list of session dicts. On subprocess failure returns an
     empty list (not None) so the Health tab still renders.
@@ -18022,9 +18036,21 @@ def _collect_windows_claude_sessions():
     import io as _io
 
     sessions = []
+    ps_cmd = (
+        # -Name 'claude*' filters server-side (only candidate processes are
+        # ever materialized), so the "touches only candidates" claim is real,
+        # not a post-enumeration Where-Object. -ErrorAction SilentlyContinue
+        # keeps a zero-match run from erroring.
+        "Get-Process -Name 'claude*' -ErrorAction SilentlyContinue | "
+        "Select-Object Id, ProcessName, SessionId, "
+        "@{N='StartTime';E={try { $_.StartTime.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') } catch { '' }}} | "
+        "ConvertTo-Csv -NoTypeInformation"
+    )
     try:
         result = subprocess.run(
-            ["tasklist", "/v", "/fo", "csv", "/nh"],
+            # -ExecutionPolicy Bypass so a locked-down host (AllSigned policy)
+            # can still run this inline -Command (tasklist needed no policy).
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
             capture_output=True, text=True, timeout=10, errors="replace", creationflags=_NO_WINDOW,
         )
     except (subprocess.SubprocessError, OSError, FileNotFoundError):
@@ -18033,18 +18059,15 @@ def _collect_windows_claude_sessions():
         return sessions
 
     try:
-        reader = list(_csv.reader(_io.StringIO(result.stdout)))
+        reader = list(_csv.DictReader(_io.StringIO(result.stdout)))
     except (_csv.Error, ValueError):
         return sessions
 
     for row in reader:
-        if len(row) < 9:
-            continue
-        image_name = row[0].strip()
-        pid_str = row[1]
-        session_name = row[2].strip()
-        session_num = row[3].strip() if len(row) > 3 else ""
-        window_title = row[8].strip()
+        image_name = (row.get("ProcessName") or "").strip()
+        pid_str = row.get("Id") or ""
+        session_id_str = (row.get("SessionId") or "").strip()
+        start_time = (row.get("StartTime") or "").strip()
         image_lower = image_name.lower()
         # Strict image-name match only. See docstring invariants.
         if not (image_lower == "claude.exe"
@@ -18058,24 +18081,28 @@ def _collect_windows_claude_sessions():
             continue
         if pid <= 0:
             continue
-        creation = _windows_process_creation(pid)
+        creation = _parse_iso_process_datetime(start_time) if start_time else None
+        if creation is None:
+            # StartTime unreadable (protected process) or unparseable: fall
+            # back to the per-PID wmic/CIM lookup.
+            creation = _windows_process_creation(pid)
         elapsed_seconds = int(creation.get("elapsed_seconds") or 0)
-        # Session # 0 is the Services session (language-independent); any
-        # other numeric value indicates a user session. Falls back to a
-        # non-empty session_name heuristic if the column is absent.
-        if session_num.isdigit():
-            has_terminal = session_num != "0"
-        else:
-            has_terminal = bool(session_name)
-        command = (image_name + " " + window_title).strip()
+        # SessionId 0 is the Services session (language-independent); any
+        # other value indicates a user session. A missing/unparseable
+        # SessionId assumes a user session (services always report 0).
+        try:
+            session_id = int(session_id_str)
+        except ValueError:
+            session_id = -1
+        has_terminal = session_id != 0
         sessions.append({
             "pid": pid,
             "started": creation.get("started", "unknown"),
             "elapsed_seconds": elapsed_seconds,
             "elapsed_human": _format_elapsed(elapsed_seconds) if elapsed_seconds else "unknown",
-            "command": command,
+            "command": image_name if image_lower.endswith(".exe") else image_name + ".exe",
             "has_terminal": has_terminal,
-            "tty": session_name if has_terminal and session_name else None,
+            "tty": f"session-{session_id}" if has_terminal and session_id > 0 else None,
         })
     return sessions
 
@@ -18340,17 +18367,22 @@ def health_selfcheck():
 
     # Live process-listing command
     if system == "Windows":
-        # tasklist probe
+        # Get-Process probe (same pipeline shape as
+        # _collect_windows_claude_sessions; #117 retired tasklist /v, which is
+        # pathologically slow for standard users on Win11)
         try:
             res = subprocess.run(
-                ["tasklist", "/v", "/fo", "csv", "/nh"],
-                capture_output=True, text=True, timeout=10, creationflags=_NO_WINDOW,
+                ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+                 "Get-Process -ErrorAction SilentlyContinue | "
+                 "Select-Object -First 1 Id, ProcessName, SessionId | "
+                 "ConvertTo-Csv -NoTypeInformation"],
+                capture_output=True, text=True, timeout=10, errors="replace", creationflags=_NO_WINDOW,
             )
-            ok = res.returncode == 0 and len(res.stdout.strip()) > 0
-            check("tasklist /v /fo csv", ok,
+            ok = res.returncode == 0 and "ProcessName" in res.stdout
+            check("Get-Process csv probe", ok,
                   f"exit={res.returncode}, bytes={len(res.stdout)}")
         except (subprocess.SubprocessError, OSError, FileNotFoundError) as e:
-            check("tasklist /v /fo csv", False, f"exception: {e!r}")
+            check("Get-Process csv probe", False, f"exception: {e!r}")
 
         # _collect_windows_claude_sessions end-to-end
         try:
@@ -18523,13 +18555,18 @@ def kill_stale_sessions(threshold_hours=12, dry_run=False):
 SETTINGS_PATH = CLAUDE_DIR / "settings.json"
 MEASURE_PY_PATH = Path(__file__).resolve()
 if sys.platform == "win32":
-    _collect_cmd = subprocess.list2cmdline(
-        [sys.executable, str(MEASURE_PY_PATH), "collect", "--quiet"]
+    # #118: Claude Code runs hooks through Git Bash even on native Windows, so
+    # this must be POSIX-shell syntax: >/dev/null (a cmd null redirect would
+    # become a literal file named NUL in the CWD) and forward-slash,
+    # single-quoted paths (not cmd.exe list2cmdline quoting). sys.executable
+    # with forward slashes runs fine from Git Bash; bare `python3` often does
+    # not exist there.
+    _py = shlex.quote(str(sys.executable).replace("\\", "/"))
+    _mp = shlex.quote(str(MEASURE_PY_PATH).replace("\\", "/"))
+    HOOK_COMMAND = (
+        f"{_py} {_mp} collect --quiet && {_py} {_mp} dashboard --quiet"
+        f" >/dev/null 2>&1"
     )
-    _dashboard_cmd = subprocess.list2cmdline(
-        [sys.executable, str(MEASURE_PY_PATH), "dashboard", "--quiet"]
-    )
-    HOOK_COMMAND = f"{_collect_cmd} && {_dashboard_cmd} >NUL 2>&1"
 else:
     HOOK_COMMAND = f"python3 '{MEASURE_PY_PATH}' collect --quiet && python3 '{MEASURE_PY_PATH}' dashboard --quiet"
 # Recognizes Token Optimizer's SessionEnd hook command: a script named
@@ -18644,6 +18681,15 @@ def _is_hook_current(settings=None):
         for hook in hook_list:
             cmd = hook.get("command", "") if isinstance(hook, dict) else ""
             if "measure.py" in cmd and "collect" in cmd and "dashboard" in cmd:
+                # #118: the pre-fix win32 SessionEnd command matched all three
+                # substrings but used a cmd.exe NUL-device redirect that breaks
+                # under Git Bash (literal NUL file + silent failure). Treat that
+                # legacy form as NOT current so setup_hook's upgrade branch
+                # rewrites it to the bash-safe >/dev/null form. Existing broken
+                # installs are the whole reported #118 population, so this is the
+                # only path that heals them.
+                if sys.platform == "win32" and re.search(r">\s*NUL\b", cmd):
+                    return False
                 return True
     return False
 
@@ -20191,43 +20237,38 @@ def _resolve_hook_command(template_cmd, plugin_root):
 
     Script installs don't use Claude Code's plugin loader, so we need to
     substitute ${CLAUDE_PLUGIN_ROOT} ourselves with the install directory.
+
+    #118: Claude Code runs hooks through Git Bash on Windows too, so the bash
+    launcher template is already the correct form there. The only
+    Windows-specific hardening is substituting a forward-slash root, so
+    backslash sequences in user names (\\t, \\n, ...) can't be mangled inside
+    bash double quotes. The pre-fix native cmd.exe conversion (list2cmdline +
+    cmd null redirect) created a literal NUL file and silently broke hooks.
     """
     if not template_cmd:
         return template_cmd
+    root = str(plugin_root)
     if platform.system() == "Windows":
-        return _windows_hook_command(template_cmd, plugin_root)
-    resolved = template_cmd.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root))
-    resolved = resolved.replace("$CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        root = root.replace("\\", "/")
+    # No shell-metachar escaping needed here: the sole caller (setup_all_hooks)
+    # rejects roots containing ' " ` $ ; & | < > (SEC-001) before this runs, so
+    # the substituted root is always inert in the bash double-quote context.
+    resolved = template_cmd.replace("${CLAUDE_PLUGIN_ROOT}", root)
+    resolved = resolved.replace("$CLAUDE_PLUGIN_ROOT", root)
     return resolved
 
 
-def _windows_hook_command(template_cmd, plugin_root):
-    """Convert a hooks.json bash launcher command to a native Windows command."""
-    match = re.search(
-        r'["\']?\$\{?CLAUDE_PLUGIN_ROOT\}?/hooks/run\.py["\']?\s+'
-        r'(.*?);\s*done;\s*exit\s+0\s*$',
-        template_cmd,
-    )
-    if not match:
-        # Non-Python hooks (for example an intentional echo command) retain
-        # their original semantics; only the known launcher shape is rewritten.
-        return template_cmd.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root)).replace(
-            "$CLAUDE_PLUGIN_ROOT", str(plugin_root)
-        )
-
-    args = shlex.split(match.group(1), posix=True)
-    while args and args[-1] in (">/dev/null", "2>&1"):
-        args.pop()
-    argv = [sys.executable, str(Path(plugin_root) / "hooks" / "run.py"), *args]
-    return subprocess.list2cmdline(argv) + " >NUL 2>&1"
-
-
 def _windows_hook_command_is_stale(existing_cmd, resolved_cmd):
-    """True when SessionStart should replace a legacy Windows bash launcher."""
+    """True when SessionStart should replace a legacy Windows hook command.
+
+    Legacy means the pre-#118 native cmd.exe form (list2cmdline argv + a cmd
+    null redirect), which fails under Git Bash. The current form is the bash
+    launcher, identical in shape to POSIX.
+    """
     return (
         platform.system() == "Windows"
         and existing_cmd != resolved_cmd
-        and "python-launcher.sh" in existing_cmd
+        and re.search(r">\s*NUL\b", existing_cmd) is not None
     )
 
 
@@ -20603,12 +20644,20 @@ def setup_all_hooks(dry_run=False, verbose=False):
                     existing_cmd = existing_hook.get("command", "")
                     has_path = ".py" in existing_cmd or ".py" in resolved_cmd
                     # On Windows, an existing command can point at the current
-                    # root yet still be the legacy Git-Bash launcher. Replace
-                    # it with the native direct-Python form during ensure-health.
+                    # root yet still be the legacy native cmd.exe form (#118).
+                    # Replace it with the Git-Bash launcher during ensure-health.
                     windows_command_stale = _windows_hook_command_is_stale(
                         existing_cmd, resolved_cmd
                     )
-                    if (not has_path or plugin_root_str in existing_cmd) and not windows_command_stale:
+                    # #118 follow-up: _resolve_hook_command now embeds a
+                    # forward-slash root on Windows, but plugin_root_str keeps
+                    # native backslashes, so a raw substring test never matches
+                    # post-fix and every hook would be "replaced" on every run
+                    # (perpetual settings.json rewrite). Normalize separators.
+                    root_in_cmd = (
+                        plugin_root_str.replace("\\", "/") in existing_cmd.replace("\\", "/")
+                    )
+                    if (not has_path or root_in_cmd) and not windows_command_stale:
                         skipped += 1
                         if verbose:
                             print(f"  [skip] {event}[{matcher}] {ident} (already present)")

--- a/scripts/check-mirror-sync.sh
+++ b/scripts/check-mirror-sync.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# check-mirror-sync.sh
+#
+# Verifies that plugins/token-optimizer/ (the Codex marketplace mirror) is in
+# sync with the canonical repo-root content (skills/, hooks/,
+# .codex-plugin/plugin.json). Single owner of the drift check, called by:
+#   - CI: .github/workflows/tests.yml (mirror-sync job) on every push/PR
+#   - Release: scripts/sign-release.sh preflight
+#
+# Works by REGENERATING the mirror with sync-codex-marketplace-plugin.sh and
+# diffing the result against the committed tree. Because the generator owns
+# the intentional divergences (hooks.json async-strip for Codex #83,
+# benchmark.py exclusion), a clean diff means "no drift" with no
+# hand-maintained exception list.
+#
+# Side effect: like the release preflight, a drifted tree is left REGENERATED
+# in the working directory, so the fix is `git add plugins/token-optimizer`.
+set -euo pipefail
+
+if [ -z "${BASH_VERSION:-}" ]; then
+  echo "ERROR: run with bash (e.g. \`bash scripts/check-mirror-sync.sh\`), not sh." >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+bash "${REPO_ROOT}/scripts/sync-codex-marketplace-plugin.sh" >/dev/null
+
+# `git status --porcelain` (not `diff --quiet`) so untracked files the regen
+# produces also count as drift, not just modifications to tracked files.
+if [ -n "$(git -C "${REPO_ROOT}" status --porcelain -- plugins/token-optimizer)" ]; then
+  echo "ERROR: plugins/token-optimizer/ is out of sync with root skills/ or hooks/." >&2
+  echo "Run scripts/sync-codex-marketplace-plugin.sh, commit the result, then retry." >&2
+  git -C "${REPO_ROOT}" status --porcelain -- plugins/token-optimizer >&2
+  git -C "${REPO_ROOT}" diff --stat -- plugins/token-optimizer >&2 || true
+  exit 1
+fi
+
+echo "mirror-sync OK: plugins/token-optimizer matches canonical skills/ + hooks/"

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -39,11 +39,8 @@ CHECKSUM_FILE="${REPO_ROOT}/CHECKSUMS.sha256"
 # mirror drifted from canonical root — a stale mirror ships outdated skills to Codex
 # users. See scripts/sync-codex-marketplace-plugin.sh and issue #51.
 echo "Verifying Codex marketplace plugin parity..."
-bash "${REPO_ROOT}/scripts/sync-codex-marketplace-plugin.sh" >/dev/null
-if ! git -C "$REPO_ROOT" diff --quiet -- plugins/token-optimizer; then
-    echo "Error: plugins/token-optimizer/ is out of sync with root skills/ or hooks/."
-    echo "Run scripts/sync-codex-marketplace-plugin.sh, commit the result, re-tag, then retry."
-    git -C "$REPO_ROOT" diff --stat -- plugins/token-optimizer
+if ! bash "${REPO_ROOT}/scripts/check-mirror-sync.sh"; then
+    echo "Error: mirror drift detected. Commit the regenerated mirror, re-tag, then retry."
     exit 1
 fi
 echo "Codex marketplace plugin parity OK."

--- a/skills/token-optimizer/scripts/codex_install.py
+++ b/skills/token-optimizer/scripts/codex_install.py
@@ -54,6 +54,14 @@ def _hook_command(script: str, *args: str, redirect_quiet: bool = False) -> str:
         # current interpreter directly so the hot path does not traverse MSYS
         # bash and python-launcher.sh (several CreateProcess calls per hook).
         # list2cmdline applies native Windows quoting for paths with spaces.
+        #
+        # Verified 2026-08-05 against Codex CLI source: codex-rs/hooks/src/
+        # engine/command_runner.rs default_shell_command() spawns hooks as
+        # `%COMSPEC% /C <command>` (fallback cmd.exe) on Windows unless the
+        # user overrides the hook shell in config. So the cmd.exe syntax below
+        # (setlocal, for /f, 2^>NUL, >NUL 2>&1) is CORRECT here — do NOT
+        # "bash-ify" it. #118 was the inverse bug: Claude Code runs hooks via
+        # Git Bash, so measure.py's Claude-facing commands are POSIX-shaped.
         if _SEMVER_DIR_RE.match(root.name):
             # CMD needs a Windows-native counterpart to the POSIX runtime
             # resolver below. Keep the baked path as a fail-open fallback when

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -17987,7 +17987,10 @@ def _windows_process_creation(pid):
             "| ForEach-Object { $_.ToString('o') }"
         )
         result = subprocess.run(
-            ["powershell", "-NoProfile", "-Command", ps_cmd],
+            # -ExecutionPolicy Bypass for parity with the other PowerShell
+            # spawns: an AllSigned host would otherwise block this per-PID
+            # fallback and leave the session flagged UNKNOWN_AGE.
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
             capture_output=True, text=True, timeout=10, errors="replace", creationflags=_NO_WINDOW,
         )
         if result.returncode == 0 and result.stdout.strip():
@@ -18001,19 +18004,30 @@ def _windows_process_creation(pid):
 
 
 def _collect_windows_claude_sessions():
-    """Collect running Claude CLI sessions on Windows via tasklist + wmic.
+    """Collect running Claude CLI sessions on Windows via PowerShell Get-Process.
 
     Safety invariants (per adversarial review 2026-04-13):
-    - Only matches on the Image Name column (claude.exe / claude-*.exe).
+    - Only matches on the process image name (claude / claude-*).
       Matching on Window Title would catch Chrome tabs viewing claude.ai,
       editors with 'claude' in the filename, etc. kill_stale_sessions
       would then TerminateProcess those apps -> unsaved-work data loss.
       POSIX parity: ps-based match requires command == 'claude'; Windows
-      requires the same strictness.
-    - Uses Session # column (numeric) to detect service-hosted processes.
-      Services run in session 0; literal 'Services' string localizes.
-    - subprocess calls use errors='replace' so non-ASCII tasklist output
+      requires the same strictness. The PowerShell-side wildcard pre-filter
+      is a performance optimization only; the strict matcher below is the
+      security layer.
+    - Uses SessionId (numeric) to detect service-hosted processes.
+      Services run in session 0; unlike the literal 'Services' string,
+      SessionId never localizes.
+    - subprocess calls use errors='replace' so non-ASCII PowerShell output
       on localized Windows can't raise UnicodeDecodeError.
+
+    #117: the previous `tasklist /v` enumeration was pathologically slow for
+    standard (non-elevated) users on Win11 -- /v queries verbose info (incl.
+    window titles) for EVERY process, hitting access-denied retries on
+    protected and other-user processes. Get-Process -Name 'claude*' filters
+    server-side, so only candidate processes are materialized, and StartTime
+    is dereferenced inside a try/catch so protected processes can't fail the
+    query.
 
     Returns a list of session dicts. On subprocess failure returns an
     empty list (not None) so the Health tab still renders.
@@ -18022,9 +18036,21 @@ def _collect_windows_claude_sessions():
     import io as _io
 
     sessions = []
+    ps_cmd = (
+        # -Name 'claude*' filters server-side (only candidate processes are
+        # ever materialized), so the "touches only candidates" claim is real,
+        # not a post-enumeration Where-Object. -ErrorAction SilentlyContinue
+        # keeps a zero-match run from erroring.
+        "Get-Process -Name 'claude*' -ErrorAction SilentlyContinue | "
+        "Select-Object Id, ProcessName, SessionId, "
+        "@{N='StartTime';E={try { $_.StartTime.ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') } catch { '' }}} | "
+        "ConvertTo-Csv -NoTypeInformation"
+    )
     try:
         result = subprocess.run(
-            ["tasklist", "/v", "/fo", "csv", "/nh"],
+            # -ExecutionPolicy Bypass so a locked-down host (AllSigned policy)
+            # can still run this inline -Command (tasklist needed no policy).
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps_cmd],
             capture_output=True, text=True, timeout=10, errors="replace", creationflags=_NO_WINDOW,
         )
     except (subprocess.SubprocessError, OSError, FileNotFoundError):
@@ -18033,18 +18059,15 @@ def _collect_windows_claude_sessions():
         return sessions
 
     try:
-        reader = list(_csv.reader(_io.StringIO(result.stdout)))
+        reader = list(_csv.DictReader(_io.StringIO(result.stdout)))
     except (_csv.Error, ValueError):
         return sessions
 
     for row in reader:
-        if len(row) < 9:
-            continue
-        image_name = row[0].strip()
-        pid_str = row[1]
-        session_name = row[2].strip()
-        session_num = row[3].strip() if len(row) > 3 else ""
-        window_title = row[8].strip()
+        image_name = (row.get("ProcessName") or "").strip()
+        pid_str = row.get("Id") or ""
+        session_id_str = (row.get("SessionId") or "").strip()
+        start_time = (row.get("StartTime") or "").strip()
         image_lower = image_name.lower()
         # Strict image-name match only. See docstring invariants.
         if not (image_lower == "claude.exe"
@@ -18058,24 +18081,28 @@ def _collect_windows_claude_sessions():
             continue
         if pid <= 0:
             continue
-        creation = _windows_process_creation(pid)
+        creation = _parse_iso_process_datetime(start_time) if start_time else None
+        if creation is None:
+            # StartTime unreadable (protected process) or unparseable: fall
+            # back to the per-PID wmic/CIM lookup.
+            creation = _windows_process_creation(pid)
         elapsed_seconds = int(creation.get("elapsed_seconds") or 0)
-        # Session # 0 is the Services session (language-independent); any
-        # other numeric value indicates a user session. Falls back to a
-        # non-empty session_name heuristic if the column is absent.
-        if session_num.isdigit():
-            has_terminal = session_num != "0"
-        else:
-            has_terminal = bool(session_name)
-        command = (image_name + " " + window_title).strip()
+        # SessionId 0 is the Services session (language-independent); any
+        # other value indicates a user session. A missing/unparseable
+        # SessionId assumes a user session (services always report 0).
+        try:
+            session_id = int(session_id_str)
+        except ValueError:
+            session_id = -1
+        has_terminal = session_id != 0
         sessions.append({
             "pid": pid,
             "started": creation.get("started", "unknown"),
             "elapsed_seconds": elapsed_seconds,
             "elapsed_human": _format_elapsed(elapsed_seconds) if elapsed_seconds else "unknown",
-            "command": command,
+            "command": image_name if image_lower.endswith(".exe") else image_name + ".exe",
             "has_terminal": has_terminal,
-            "tty": session_name if has_terminal and session_name else None,
+            "tty": f"session-{session_id}" if has_terminal and session_id > 0 else None,
         })
     return sessions
 
@@ -18340,17 +18367,22 @@ def health_selfcheck():
 
     # Live process-listing command
     if system == "Windows":
-        # tasklist probe
+        # Get-Process probe (same pipeline shape as
+        # _collect_windows_claude_sessions; #117 retired tasklist /v, which is
+        # pathologically slow for standard users on Win11)
         try:
             res = subprocess.run(
-                ["tasklist", "/v", "/fo", "csv", "/nh"],
-                capture_output=True, text=True, timeout=10, creationflags=_NO_WINDOW,
+                ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+                 "Get-Process -ErrorAction SilentlyContinue | "
+                 "Select-Object -First 1 Id, ProcessName, SessionId | "
+                 "ConvertTo-Csv -NoTypeInformation"],
+                capture_output=True, text=True, timeout=10, errors="replace", creationflags=_NO_WINDOW,
             )
-            ok = res.returncode == 0 and len(res.stdout.strip()) > 0
-            check("tasklist /v /fo csv", ok,
+            ok = res.returncode == 0 and "ProcessName" in res.stdout
+            check("Get-Process csv probe", ok,
                   f"exit={res.returncode}, bytes={len(res.stdout)}")
         except (subprocess.SubprocessError, OSError, FileNotFoundError) as e:
-            check("tasklist /v /fo csv", False, f"exception: {e!r}")
+            check("Get-Process csv probe", False, f"exception: {e!r}")
 
         # _collect_windows_claude_sessions end-to-end
         try:
@@ -18523,13 +18555,18 @@ def kill_stale_sessions(threshold_hours=12, dry_run=False):
 SETTINGS_PATH = CLAUDE_DIR / "settings.json"
 MEASURE_PY_PATH = Path(__file__).resolve()
 if sys.platform == "win32":
-    _collect_cmd = subprocess.list2cmdline(
-        [sys.executable, str(MEASURE_PY_PATH), "collect", "--quiet"]
+    # #118: Claude Code runs hooks through Git Bash even on native Windows, so
+    # this must be POSIX-shell syntax: >/dev/null (a cmd null redirect would
+    # become a literal file named NUL in the CWD) and forward-slash,
+    # single-quoted paths (not cmd.exe list2cmdline quoting). sys.executable
+    # with forward slashes runs fine from Git Bash; bare `python3` often does
+    # not exist there.
+    _py = shlex.quote(str(sys.executable).replace("\\", "/"))
+    _mp = shlex.quote(str(MEASURE_PY_PATH).replace("\\", "/"))
+    HOOK_COMMAND = (
+        f"{_py} {_mp} collect --quiet && {_py} {_mp} dashboard --quiet"
+        f" >/dev/null 2>&1"
     )
-    _dashboard_cmd = subprocess.list2cmdline(
-        [sys.executable, str(MEASURE_PY_PATH), "dashboard", "--quiet"]
-    )
-    HOOK_COMMAND = f"{_collect_cmd} && {_dashboard_cmd} >NUL 2>&1"
 else:
     HOOK_COMMAND = f"python3 '{MEASURE_PY_PATH}' collect --quiet && python3 '{MEASURE_PY_PATH}' dashboard --quiet"
 # Recognizes Token Optimizer's SessionEnd hook command: a script named
@@ -18644,6 +18681,15 @@ def _is_hook_current(settings=None):
         for hook in hook_list:
             cmd = hook.get("command", "") if isinstance(hook, dict) else ""
             if "measure.py" in cmd and "collect" in cmd and "dashboard" in cmd:
+                # #118: the pre-fix win32 SessionEnd command matched all three
+                # substrings but used a cmd.exe NUL-device redirect that breaks
+                # under Git Bash (literal NUL file + silent failure). Treat that
+                # legacy form as NOT current so setup_hook's upgrade branch
+                # rewrites it to the bash-safe >/dev/null form. Existing broken
+                # installs are the whole reported #118 population, so this is the
+                # only path that heals them.
+                if sys.platform == "win32" and re.search(r">\s*NUL\b", cmd):
+                    return False
                 return True
     return False
 
@@ -20191,43 +20237,38 @@ def _resolve_hook_command(template_cmd, plugin_root):
 
     Script installs don't use Claude Code's plugin loader, so we need to
     substitute ${CLAUDE_PLUGIN_ROOT} ourselves with the install directory.
+
+    #118: Claude Code runs hooks through Git Bash on Windows too, so the bash
+    launcher template is already the correct form there. The only
+    Windows-specific hardening is substituting a forward-slash root, so
+    backslash sequences in user names (\\t, \\n, ...) can't be mangled inside
+    bash double quotes. The pre-fix native cmd.exe conversion (list2cmdline +
+    cmd null redirect) created a literal NUL file and silently broke hooks.
     """
     if not template_cmd:
         return template_cmd
+    root = str(plugin_root)
     if platform.system() == "Windows":
-        return _windows_hook_command(template_cmd, plugin_root)
-    resolved = template_cmd.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root))
-    resolved = resolved.replace("$CLAUDE_PLUGIN_ROOT", str(plugin_root))
+        root = root.replace("\\", "/")
+    # No shell-metachar escaping needed here: the sole caller (setup_all_hooks)
+    # rejects roots containing ' " ` $ ; & | < > (SEC-001) before this runs, so
+    # the substituted root is always inert in the bash double-quote context.
+    resolved = template_cmd.replace("${CLAUDE_PLUGIN_ROOT}", root)
+    resolved = resolved.replace("$CLAUDE_PLUGIN_ROOT", root)
     return resolved
 
 
-def _windows_hook_command(template_cmd, plugin_root):
-    """Convert a hooks.json bash launcher command to a native Windows command."""
-    match = re.search(
-        r'["\']?\$\{?CLAUDE_PLUGIN_ROOT\}?/hooks/run\.py["\']?\s+'
-        r'(.*?);\s*done;\s*exit\s+0\s*$',
-        template_cmd,
-    )
-    if not match:
-        # Non-Python hooks (for example an intentional echo command) retain
-        # their original semantics; only the known launcher shape is rewritten.
-        return template_cmd.replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root)).replace(
-            "$CLAUDE_PLUGIN_ROOT", str(plugin_root)
-        )
-
-    args = shlex.split(match.group(1), posix=True)
-    while args and args[-1] in (">/dev/null", "2>&1"):
-        args.pop()
-    argv = [sys.executable, str(Path(plugin_root) / "hooks" / "run.py"), *args]
-    return subprocess.list2cmdline(argv) + " >NUL 2>&1"
-
-
 def _windows_hook_command_is_stale(existing_cmd, resolved_cmd):
-    """True when SessionStart should replace a legacy Windows bash launcher."""
+    """True when SessionStart should replace a legacy Windows hook command.
+
+    Legacy means the pre-#118 native cmd.exe form (list2cmdline argv + a cmd
+    null redirect), which fails under Git Bash. The current form is the bash
+    launcher, identical in shape to POSIX.
+    """
     return (
         platform.system() == "Windows"
         and existing_cmd != resolved_cmd
-        and "python-launcher.sh" in existing_cmd
+        and re.search(r">\s*NUL\b", existing_cmd) is not None
     )
 
 
@@ -20603,12 +20644,20 @@ def setup_all_hooks(dry_run=False, verbose=False):
                     existing_cmd = existing_hook.get("command", "")
                     has_path = ".py" in existing_cmd or ".py" in resolved_cmd
                     # On Windows, an existing command can point at the current
-                    # root yet still be the legacy Git-Bash launcher. Replace
-                    # it with the native direct-Python form during ensure-health.
+                    # root yet still be the legacy native cmd.exe form (#118).
+                    # Replace it with the Git-Bash launcher during ensure-health.
                     windows_command_stale = _windows_hook_command_is_stale(
                         existing_cmd, resolved_cmd
                     )
-                    if (not has_path or plugin_root_str in existing_cmd) and not windows_command_stale:
+                    # #118 follow-up: _resolve_hook_command now embeds a
+                    # forward-slash root on Windows, but plugin_root_str keeps
+                    # native backslashes, so a raw substring test never matches
+                    # post-fix and every hook would be "replaced" on every run
+                    # (perpetual settings.json rewrite). Normalize separators.
+                    root_in_cmd = (
+                        plugin_root_str.replace("\\", "/") in existing_cmd.replace("\\", "/")
+                    )
+                    if (not has_path or root_in_cmd) and not windows_command_stale:
                         skipped += 1
                         if verbose:
                             print(f"  [skip] {event}[{matcher}] {ident} (already present)")

--- a/tests/test_windows_hook_launcher.py
+++ b/tests/test_windows_hook_launcher.py
@@ -1,25 +1,48 @@
-"""Regression coverage for native Windows hook command generation."""
+"""Regression coverage for Windows hook command generation (#118).
+
+Claude Code runs ``command`` hooks through Git Bash on native Windows, so
+generated hook commands must be POSIX-shell safe: ``>/dev/null 2>&1`` (never
+``>NUL``, which Git Bash materializes as a literal file named ``NUL`` in the
+CWD) and forward-slash or single-quoted paths (never cmd.exe
+``list2cmdline`` quoting). Codex is different: it spawns hooks via
+``%COMSPEC% /C`` (cmd.exe), so codex_install.py's cmd syntax is correct and
+pinned by the tests below.
+"""
 
 import importlib.util
 import ast
+import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path, PureWindowsPath
+from types import SimpleNamespace
+
+import pytest
 
 
 REPO = Path(__file__).resolve().parent.parent
 MODULE_PATH = REPO / "skills" / "token-optimizer" / "scripts" / "codex_install.py"
 MEASURE_PATH = REPO / "skills" / "token-optimizer" / "scripts" / "measure.py"
 
+_CMD_NUL_RE = re.compile(r">\s*NUL\b")
+
+HOOKS_JSON_TEMPLATE = (
+    'for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; '
+    'do command -v "$b" >/dev/null 2>&1 && '
+    'exec "$b" "${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh" '
+    '"${CLAUDE_PLUGIN_ROOT}/hooks/run.py" '
+    'skills/token-optimizer/scripts/measure.py ensure-health --quiet; done; exit 0'
+)
+
 
 def _load_measure_hook_resolver(platform):
     tree = ast.parse(MEASURE_PATH.read_text(encoding="utf-8"))
     wanted = {
-        "_windows_hook_command",
-        "_windows_hook_command_is_stale",
         "_resolve_hook_command",
+        "_windows_hook_command_is_stale",
     }
     nodes = [node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in wanted]
     namespace = {
@@ -32,6 +55,37 @@ def _load_measure_hook_resolver(platform):
     }
     exec(compile(ast.Module(body=nodes, type_ignores=[]), str(MEASURE_PATH), "exec"), namespace)
     return namespace
+
+
+def _load_measure_hook_command():
+    """Exec the module-level ``if sys.platform == "win32"`` block that assigns
+    HOOK_COMMAND, simulating a Windows interpreter."""
+    tree = ast.parse(MEASURE_PATH.read_text(encoding="utf-8"))
+    node = None
+    for candidate in tree.body:
+        if not isinstance(candidate, ast.If):
+            continue
+        for stmt in ast.walk(candidate):
+            if isinstance(stmt, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "HOOK_COMMAND" for t in stmt.targets
+            ):
+                node = candidate
+                break
+        if node is not None:
+            break
+    assert node is not None, "module-level HOOK_COMMAND assignment not found"
+    namespace = {
+        "sys": SimpleNamespace(
+            platform="win32",
+            executable="C:\\Python313\\python.exe",
+        ),
+        "shlex": shlex,
+        "subprocess": subprocess,
+        "Path": Path,
+        "MEASURE_PY_PATH": "C:\\Users\\Test User\\.claude\\token-optimizer\\scripts\\measure.py",
+    }
+    exec(compile(ast.Module(body=[node], type_ignores=[]), str(MEASURE_PATH), "exec"), namespace)
+    return namespace["HOOK_COMMAND"]
 
 
 def _load_codex_install(monkeypatch, platform):
@@ -113,29 +167,30 @@ def test_posix_hook_command_keeps_bash_resolver(monkeypatch):
     assert command.endswith(module._BASH_RESOLVER_SUFFIX)
 
 
-def test_claude_windows_hook_command_invokes_python_directly():
+# ---------- #118: Claude Code hooks run under Git Bash on Windows ----------
+
+
+def test_claude_windows_hook_command_stays_bash_safe():
+    """#118: the Windows resolution must keep the Git-Bash launcher form.
+
+    The pre-fix code rewrote it to native cmd.exe syntax (list2cmdline +
+    a cmd null redirect), which under Git Bash created a literal NUL file
+    and silently broke every hook.
+    """
     module = _load_measure_hook_resolver("Windows")
-    template = (
-        'for b in bash /bin/bash; do command -v "$b" >/dev/null 2>&1 && '
-        'exec "$b" "${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh" '
-        '"${CLAUDE_PLUGIN_ROOT}/hooks/run.py" '
-        'skills/token-optimizer/scripts/measure.py ensure-health --quiet; done; exit 0'
-    )
     root = Path(r"C:\Users\Test User\.claude\token-optimizer")
 
-    command = module["_resolve_hook_command"](template, root)
+    command = module["_resolve_hook_command"](HOOKS_JSON_TEMPLATE, root)
 
-    expected_argv = [
-        sys.executable,
-        str(root / "hooks" / "run.py"),
-        "skills/token-optimizer/scripts/measure.py",
-        "ensure-health",
-        "--quiet",
-    ]
-    assert command.startswith(subprocess.list2cmdline(expected_argv))
-    assert command.endswith(" >NUL 2>&1")
-    assert "python-launcher.sh" not in command
-    assert "for b in bash" not in command
+    assert _CMD_NUL_RE.search(command) is None
+    assert ">/dev/null 2>&1" in command
+    assert "python-launcher.sh" in command
+    assert "for b in bash" in command
+    # Root substituted with forward slashes only (backslashes inside bash
+    # double quotes invite mangling of \t, \n, ... in user names).
+    assert "C:/Users/Test User/.claude/token-optimizer" in command
+    assert "\\" not in command
+    assert command.endswith("; done; exit 0")
 
 
 def test_claude_posix_hook_command_is_byte_for_byte_unchanged():
@@ -152,12 +207,132 @@ def test_claude_posix_hook_command_is_byte_for_byte_unchanged():
     )
 
 
-def test_claude_windows_session_start_marks_legacy_launcher_for_self_heal():
-    module = _load_measure_hook_resolver("Windows")
-    old = 'for b in bash; do exec "$b" "C:/plugin/hooks/python-launcher.sh"; done; exit 0'
-    native = 'C:\\Python\\python.exe C:\\plugin\\hooks\\run.py script.py >NUL 2>&1'
+def _hook_runtime_bash():
+    """The bash Claude Code actually runs hooks under on Windows is Git Bash,
+    NOT WSL's C:\\Windows\\System32\\bash.exe. They differ where it matters
+    here: WSL bash, invoked with a Windows cwd, routes /dev/null through its
+    Windows-path translation layer and can leave a literal NUL artifact, while
+    Git Bash's MSYS runtime handles /dev/null correctly. shutil.which("bash")
+    often resolves the WSL launcher first on GitHub runners, so the killer
+    regression must resolve Git Bash explicitly (and skip when only WSL bash
+    exists — WSL is not the hook runtime being regression-tested)."""
+    for c in (
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files (x86)\Git\bin\bash.exe",
+        "/bin/bash",
+        "/usr/bin/bash",
+    ):
+        if Path(c).exists():
+            return c
+    b = shutil.which("bash")
+    if b and "System32" in b:  # WSL launcher — not the hook shell
+        return None
+    return b
 
-    assert module["_windows_hook_command_is_stale"](old, native) is True
+
+def test_claude_windows_hook_command_executes_under_bash_without_nul_file(tmp_path):
+    """Killer regression for #118: run the resolved command under the bash
+    Claude Code actually uses for hooks (Git Bash on Windows) in a scratch dir.
+    Pre-fix this left a literal file named NUL behind."""
+    bash = _hook_runtime_bash()
+    if not bash:
+        pytest.skip("Git Bash (the Windows hook runtime) unavailable; WSL bash is not the hook shell")
+    root = tmp_path / "plugin root"
+    (root / "hooks").mkdir(parents=True)
+    (root / "hooks" / "python-launcher.sh").write_text("#!/bin/bash\nexit 0\n")
+    (root / "hooks" / "run.py").write_text("import sys; sys.exit(0)\n")
+
+    module = _load_measure_hook_resolver("Windows")
+    command = module["_resolve_hook_command"](HOOKS_JSON_TEMPLATE, root)
+
+    proc = subprocess.run(
+        [bash, "-c", command],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, f"hook command failed under {bash}: {proc.stderr}"
+    # Detect a literal file named NUL via the directory LISTING, not
+    # Path.exists(): on Windows `NUL` is a reserved device name, so
+    # `(tmp_path / "NUL").exists()` is ALWAYS True (it resolves to the null
+    # device, not a file) and cannot tell whether the #118 bug fired. A real
+    # literal NUL file (created by the pre-fix `>NUL` via MSYS's NT-path bypass)
+    # appears as a directory entry; the device never does.
+    entries = os.listdir(tmp_path)
+    assert "NUL" not in entries, (
+        f"literal NUL file created under {bash} (dir listing: {entries})"
+    )
+
+
+def test_claude_windows_hook_command_string_is_bash_parseable():
+    """bash -n must parse the resolved command (syntax-level Git Bash safety)."""
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash not on PATH")
+    module = _load_measure_hook_resolver("Windows")
+    root = Path(r"C:\Users\Test User\.claude\token-optimizer")
+
+    command = module["_resolve_hook_command"](HOOKS_JSON_TEMPLATE, root)
+
+    proc = subprocess.run([bash, "-n"], input=command, capture_output=True, text=True)
+    assert proc.returncode == 0, f"bash failed to parse hook command: {proc.stderr}"
+
+
+def test_claude_windows_hook_command_constant_is_bash_safe():
+    """The SessionEnd HOOK_COMMAND written to settings.json (win32 branch)."""
+    command = _load_measure_hook_command()
+
+    assert _CMD_NUL_RE.search(command) is None
+    assert command.endswith(">/dev/null 2>&1")
+    assert "\\" not in command, "backslash path leaks into a bash command"
+    # Space in the path must be single-quoted (POSIX), not list2cmdline-quoted.
+    assert "'C:/Users/Test User/.claude/token-optimizer/scripts/measure.py'" in command
+    assert "collect --quiet" in command and "dashboard --quiet" in command
+
+
+def test_claude_windows_hook_command_constant_parses_under_bash():
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash not on PATH")
+    command = _load_measure_hook_command()
+
+    proc = subprocess.run([bash, "-n"], input=command, capture_output=True, text=True)
+    assert proc.returncode == 0, f"bash failed to parse HOOK_COMMAND: {proc.stderr}"
+
+
+def test_measure_py_has_no_cmd_null_redirect_anywhere():
+    """Source-grep guard: the cmd.exe null redirect must never reappear in
+    measure.py. (codex_install.py is exempt: Codex spawns hooks via
+    %COMSPEC% /C, so cmd syntax is correct there.)"""
+    src = MEASURE_PATH.read_text(encoding="utf-8")
+
+    assert _CMD_NUL_RE.search(src) is None, (
+        "cmd.exe null redirect found in measure.py; Claude Code runs hooks "
+        "under Git Bash where it creates a literal NUL file (#118)"
+    )
+
+
+def test_claude_windows_session_start_marks_legacy_cmd_form_for_self_heal():
+    """Installs holding the pre-fix native cmd.exe form must be flagged stale
+    so ensure-health replaces them with the bash launcher form."""
+    module = _load_measure_hook_resolver("Windows")
+    legacy_cmd_form = (
+        "C:\\Python\\python.exe C:\\plugin\\hooks\\run.py"
+        " script.py >" + "NUL 2>&1"  # split so the source-grep guard stays meaningful
+    )
+    resolved = module["_resolve_hook_command"](HOOKS_JSON_TEMPLATE, Path("C:/plugin"))
+
+    assert module["_windows_hook_command_is_stale"](legacy_cmd_form, resolved) is True
+
+
+def test_claude_windows_current_bash_launcher_is_not_stale():
+    module = _load_measure_hook_resolver("Windows")
+    root = Path(r"C:\Users\Test User\.claude\token-optimizer")
+    current = module["_resolve_hook_command"](HOOKS_JSON_TEMPLATE, root)
+
+    assert module["_windows_hook_command_is_stale"](current, current) is False
 
 
 def test_claude_posix_does_not_refresh_current_root_launcher():
@@ -165,3 +340,71 @@ def test_claude_posix_does_not_refresh_current_root_launcher():
     old = 'for b in bash; do exec "$b" "/opt/plugin/hooks/python-launcher.sh"; done; exit 0'
 
     assert module["_windows_hook_command_is_stale"](old, "different") is False
+
+
+def _load_full_measure():
+    """Full importlib load (for functions the AST resolver doesn't extract)."""
+    scripts = str(MEASURE_PATH.parent)
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    spec = importlib.util.spec_from_file_location("measure_hookcurrent_uut", MEASURE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_windows_legacy_nul_sessionend_hook_reads_as_not_current(monkeypatch):
+    """#118 F1: the pre-fix >NUL SessionEnd command matched all three
+    substrings and read as 'current', so existing broken Windows installs were
+    never healed ('already up to date. Nothing to do.'). It must now read as
+    NOT current on win32 so setup_hook's upgrade branch rewrites it."""
+    measure = _load_full_measure()
+    monkeypatch.setattr(measure.sys, "platform", "win32")
+    legacy = (
+        "python.exe C:/p/measure.py collect --quiet && "
+        "python.exe C:/p/measure.py dashboard --quiet >NUL 2>&1"
+    )
+    legacy_settings = {"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": legacy}]}]}}
+    assert measure._is_hook_current(legacy_settings) is False
+    # The bash-safe replacement IS current (no rewrite loop).
+    good = legacy.replace(">NUL 2>&1", ">/dev/null 2>&1")
+    good_settings = {"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": good}]}]}}
+    assert measure._is_hook_current(good_settings) is True
+
+
+def test_posix_nul_sessionend_hook_is_win32_gated(monkeypatch):
+    """The >NUL staleness heuristic is win32-only; POSIX never emits >NUL."""
+    measure = _load_full_measure()
+    monkeypatch.setattr(measure.sys, "platform", "linux")
+    cmd = "python3 /p/measure.py collect --quiet && python3 /p/measure.py dashboard --quiet >NUL 2>&1"
+    settings = {"hooks": {"SessionEnd": [{"hooks": [{"type": "command", "command": cmd}]}]}}
+    assert measure._is_hook_current(settings) is True
+
+
+def test_windows_resolved_command_matches_native_root_after_normalization():
+    """#118 F2 (documents WHY): _resolve_hook_command embeds a forward-slash
+    root on Windows, so a raw substring test of the native-backslash root
+    against the resolved command fails; normalized containment succeeds."""
+    module = _load_measure_hook_resolver("Windows")
+    native_root = r"C:\Users\Test User\.claude\plugins\token-optimizer"
+    resolved = module["_resolve_hook_command"](HOOKS_JSON_TEMPLATE, PureWindowsPath(native_root))
+    assert native_root not in resolved
+    assert native_root.replace("\\", "/") in resolved.replace("\\", "/")
+
+
+def test_setup_all_hooks_containment_is_separator_normalized():
+    """#118 F2 (reversion guard, non-vacuous): setup_all_hooks' 'already
+    present' test must normalize separators on BOTH operands. A revert to the
+    raw `plugin_root_str in existing_cmd` reintroduces the perpetual
+    settings.json rewrite on Windows (forward-slash resolved root never
+    contains the native-backslash plugin_root_str) — this test fails on that
+    revert."""
+    src = MEASURE_PATH.read_text(encoding="utf-8")
+    # The buggy raw predicate must NOT be the active containment test.
+    assert "plugin_root_str in existing_cmd" not in src, (
+        "raw (un-normalized) containment reintroduces the F2 rewrite loop"
+    )
+    # Both operands must be separator-normalized before the containment test.
+    # (Source contains two literal backslashes: replace("\\", "/").)
+    assert r'plugin_root_str.replace("\\", "/")' in src
+    assert r'existing_cmd.replace("\\", "/")' in src

--- a/tests/test_windows_process_enum.py
+++ b/tests/test_windows_process_enum.py
@@ -1,0 +1,165 @@
+"""Regression and smoke coverage for #117: Windows process enumeration.
+
+``tasklist /v /fo csv /nh`` is pathologically slow for standard (non-elevated)
+users on Windows 11: the /v flag queries verbose info (incl. window titles)
+for every process, hitting access-denied retries on protected/other-user
+processes. The collector now uses a PowerShell ``Get-Process`` pipeline that
+pre-filters by image name and never touches window titles. These tests pin:
+
+- the spawned command is Get-Process-based and never tasklist
+- errors="replace" and the _NO_WINDOW console-less spawn guard are preserved
+- the strict image-name matcher still rejects claude-adjacent processes
+- SessionId 0 (services session) still means "no terminal"
+- an empty StartTime (access denied) falls back to the per-PID lookup
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parent.parent
+MEASURE_PATH = REPO / "skills" / "token-optimizer" / "scripts" / "measure.py"
+
+
+def _load_measure():
+    scripts = str(MEASURE_PATH.parent)
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)  # measure.py imports sibling modules (hook_io, ...)
+    spec = importlib.util.spec_from_file_location("measure_under_test", MEASURE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GET_PROCESS_CSV = (
+    '"Id","ProcessName","SessionId","StartTime"\r\n'
+    '"1234","claude","1","2020-01-01T00:00:00Z"\r\n'
+    '"5678","claudeHelper","1","2020-01-01T00:00:00Z"\r\n'
+    '"90","claude","0",""\r\n'
+)
+
+
+def _fake_run_factory(record, stdout, returncode=0):
+    def fake_run(argv, **kwargs):
+        record.append((argv, kwargs))
+        return subprocess.CompletedProcess(argv, returncode, stdout=stdout, stderr="")
+
+    return fake_run
+
+
+def test_windows_sessions_use_get_process_not_tasklist(monkeypatch):
+    measure = _load_measure()
+    record = []
+    monkeypatch.setattr(measure.subprocess, "run", _fake_run_factory(record, GET_PROCESS_CSV))
+    monkeypatch.setattr(measure, "_windows_process_creation", lambda pid: {})
+
+    sessions = measure._collect_windows_claude_sessions()
+
+    assert record, "no subprocess spawned"
+    argv, kwargs = record[0]
+    joined = " ".join(str(a) for a in argv)
+    assert "tasklist" not in joined
+    assert "Get-Process" in joined
+    # Non-ASCII safety and the console-less spawn guard (#107) preserved.
+    assert kwargs.get("errors") == "replace"
+    assert kwargs.get("creationflags") == measure._NO_WINDOW
+    assert kwargs.get("timeout") == 10
+
+    # Strict image-name matcher: claudeHelper must be rejected even though the
+    # PowerShell-side wildcard let it through.
+    assert [s["pid"] for s in sessions] == [1234, 90]
+
+    by_pid = {s["pid"]: s for s in sessions}
+    # SessionId 0 is the services session: no terminal.
+    assert by_pid[1234]["has_terminal"] is True
+    assert by_pid[90]["has_terminal"] is False
+    # StartTime from the CSV is used (no per-PID lookup needed).
+    assert by_pid[1234]["started"] != "unknown"
+    assert by_pid[1234]["elapsed_seconds"] > 0
+    # Empty StartTime (access denied) fell back to the mocked per-PID lookup.
+    assert by_pid[90]["started"] == "unknown"
+
+
+def test_windows_sessions_empty_starttime_invokes_per_pid_fallback(monkeypatch):
+    measure = _load_measure()
+    record = []
+    csv_one_row = (
+        '"Id","ProcessName","SessionId","StartTime"\r\n'
+        '"4321","claude","1",""\r\n'
+    )
+    monkeypatch.setattr(measure.subprocess, "run", _fake_run_factory(record, csv_one_row))
+    fallback_calls = []
+    monkeypatch.setattr(
+        measure,
+        "_windows_process_creation",
+        lambda pid: fallback_calls.append(pid) or {"started": "Wed Aug  5 10:00:00 2026", "elapsed_seconds": 60},
+    )
+
+    sessions = measure._collect_windows_claude_sessions()
+
+    assert fallback_calls == [4321]
+    assert sessions[0]["elapsed_seconds"] == 60
+    assert sessions[0]["elapsed_human"] == "1m"
+
+
+def test_windows_sessions_spawn_failure_returns_empty_list(monkeypatch):
+    measure = _load_measure()
+
+    def raising_run(argv, **kwargs):
+        raise FileNotFoundError("powershell not found")
+
+    monkeypatch.setattr(measure.subprocess, "run", raising_run)
+
+    assert measure._collect_windows_claude_sessions() == []
+
+
+def test_windows_sessions_nonzero_exit_returns_empty_list(monkeypatch):
+    measure = _load_measure()
+    record = []
+    monkeypatch.setattr(
+        measure.subprocess, "run", _fake_run_factory(record, "", returncode=1)
+    )
+
+    assert measure._collect_windows_claude_sessions() == []
+
+
+def test_windows_sessions_spawn_hardening_flags(monkeypatch):
+    """LOW-2 + MED-3: the collector must pass -ExecutionPolicy Bypass (so an
+    AllSigned host doesn't block the inline -Command) and use the server-side
+    -Name 'claude*' filter. Both can regress silently without an argv assert."""
+    measure = _load_measure()
+    record = []
+    monkeypatch.setattr(measure.subprocess, "run", _fake_run_factory(record, GET_PROCESS_CSV))
+    monkeypatch.setattr(measure, "_windows_process_creation", lambda pid: {})
+
+    measure._collect_windows_claude_sessions()
+
+    assert record, "no subprocess spawned"
+    argv = [str(a) for a in record[0][0]]
+    assert "-ExecutionPolicy" in argv and "Bypass" in argv
+    joined = " ".join(argv)
+    assert "-Name" in joined and "claude*" in joined
+
+
+def test_self_check_probes_get_process_not_tasklist():
+    """The Windows self-check probe (measure.py self-check) must exercise the
+    new enumeration command, not the retired tasklist probe."""
+    src = MEASURE_PATH.read_text(encoding="utf-8")
+    assert '"tasklist", "/v"' not in src, "tasklist /v spawn still present in measure.py"
+    assert "Get-Process" in src
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="real Get-Process smoke only on Windows")
+def test_collect_windows_sessions_real_spawn():
+    """Smoke: on real Windows the collector runs end-to-end within its timeout
+    and returns a list (empty or not). Catches missing-PowerShell and
+    output-shape regressions that mocks cannot see."""
+    measure = _load_measure()
+
+    sessions = measure._collect_windows_claude_sessions()
+
+    assert isinstance(sessions, list)


### PR DESCRIPTION
## Summary
Fixes two Windows bugs and hardens the mirror against drift.

**#118 — Windows hooks broke silently under Git Bash.** Hook commands were built with cmd.exe syntax (`list2cmdline` + a `NUL`-device redirect), but Claude Code runs hooks through Git Bash, which materialized a literal `NUL` file in every project and silently broke every hook. Now emits bash-safe commands (`shlex.quote`, forward-slash paths, `/dev/null`). Critically, this also **heals existing broken installs**: `_is_hook_current` now treats the legacy `NUL`-redirect SessionEnd command as stale on win32 so the upgrade path rewrites it, and `setup_all_hooks` normalizes path separators so it no longer rewrites `settings.json` on every run. `codex_install.py` is intentionally left cmd.exe — Codex spawns hooks via `%COMSPEC% /C` (verified against the codex-rs source).

**#117 — `tasklist /v` was pathologically slow** for standard users on Win11. Replaced with a `Get-Process -Name 'claude*'` pipeline (server-side filter, `try/catch` StartTime, `-ExecutionPolicy Bypass`), preserving the strict image-name matcher and console-less spawn guard.

**Ponytail learning — mirror-sync verifier.** Added `scripts/check-mirror-sync.sh` + a CI job so the `plugins/` Codex mirror can't drift from canonical on any push (previously caught only at release time). `sign-release.sh` delegates to it.

## Tests
5 new regression tests: legacy hook heals, idempotent re-run, no literal `NUL` under real bash, `-ExecutionPolicy`/`-Name` argv, mirror-sync drift guard. Full suite **1063 passed, 13 skipped, 0 failed**. Mirror parity verified (both `measure.py`/`codex_install.py` copies byte-identical).

## Verification
Reviewed across independent lanes (plan, adversarial torture, cold-review) before landing; every finding verified against the code. Note: the win32-only real-spawn smoke tests are skipped off-Windows — the **Windows CI leg is the real gate** for the runtime behavior.

## Follow-up (not in this PR)
`openclaw/dist/` build-drift verifier (G8) — deferred to its own PR where the build can be validated in a clean env.

Closes #117
Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
