### PR TITLE
fix: gate quality-cache --warn with the same cap/cooldown/band guardrails as _maybe_nudge

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -30886,9 +30886,10 @@ _LOOP_LAST_MESSAGES = 4
 # Transient nudge/loop/warning state that must survive across the separate
 # UserPromptSubmit and PostCompact hook processes. compute_quality_score() builds
 # a fresh result each run, so quality_cache() carries these forward from the prior
-# on-disk cache. Any new "_nudge_*"/"_loop_*"/warning-dedup key set in _maybe_nudge
-# or _maybe_loop_warning MUST be registered here — a sibling key silently missing
-# from this set is exactly what broke the nudge follow-through credit (A6).
+# on-disk cache. Any new "_nudge_*"/"_loop_*"/"_warn_*"/warning-dedup key set in
+# _maybe_nudge, _maybe_loop_warning, or _maybe_quality_warn MUST be registered
+# here — a sibling key silently missing from this set is exactly what broke the
+# nudge follow-through credit (A6).
 _CARRY_KEYS = (
     "_nudge_fill_pct_at_fire",
     "_nudge_fire_epoch",
@@ -30900,6 +30901,9 @@ _CARRY_KEYS = (
     "progressive_bands_captured",
     "_last_fill_warn_level",
     "_last_tool_call_warn_level",
+    "_warn_count",
+    "_warn_last_epoch",
+    "_warn_last_band",
 )
 
 
@@ -31153,6 +31157,53 @@ def _maybe_nudge(result, cache_path, quality_data, quiet=False):
     )
 
 
