### PR TITLE
fix: label cross-session checkpoint offers as belonging to another session

### DIFF
--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -24464,7 +24464,19 @@ def compact_restore(session_id=None, cwd=None, is_compact=False, new_session_onl
             return
         desc = _checkpoint_descriptor(latest["path"])
         about = f" (prior work on {desc})" if desc else ""
-        print(f"[Token Optimizer] A recent checkpoint is available{about} at {latest['path']}. Load it only if it matches what you are working on now.")
+        # Make the cross-session nature explicit: project+branch alone is not
+        # distinguishing in a shared checkout with many concurrent sessions in
+        # the same cwd/branch, so an unlabeled pointer reads as "your own prior
+        # work" even when it never is (own-session checkpoints are excluded from
+        # `chosen` above by construction). Name the source session so a reader
+        # cannot mistake it for continuity of the current session.
+        src_sid_match = re.match(r'^([0-9a-fA-F-]{8,36})-\d{8}-\d{6}-', latest["filename"])
+        src_sid_short = src_sid_match.group(1)[:8] if src_sid_match else None
+        if src_sid_short and (not sid_safe or not sid_safe.startswith(src_sid_short)):
+            print(f"[Token Optimizer] A checkpoint from a DIFFERENT session ({src_sid_short}){about} is available at {latest['path']}. "
+                  f"This is NOT your own session's prior work -- load it only if you intend to resume that other session's work.")
+        else:
+            print(f"[Token Optimizer] A recent checkpoint is available{about} at {latest['path']}. Load it only if it matches what you are working on now.")
         return
 
     if is_compact and sid_safe:


### PR DESCRIPTION
Hi Alex — a small usability fix from a workspace where several Claude Code sessions run concurrently in the same repo.

## What I observed

On 2026-08-07, resuming a session in a shared checkout (several sibling sessions active, same cwd, same branch) triggered the SessionStart pointer message: `"A recent checkpoint is available (prior work on <project> · branch <branch>) at ...checkpoints\<other-session-id>-...md"`. The referenced checkpoint belonged to a different, concurrently-running sibling session, not the one that had just resumed. This happened more than once across the same working session, each time pointing at a different sibling.

## Why

`compact_restore(new_session_only=True)` selects a checkpoint from `CHECKPOINT_DIR`, a single flat directory shared by every session on the machine. In the cwd-matched branch it explicitly skips the current session's own checkpoints (`if sid_safe and sid_safe in cp["filename"]: continue`), and when `cwd == Path.home()` it falls back to the single globally most-recent checkpoint on disk with no project/owner scoping at all. So the offered checkpoint is always someone else's, by design — but the printed label only carries project + branch, which is identical for every concurrent session working in the same project/branch. In that shared-checkout case the pointer reads as "your own prior work" when it structurally never is.

## Fix

Doesn't change what checkpoint gets selected (that cross-session-discovery behavior looks intentional and I didn't want to second-guess it) — just makes the message honest about what it's pointing at: extracts the source checkpoint's owning session id from its filename, and when it doesn't match the current session, says so explicitly ("A checkpoint from a DIFFERENT session (\<id\>) ... This is NOT your own session's prior work — load it only if you intend to resume that other session's work.").

One file, 14 lines. If you'd rather solve this a different way (e.g. scoping selection by session id first and only falling back to cross-session with the label), I'm glad to rework it — this was the smallest change that fixes the misleading part without touching the selection logic.
