### PR TITLE
fix: score session fill% against the model that produced the tokens

### DIFF
--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -2046,6 +2046,33 @@ def _is_1m_model(model_str):
     return True
 
 
+def _context_window_for_model_str(model_str):
+    """Resolve a context-window size for a SPECIFIC model string (e.g. one
+    parsed straight out of a transcript message), honoring the same
+    explicit-override precedence as detect_context_window() -- but keyed to
+    the model that actually produced the tokens being measured, not an
+    env/config global that may name a different model entirely (e.g. a
+    1M-context variant like "claude-opus-5[1m]" running while
+    CLAUDE_MODEL/settings.json still say plain "opus").
+    """
+    if os.environ.get("CLAUDE_CODE_DISABLE_1M_CONTEXT") == "1":
+        return 200_000
+    raw = os.environ.get("TOKEN_OPTIMIZER_CONTEXT_SIZE", "").strip()
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    if _cli_context_size:
+        return _cli_context_size
+    m = (model_str or "").lower().strip()
+    if not m:
+        return None
+    if "haiku" in m:
+        return 200_000
+    return 1_000_000 if _is_1m_model(m) else 200_000
+
+
 _codex_config_cache: tuple[float, dict] | None = None
 
 
@@ -20747,6 +20774,12 @@ def _parse_jsonl_for_quality(filepath):
         "total_entries": idx,
         "context_tokens": context_tokens,
         "model": current_model,
+        # Context-window size for THIS session's actual model, not the
+        # env/config global that detect_context_window() falls back to.
+        # See _context_window_for_model_str() -- fixes fill%/quality scoring
+        # for sessions whose live model differs from CLAUDE_MODEL/settings.json
+        # (e.g. a 1M-context variant while the global default says plain).
+        "model_context_window": _context_window_for_model_str(current_model),
     }
 
 


### PR DESCRIPTION
Hi Alex, thanks for building this — sending over a small fix I found while poking at the quality-scoring code.

## What I found

`compute_quality_score()` derives the context-fill-percentage denominator from `detect_context_window()`, which resolves "the model" from `CLAUDE_MODEL`/`ANTHROPIC_MODEL` env vars or `~/.claude/settings.json` — process-wide globals. `quality_data["model"]`, the model actually parsed out of the transcript one function earlier in `_parse_jsonl_for_quality()`, is set correctly but was never plumbed into the window-size lookup at all (I checked — no code path reads it for that purpose). Any time the live per-message model differs from whatever the env/config global says, fill% gets scored against the wrong window.

## Reproduction (self-contained, no external setup needed)

```python
# repro_session.jsonl
{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}
{"type":"assistant","message":{"role":"assistant","model":"claude-3-haiku-20260101","usage":{"input_tokens":150000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0},"content":[{"type":"text","text":"hi"}]}}
```

```
$ env -u CLAUDE_MODEL -u ANTHROPIC_MODEL -u TOKEN_OPTIMIZER_CONTEXT_SIZE -u CLAUDE_CODE_DISABLE_1M_CONTEXT python -c "
import measure
qd = measure._parse_jsonl_for_quality('repro_session.jsonl')
result = measure.compute_quality_score(qd, session_id='reprotest')
cfd = result['breakdown']['context_fill_degradation']
print(qd['model'], cfd['model_context_window'], cfd['fill_pct'])
"
```

On my machine, with `~/.claude/settings.json` set to `"model": "opus"` (unrelated to this transcript), that printed `claude-3-haiku-20260101 1000000 15.0` — a session that's objectively 150,000/200,000 = 75% full on Haiku's window came out scored as 15% full ("PEAK ZONE", green) instead of 75% ("CRITICAL", red). Substituting a different global settings.json model reproduces the same mismatch in the other direction.

## Fix

Added `_context_window_for_model_str()`, which applies the same override precedence `detect_context_window()` already uses (`CLAUDE_CODE_DISABLE_1M_CONTEXT`, `TOKEN_OPTIMIZER_CONTEXT_SIZE`, `--context-size`) but keyed to a specific model string, and used it in `_parse_jsonl_for_quality()` to store `model_context_window` on `quality_data` from the transcript-parsed model. `compute_quality_score()` and its downstream consumers already read `quality_data.get("model_context_window")` first — they just never had it populated, so this is additive rather than a rewrite of the scoring path.

One file, 33 lines, `py_compile`-clean. Happy to adjust the approach if you'd rather resolve this differently (e.g. threading the model through explicitly instead of via the dict) — this was the smallest change I could find that didn't touch the call sites.