+def _maybe_quality_warn(result, warn_threshold):
+    """Gate the `quality-cache --warn` CLI message with the same guardrails
+    _maybe_nudge already has: session cap + cooldown + "only re-fire on a NEW
+    lower quality band."
+
+    Without this, the plain-text warning ("Context quality: N/100. Stale reads
+    and bloated results building up. Consider /compact.") re-printed on every
+    UserPromptSubmit where score < warn_threshold -- no cap, no cooldown, no
+    "only if it got worse" check. A session hovering in one band under the
+    default warn_threshold=70 (e.g. 69 -> 66 -> 64 -> 62) nagged on every
+    single prompt. _maybe_nudge, its sibling above, already solved this exact
+    problem for the proactive nudge; this reuses the same constants
+    (_NUDGE_SESSION_CAP, _NUDGE_COOLDOWN_SECONDS) so both paths behave
+    consistently. A later drop into a new lower 10-point band (e.g. from the
+    60s into the 50s) still warns again, since that is new information worth
+    surfacing even mid-cooldown-window.
+
+    Returns True if the CLI should print the warning this tick.
+    """
+    score = result.get("score")
+    if score is None or score >= warn_threshold:
+        return False
+
+    warn_count = result.get("_warn_count", 0)
+    last_warn_epoch = result.get("_warn_last_epoch", 0)
+    last_band = result.get("_warn_last_band")
+    band = int(score // 10)
+
+    if warn_count >= _NUDGE_SESSION_CAP:
+        return False
+
+    now = time.time()
+    if now - last_warn_epoch < _NUDGE_COOLDOWN_SECONDS:
+        return False
+
+    # Only re-warn once quality has dropped into a NEW lower band since the
+    # last warning fired (e.g. from the 60s into the 50s). Repeated ticks
+    # within the same band are exactly the spam this guards against.
+    if last_band is not None and band >= last_band:
+        return False
+
+    result["_warn_count"] = warn_count + 1
+    result["_warn_last_epoch"] = now
+    result["_warn_last_band"] = band
+    return True
+
+
 def _maybe_loop_warning(result, cache_path, quality_data, quiet=False):
     """Check for real-time loops. Returns systemMessage string or None."""
     if not _is_v5_feature_enabled("loop_detection"):
@@ -31242,7 +31293,7 @@ def _release_quality_lock(lock):
     lock.release()
 
 
-def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_jsonl=None, force=False, pure_time_throttle=False, session_id=None):
+def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_jsonl=None, force=False, pure_time_throttle=False, session_id=None, warn=False):
     """Run quality analysis and write score to cache file for status line.
 
     Skips analysis if cache is younger than throttle_seconds (unless force=True).
@@ -31250,6 +31301,10 @@ def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_
         session_jsonl: Path string to the session JSONL (from hook transcript_path).
                        If provided, used directly instead of guessing by mtime.
         force: If True, bypass throttle (used by PostCompact hook for immediate refresh).
+        warn: If True and the (possibly just-recomputed) score is below warn_threshold,
+                       print the plain-text "Context quality: N/100..." CLI warning --
+                       gated by _maybe_quality_warn (cap + cooldown + band-drop) the
+                       same way the proactive nudge below is gated.
         pure_time_throttle: If True, throttle purely on cache age and ignore whether
                        the transcript changed. The default (False) recomputes whenever
                        the session changed, which is right for the infrequent
@@ -31481,6 +31536,28 @@ def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_
                 print(json.dumps({"systemMessage": fresh_msg}))
             except Exception:
                 pass
+
+        # `quality-cache --warn` plain-text CLI warning (distinct from the
+        # systemMessage JSON above -- this is what the UserPromptSubmit hook
+        # actually installs: `quality-cache --warn --quiet`). Gated by
+        # _maybe_quality_warn so it no longer re-prints on every prompt while a
+        # session sits in one quality band; see that function for the rationale.
+        if warn and _maybe_quality_warn(result, warn_threshold):
+            _emit_warn = True
+            try:
+                from context_pressure import should_inject, get_pressure_level, log_suppression
+                _wf = str(filepath) if filepath else None
+                if not should_inject(_wf, session_id=_session_id, priority="informational"):
+                    log_suppression("quality_warning", get_pressure_level(_wf, session_id=_session_id))
+                    _emit_warn = False
+            except Exception:
+                pass
+            if _emit_warn:
+                if result["score"] < 50:
+                    print(f"[Token Optimizer] Context quality: {result['score']}/100 (critical). Heavy rot detected. Consider /clear with checkpoint.")
+                else:
+                    print(f"[Token Optimizer] Context quality: {result['score']}/100. Stale reads and bloated results building up. Consider /compact.")
+            _write_quality_cache(cache_path, result)
 
         # Nudge follow-through: if PostCompact triggered this run (force=True)
         # and a nudge preceded the compact, measure the actual fill_pct recovery.
@@ -38989,7 +39066,12 @@ if __name__ == "__main__":
                     session_id_from_hook = payload.get("session_id")
                 except (json.JSONDecodeError, OSError):
                     pass
-            score = quality_cache(throttle_seconds=throttle, warn_threshold=warn_threshold, quiet=quiet, session_jsonl=session_jsonl, force=force, pure_time_throttle=throttle_only, session_id=session_id_from_hook)
+            # The --warn print itself now happens inside quality_cache() (gated by
+            # _maybe_quality_warn: session cap + cooldown + band-drop), so it can
+            # reuse the already-resolved filepath/cache_path/result instead of
+            # re-deriving them here. See quality_cache()'s `warn` handling for the
+            # actual message text and gating.
+            score = quality_cache(throttle_seconds=throttle, warn_threshold=warn_threshold, quiet=quiet, session_jsonl=session_jsonl, force=force, pure_time_throttle=throttle_only, session_id=session_id_from_hook, warn=warn)
             # Tripwire piggyback: the --throttle-only invocation fires on the
             # PostToolUse Edit/Write path (where active first-read follow-ups are
             # resolved), so this is the natural place to refresh the per-cohort
@@ -39000,20 +39082,6 @@ if __name__ == "__main__":
                     evaluate_cohort_tripwire()
                 except Exception:
                     pass
-            if warn and score is not None and score < warn_threshold:
-                _emit_warn = True
-                try:
-                    from context_pressure import should_inject, get_pressure_level, log_suppression
-                    if not should_inject(session_jsonl, priority="informational"):
-                        log_suppression("quality_warning", get_pressure_level(session_jsonl))
-                        _emit_warn = False
-                except Exception:
-                    pass
-                if _emit_warn:
-                    if score < 50:
-                        print(f"[Token Optimizer] Context quality: {score}/100 (critical). Heavy rot detected. Consider /clear with checkpoint.")
-                    else:
-                        print(f"[Token Optimizer] Context quality: {score}/100. Stale reads and bloated results building up. Consider /compact.")
         except _HookTimeout:
             print(
                 "[Token Optimizer] hook budget exceeded; skipping quality-cache tick to keep session responsive",

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -30886,9 +30886,10 @@ _LOOP_LAST_MESSAGES = 4
 # Transient nudge/loop/warning state that must survive across the separate
 # UserPromptSubmit and PostCompact hook processes. compute_quality_score() builds
 # a fresh result each run, so quality_cache() carries these forward from the prior
-# on-disk cache. Any new "_nudge_*"/"_loop_*"/warning-dedup key set in _maybe_nudge
-# or _maybe_loop_warning MUST be registered here — a sibling key silently missing
-# from this set is exactly what broke the nudge follow-through credit (A6).
+# on-disk cache. Any new "_nudge_*"/"_loop_*"/"_warn_*"/warning-dedup key set in
+# _maybe_nudge, _maybe_loop_warning, or _maybe_quality_warn MUST be registered
+# here — a sibling key silently missing from this set is exactly what broke the
+# nudge follow-through credit (A6).
 _CARRY_KEYS = (
     "_nudge_fill_pct_at_fire",
     "_nudge_fire_epoch",
@@ -30900,6 +30901,9 @@ _CARRY_KEYS = (
     "progressive_bands_captured",
     "_last_fill_warn_level",
     "_last_tool_call_warn_level",
+    "_warn_count",
+    "_warn_last_epoch",
+    "_warn_last_band",
 )
 
 
@@ -31153,6 +31157,53 @@ def _maybe_nudge(result, cache_path, quality_data, quiet=False):
     )
 
 
+def _maybe_quality_warn(result, warn_threshold):
+    """Gate the `quality-cache --warn` CLI message with the same guardrails
+    _maybe_nudge already has: session cap + cooldown + "only re-fire on a NEW
+    lower quality band."
+
+    Without this, the plain-text warning ("Context quality: N/100. Stale reads
+    and bloated results building up. Consider /compact.") re-printed on every
+    UserPromptSubmit where score < warn_threshold -- no cap, no cooldown, no
+    "only if it got worse" check. A session hovering in one band under the
+    default warn_threshold=70 (e.g. 69 -> 66 -> 64 -> 62) nagged on every
+    single prompt. _maybe_nudge, its sibling above, already solved this exact
+    problem for the proactive nudge; this reuses the same constants
+    (_NUDGE_SESSION_CAP, _NUDGE_COOLDOWN_SECONDS) so both paths behave
+    consistently. A later drop into a new lower 10-point band (e.g. from the
+    60s into the 50s) still warns again, since that is new information worth
+    surfacing even mid-cooldown-window.
+
+    Returns True if the CLI should print the warning this tick.
+    """
+    score = result.get("score")
+    if score is None or score >= warn_threshold:
+        return False
+
+    warn_count = result.get("_warn_count", 0)
+    last_warn_epoch = result.get("_warn_last_epoch", 0)
+    last_band = result.get("_warn_last_band")
+    band = int(score // 10)
+
+    if warn_count >= _NUDGE_SESSION_CAP:
+        return False
+
+    now = time.time()
+    if now - last_warn_epoch < _NUDGE_COOLDOWN_SECONDS:
+        return False
+
+    # Only re-warn once quality has dropped into a NEW lower band since the
+    # last warning fired (e.g. from the 60s into the 50s). Repeated ticks
+    # within the same band are exactly the spam this guards against.
+    if last_band is not None and band >= last_band:
+        return False
+
+    result["_warn_count"] = warn_count + 1
+    result["_warn_last_epoch"] = now
+    result["_warn_last_band"] = band
+    return True
+
+
 def _maybe_loop_warning(result, cache_path, quality_data, quiet=False):
     """Check for real-time loops. Returns systemMessage string or None."""
     if not _is_v5_feature_enabled("loop_detection"):
@@ -31242,7 +31293,7 @@ def _release_quality_lock(lock):
     lock.release()
 
 
-def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_jsonl=None, force=False, pure_time_throttle=False, session_id=None):
+def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_jsonl=None, force=False, pure_time_throttle=False, session_id=None, warn=False):
     """Run quality analysis and write score to cache file for status line.
 
     Skips analysis if cache is younger than throttle_seconds (unless force=True).
@@ -31250,6 +31301,10 @@ def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_
         session_jsonl: Path string to the session JSONL (from hook transcript_path).
                        If provided, used directly instead of guessing by mtime.
         force: If True, bypass throttle (used by PostCompact hook for immediate refresh).
+        warn: If True and the (possibly just-recomputed) score is below warn_threshold,
+                       print the plain-text "Context quality: N/100..." CLI warning --
+                       gated by _maybe_quality_warn (cap + cooldown + band-drop) the
+                       same way the proactive nudge below is gated.
         pure_time_throttle: If True, throttle purely on cache age and ignore whether
                        the transcript changed. The default (False) recomputes whenever
                        the session changed, which is right for the infrequent
@@ -31481,6 +31536,28 @@ def quality_cache(throttle_seconds=120, warn_threshold=70, quiet=False, session_
                 print(json.dumps({"systemMessage": fresh_msg}))
             except Exception:
                 pass
+
+        # `quality-cache --warn` plain-text CLI warning (distinct from the
+        # systemMessage JSON above -- this is what the UserPromptSubmit hook
+        # actually installs: `quality-cache --warn --quiet`). Gated by
+        # _maybe_quality_warn so it no longer re-prints on every prompt while a
+        # session sits in one quality band; see that function for the rationale.
+        if warn and _maybe_quality_warn(result, warn_threshold):
+            _emit_warn = True
+            try:
+                from context_pressure import should_inject, get_pressure_level, log_suppression
+                _wf = str(filepath) if filepath else None
+                if not should_inject(_wf, session_id=_session_id, priority="informational"):
+                    log_suppression("quality_warning", get_pressure_level(_wf, session_id=_session_id))
+                    _emit_warn = False
+            except Exception:
+                pass
+            if _emit_warn:
+                if result["score"] < 50:
+                    print(f"[Token Optimizer] Context quality: {result['score']}/100 (critical). Heavy rot detected. Consider /clear with checkpoint.")
+                else:
+                    print(f"[Token Optimizer] Context quality: {result['score']}/100. Stale reads and bloated results building up. Consider /compact.")
+            _write_quality_cache(cache_path, result)
 
         # Nudge follow-through: if PostCompact triggered this run (force=True)
         # and a nudge preceded the compact, measure the actual fill_pct recovery.
@@ -38989,7 +39066,12 @@ if __name__ == "__main__":
                     session_id_from_hook = payload.get("session_id")
                 except (json.JSONDecodeError, OSError):
                     pass
-            score = quality_cache(throttle_seconds=throttle, warn_threshold=warn_threshold, quiet=quiet, session_jsonl=session_jsonl, force=force, pure_time_throttle=throttle_only, session_id=session_id_from_hook)
+            # The --warn print itself now happens inside quality_cache() (gated by
+            # _maybe_quality_warn: session cap + cooldown + band-drop), so it can
+            # reuse the already-resolved filepath/cache_path/result instead of
+            # re-deriving them here. See quality_cache()'s `warn` handling for the
+            # actual message text and gating.
+            score = quality_cache(throttle_seconds=throttle, warn_threshold=warn_threshold, quiet=quiet, session_jsonl=session_jsonl, force=force, pure_time_throttle=throttle_only, session_id=session_id_from_hook, warn=warn)
             # Tripwire piggyback: the --throttle-only invocation fires on the
             # PostToolUse Edit/Write path (where active first-read follow-ups are
             # resolved), so this is the natural place to refresh the per-cohort
@@ -39000,20 +39082,6 @@ if __name__ == "__main__":
                     evaluate_cohort_tripwire()
                 except Exception:
                     pass
-            if warn and score is not None and score < warn_threshold:
-                _emit_warn = True
-                try:
-                    from context_pressure import should_inject, get_pressure_level, log_suppression
-                    if not should_inject(session_jsonl, priority="informational"):
-                        log_suppression("quality_warning", get_pressure_level(session_jsonl))
-                        _emit_warn = False
-                except Exception:
-                    pass
-                if _emit_warn:
-                    if score < 50:
-                        print(f"[Token Optimizer] Context quality: {score}/100 (critical). Heavy rot detected. Consider /clear with checkpoint.")
-                    else:
-                        print(f"[Token Optimizer] Context quality: {score}/100. Stale reads and bloated results building up. Consider /compact.")
         except _HookTimeout:
             print(
                 "[Token Optimizer] hook budget exceeded; skipping quality-cache tick to keep session responsive",

--- a/tests/test_quality_warn_band_gate.py
+++ b/tests/test_quality_warn_band_gate.py
@@ -1,0 +1,216 @@
+"""Behavioral proof that `quality-cache --warn` no longer re-prints the plain
+"[Token Optimizer] Context quality: N/100..." warning on every
+UserPromptSubmit while a session sits in one quality band.
+
+Why this exists: the sibling proactive nudge (_maybe_nudge, below the warn
+gate in measure.py) has always had a session cap (_NUDGE_SESSION_CAP),
+a cooldown (_NUDGE_COOLDOWN_SECONDS), and an "only if it got worse" check.
+The --warn CLI path -- the plain-text message the UserPromptSubmit hook
+installs via `quality-cache --warn --quiet` -- never got the same
+guardrails: it fired on every tick where score < warn_threshold, with no
+cap, no cooldown, no re-fire condition. A session hovering in the 60s under
+the default warn_threshold=70 (e.g. 69 -> 66 -> 64 -> 62, all the same
+10-point band) nagged on every single prompt.
+
+_maybe_quality_warn fixes this by reusing _NUDGE_SESSION_CAP and
+_NUDGE_COOLDOWN_SECONDS from the sibling nudge, plus a band-drop gate: it
+only re-fires once quality crosses into a NEW lower 10-point band. These
+tests exercise the gate function directly (fast, precise) and then drive the
+real quality_cache(warn=True) path end-to-end (mirroring
+test_quality_cache_release_on_timeout.py's pattern) to prove the actual CLI
+print is suppressed/allowed the same way.
+
+Run: python3 -m pytest tests/test_quality_warn_band_gate.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+@pytest.fixture()
+def m(monkeypatch):
+    tmp = tempfile.mkdtemp(prefix="to-qwarn-")
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", tmp)
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+# --- unit tests: the pure gate function --------------------------------------
+
+def test_first_drop_below_threshold_fires(m):
+    result = {"score": 66}
+    assert m._maybe_quality_warn(result, warn_threshold=70) is True
+    assert result["_warn_count"] == 1
+    assert result["_warn_last_band"] == 6
+
+
+def test_same_band_does_not_refire(m):
+    """THE reported bug: 69 -> 66 -> 64 -> 62 (all band 6) must warn once."""
+    result = {"score": 69}
+    assert m._maybe_quality_warn(result, warn_threshold=70) is True
+    for score in (66, 64, 62):
+        result["score"] = score
+        assert m._maybe_quality_warn(result, warn_threshold=70) is False, (
+            f"re-fired within the same band at score={score}"
+        )
+    assert result["_warn_count"] == 1
+
+
+def test_drop_into_a_new_lower_band_fires_again(m):
+    result = {"score": 62}
+    assert m._maybe_quality_warn(result, warn_threshold=70) is True
+    result["score"] = 47  # crosses from band 6 into band 4
+    # Defeat the cooldown so the band drop -- not elapsed time -- is under test.
+    result["_warn_last_epoch"] = 0
+    assert m._maybe_quality_warn(result, warn_threshold=70) is True
+    assert result["_warn_last_band"] == 4
+    assert result["_warn_count"] == 2
+
+
+def test_cooldown_blocks_even_a_genuine_band_drop(m):
+    """Cooldown is unconditional, matching _maybe_nudge's own cooldown gate."""
+    result = {"score": 62}
+    assert m._maybe_quality_warn(result, warn_threshold=70) is True
+    result["score"] = 30  # a big drop, well into a new band
+    # _warn_last_epoch was just set to "now" -- cooldown has not elapsed yet.
+    assert m._maybe_quality_warn(result, warn_threshold=70) is False
+
+
+def test_session_cap_stops_after_the_cap(m):
+    result = {"score": 65}
+    fired = 0
+    for band_score in (65, 55, 45, 35):  # 4 distinct, ever-lower bands
+        result["score"] = band_score
+        result["_warn_last_epoch"] = 0  # defeat cooldown each time
+        if m._maybe_quality_warn(result, warn_threshold=70):
+            fired += 1
+    assert fired == m._NUDGE_SESSION_CAP == 3
+
+
+def test_score_at_or_above_threshold_never_fires(m):
+    result = {"score": 70}
+    assert m._maybe_quality_warn(result, warn_threshold=70) is False
+    assert "_warn_count" not in result
+
+
+# --- end-to-end: quality_cache(warn=True) drives the real print path --------
+
+def _quiet_quality_data():
+    return {"messages": [], "decisions": [], "compactions": 0}
+
+
+def test_quality_cache_warn_does_not_repeat_within_a_band(m, monkeypatch, tmp_path, capsys):
+    cache_dir = tmp_path / "to-cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(m, "QUALITY_CACHE_DIR", cache_dir)
+
+    session = tmp_path / "sess-warn.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(m, "_parse_jsonl_for_quality", lambda fp: _quiet_quality_data())
+
+    scores = iter([66, 64, 62])  # same band (6), three ticks in a row
+
+    def _fake_score(quality_data, session_id=None):
+        return {"score": next(scores), "breakdown": {}, "signals": {}}
+
+    monkeypatch.setattr(m, "compute_quality_score", _fake_score)
+
+    fired = []
+    for _ in range(3):
+        capsys.readouterr()
+        m.quality_cache(
+            throttle_seconds=0, quiet=True, session_jsonl=str(session),
+            force=True, warn=True, warn_threshold=70,
+        )
+        out = capsys.readouterr().out
+        fired.append("Context quality:" in out)
+
+    assert fired == [True, False, False], (
+        f"expected exactly one warning across three same-band ticks, got {fired}"
+    )
+
+
+def test_quality_cache_warn_fires_again_on_band_drop(m, monkeypatch, tmp_path, capsys):
+    cache_dir = tmp_path / "to-cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(m, "QUALITY_CACHE_DIR", cache_dir)
+
+    session = tmp_path / "sess-warn2.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(m, "_parse_jsonl_for_quality", lambda fp: _quiet_quality_data())
+
+    scores = iter([66, 45])  # band 6, then band 4
+
+    def _fake_score(quality_data, session_id=None):
+        return {"score": next(scores), "breakdown": {}, "signals": {}}
+
+    monkeypatch.setattr(m, "compute_quality_score", _fake_score)
+
+    m.quality_cache(
+        throttle_seconds=0, quiet=True, session_jsonl=str(session),
+        force=True, warn=True, warn_threshold=70,
+    )
+    capsys.readouterr()
+
+    # Defeat the cooldown directly on the persisted per-session cache so the
+    # band drop -- not elapsed time -- is what this test proves.
+    cache_path = m._quality_cache_path_for(Path(session))
+    cached = m._read_quality_cache(cache_path)
+    cached["_warn_last_epoch"] = 0
+    m._write_quality_cache(cache_path, cached)
+
+    m.quality_cache(
+        throttle_seconds=0, quiet=True, session_jsonl=str(session),
+        force=True, warn=True, warn_threshold=70,
+    )
+    out = capsys.readouterr().out
+    assert "Context quality:" in out, "a drop into a new lower band must re-warn"
+    assert "45/100" in out
+
+
+def test_quality_cache_warn_false_does_not_print(m, monkeypatch, tmp_path, capsys):
+    """Sanity: passing warn=False (the non-hook default) never prints, no
+    matter how low the score -- this is what SessionStart/PreCompact's
+    `quality-cache --force --quiet` invocations rely on."""
+    cache_dir = tmp_path / "to-cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(m, "QUALITY_CACHE_DIR", cache_dir)
+
+    session = tmp_path / "sess-noflag.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "timestamp": "2026-01-01T00:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(m, "_parse_jsonl_for_quality", lambda fp: _quiet_quality_data())
+    monkeypatch.setattr(
+        m, "compute_quality_score",
+        lambda quality_data, session_id=None: {"score": 10, "breakdown": {}, "signals": {}},
+    )
+
+    capsys.readouterr()
+    m.quality_cache(
+        throttle_seconds=0, quiet=True, session_jsonl=str(session), force=True,
+    )
+    out = capsys.readouterr().out
+    assert "Context quality:" not in out


### PR DESCRIPTION
## Summary

`quality-cache --warn` — the plain-text warning the `UserPromptSubmit` hook installs (`quality-cache --warn --quiet`) — had no session cap, no cooldown, and no "only if it got worse" check. It fired on every prompt where `score < warn_threshold` (default 70), so a session hovering in a single 10-point band (e.g. `69 -> 66 -> 64 -> 62`) nagged the user on every single turn. Fixes #124.

Its sibling, `_maybe_nudge` (the proactive `systemMessage` nudge a few hundred lines earlier in `measure.py`), already solved this exact problem: it enforces `_NUDGE_SESSION_CAP` (3) and `_NUDGE_COOLDOWN_SECONDS` (300s), only firing on a >15pt drop or a cross below 60. The `--warn` path never got the same guardrails — the two nudge paths were inconsistent with no apparent reason for the gap.

## What changed

- Added `_maybe_quality_warn(result, warn_threshold)` next to `_maybe_nudge`, gated the same way: reuses `_NUDGE_SESSION_CAP` / `_NUDGE_COOLDOWN_SECONDS`, plus a band-drop check — it only re-fires once the score crosses into a **new, lower** 10-point band. `69 -> 66 -> 64 -> 62` now warns once; a later drop into the 50s warns again.
- State (`_warn_count` / `_warn_last_epoch` / `_warn_last_band`) persists in the existing per-session quality-cache sidecar, registered in `_CARRY_KEYS` alongside the other nudge/loop/warning state — the same mechanism `_maybe_nudge` already relies on to survive the `UserPromptSubmit` → `PostCompact` process boundary.
- The actual `print(...)` moved from the CLI dispatch (`elif args[0] == "quality-cache":`) into `quality_cache()` itself, gated behind a new `warn=False` parameter. `quality_cache()` is only called from that one CLI dispatch site, so this is a safe, non-breaking move — and it's actually *more* consistent with the file's existing style: every other nudge/loop/fill/tool-call warning already prints from inside `quality_cache()`, where `filepath`/`cache_path`/`result` are already resolved; the plain-text `--warn` message was the one outlier printing from outside it, re-deriving nothing extra but duplicating the `should_inject` gate pattern one level removed.
- The existing `context_pressure.should_inject` throttle is kept exactly as-is, still applied unconditionally as a second, independent gate (belt-and-suspenders).
- `plugins/token-optimizer/skills/token-optimizer/scripts/measure.py` (the Codex marketplace mirror) re-synced via `scripts/sync-codex-marketplace-plugin.sh` so the two trees stay byte-identical (enforced by `tests/test_duplicate_script_sync.py` / `tests/test_session_locale_and_hooks.py::test_measure_py_dual_tree_parity`).

## Why this is low-risk

- No default thresholds changed, no behavior removed — the warning still fires, just not on every single prompt.
- `warn` defaults to `False`, so `quality_cache()`'s other caller pattern (`--force --quiet` from `SessionStart`/`PreCompact`, which never passes `--warn`) is byte-for-byte unaffected.
- `score` is not otherwise used at the CLI dispatch call site after this change, and printing already happens exactly where every other nudge in this file prints from.

## Testing

- Added `tests/test_quality_warn_band_gate.py`:
  - Unit tests directly against `_maybe_quality_warn` (first-drop fires, same-band repeats are suppressed, a genuine drop into a new lower band re-fires, cooldown blocks even a real band drop, session cap stops firing after 3, at/above threshold never fires).
  - Two end-to-end tests driving the real `quality_cache(warn=True)` path (mirroring `tests/test_quality_cache_release_on_timeout.py`'s pattern) with `capsys`, proving the actual CLI print fires once across three same-band ticks and fires again on a real band drop.
  - A sanity test that `warn=False` never prints.
- `python3 -m pytest tests/ -q` (excluding one file/test that fails identically on unmodified `main` under this Python 3.9 environment — `dict | None` syntax needs 3.10+, unrelated to this change): **1052 passed, 13 skipped**.
- `python3 -m py_compile` on both copies of `measure.py` and the new test file: clean.

Fixes #124
