### PR TITLE
fix: a disabled plugin should stop spending tokens (enabledPlugins self-check)

### DIFF
--- a/hooks/run.py
+++ b/hooks/run.py
@@ -85,8 +85,53 @@ def _check_consent() -> bool:
         return True  # Fail-open: never block on errors
 
 
+def _plugin_disabled_by_host() -> bool:
+    """Return True if the host explicitly turned this plugin off via
+    ~/.claude/settings.json's enabledPlugins map, so main() can no-op before
+    spawning the dispatch subprocess at all.
+
+    Claude Code's plugin loader does not appear to reliably stop invoking an
+    already-registered plugin's hooks.json commands for existing sessions
+    after enabledPlugins[<name>@<marketplace>] is flipped to false (observed:
+    8/8 sessions started after such an edit still ran hooks and printed
+    "[Token Optimizer]" output). This is a defensive self-check so the plugin
+    honors its own disable flag even when the host does not enforce it,
+    instead of silently continuing to spend tokens on every hook event.
+
+    Fail-open (return False) on any error -- a missing/unreadable settings
+    file, or a plugin/marketplace name we can't resolve, must never silently
+    disable the plugin for users who never touched this setting.
+    """
+    try:
+        plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+        if not plugin_root:
+            return False
+        meta_dir = Path(plugin_root) / ".claude-plugin"
+        plugin_json = meta_dir / "plugin.json"
+        marketplace_json = meta_dir / "marketplace.json"
+        if not plugin_json.is_file() or not marketplace_json.is_file():
+            return False
+        plugin_name = json.loads(plugin_json.read_text(encoding="utf-8")).get("name", "").strip()
+        marketplace_name = json.loads(marketplace_json.read_text(encoding="utf-8")).get("name", "").strip()
+        if not plugin_name or not marketplace_name:
+            return False
+        settings_path = Path.home() / ".claude" / "settings.json"
+        if not settings_path.is_file() or settings_path.is_symlink():
+            return False
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        enabled_plugins = settings.get("enabledPlugins")
+        if not isinstance(enabled_plugins, dict):
+            return False
+        key = f"{plugin_name}@{marketplace_name}"
+        return enabled_plugins.get(key) is False
+    except Exception:
+        return False
+
+
 def main() -> int:
     if len(sys.argv) < 2:
+        return 0
+    if _plugin_disabled_by_host():
         return 0
 
     script_rel = sys.argv[1]


### PR DESCRIPTION
Hi Alex — this one's about a plugin the user turned off still spending their tokens, so I wanted to flag it even though the underlying cause looks like it may sit outside this repo.

## User-visible impact

Setting `enabledPlugins["token-optimizer@<marketplace>"] = false` in `~/.claude/settings.json` does not stop this plugin's `hooks.json` commands from running in sessions started after the edit. On my machine, I edited that setting to `false` at 2026-08-07 01:28:07, then checked every session transcript that started afterward: 8 of 8 still ran the hook dispatcher and printed `[Token Optimizer]` output on SessionStart alone (roughly 1,000+ tokens/session just for that one hook group, before counting PreToolUse/Stop/PreCompact). A user who explicitly disabled the plugin keeps paying for it.

## What I checked before assuming it was a bug here

- Setting key name matches the plugin's own registered id exactly (`installed_plugins.json`).
- Correct scope (global user settings.json — this install is user-scoped).
- No project-level override re-enabling it.
- No stray direct `hooks` entry bypassing the plugin system.

So on my machine this isn't a misconfiguration on my end.

## Scope of what I can actually confirm

I traced `hooks/run.py` (the dispatcher every `hooks.json` command routes through) and found it has zero awareness of the host's `enabledPlugins` setting — it has an unrelated, separate consent gate but nothing checks this flag. I could not find where in this repo hook registration would be conditioned on that setting, which suggests whatever *should* be stopping invocation for a disabled plugin lives in the Claude Code harness itself, not in this codebase — I don't have visibility into that harness's source, so I can't tell you definitively whether this is a harness limitation, a caching/registration quirk specific to already-running sessions, or something else entirely. I'm reporting what I measured (the flag doesn't stop invocation) and what I checked (it isn't a config error), not a diagnosis of the harness's internals.

## Fix (a plugin-side mitigation, not a claim about root cause)

Since I can't fix or verify the harness side, I added a defensive self-check in `hooks/run.py`: it reads the plugin's own `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (both already shipped with every install) to resolve its own `<name>@<marketplace>` key, checks it against `~/.claude/settings.json`'s `enabledPlugins`, and no-ops before spawning the dispatch subprocess if explicitly disabled. Fails open on any missing file, unreadable JSON, or unresolved name, so it can't newly break anything for someone who hasn't touched the setting.

I verified this mechanistically against my own real, live-disabled settings.json — direct call to the new check returns `True`, and invoking `hooks/run.py` with a real `hooks.json` command line now exits 0 with no subprocess spawned (previously ran normally regardless of the flag). I have *not* been able to verify it end-to-end against a brand-new live Claude Code session started after this fix (that needs an actual fresh CLI process, which was outside what I could do in this pass) — flagging that gap rather than claiming full confirmation.

If you have a cleaner read on where the actual root cause lives (maybe this is worth a report to Anthropic too, if it's genuinely harness-side), I'd rather defer to your judgment on whether this workaround belongs here at all versus just documenting the limitation. Entirely your call.
