### PR TITLE
fix(dashboard): lead the hero with the throughput %, not the $ slices

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -3885,17 +3885,17 @@ var DB = (function() {
         // No glow on this headline. `.metric-large` carries a text-shadow built
         // from --c-border-strong, which is a light veil on dark but resolves to a
         // DARK halo in light mode, so the words read as smudged rather than lit.
-        // USD-per-window is the headline; the throughput multiplier is
-        // demoted to the secondary line below.
-        (usdHeadline
-          ? '<div class="metric-large" style="text-wrap:balance;text-shadow:none;">' + usdHeadline + '</div>'
-          : '<div class="metric-large" style="text-wrap:balance;text-shadow:none;"><em style="font-style:normal;color:var(--c-accent-cyan);">' + rw.extra_work_pct + '%</em> more work</div>') +
-        // Demoted secondary: the per-token throughput multiplier is real but
-        // a DIFFERENT unit from the window headroom points and the dollar figure.
-        // Stated as a separate line with a one-line units note so it is never
-        // presented as combinable with the per-window numbers (the old
-        // 40.2 / 8.4 / 20.1 display implied 8.4 + 20.1 combined into 40.2).
-        '<div style="margin-top:var(--s-2);font-size:15px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">&asymp;' + rw.extra_work_pct + '% more work per token (lighter context &times;' + rw.context_multiplier + ' &middot; lighter models &times;' + rw.routing_multiplier + '). A per-token throughput multiplier, shown separately from the window headroom and dollar figures below.</div>' +
+        // Headline = the per-token throughput multiplier ("X% more work per token").
+        // The dollar figures live in the per-window cards below, NOT the headline, so
+        // the top line stays a single honest unit (a %) instead of mixing $ and %.
+        // The USD-per-window string is kept only as a fallback for the rare case where
+        // the throughput multiplier is not yet computable.
+        ((isFinite(Number(rw.extra_work_pct)) && Number(rw.extra_work_pct) > 0)
+          ? '<div class="metric-large" style="text-wrap:balance;text-shadow:none;"><em style="font-style:normal;color:var(--c-accent-cyan);">&asymp;' + rw.extra_work_pct + '%</em> more work per token</div>'
+          : '<div class="metric-large" style="text-wrap:balance;text-shadow:none;">' + (usdHeadline || '<em style="font-style:normal;color:var(--c-accent-cyan);">more work</em>') + '</div>') +
+        // Secondary: the composition of the multiplier, plus a one-line units note so it
+        // is never presented as combinable with the per-window dollar/headroom numbers.
+        '<div style="margin-top:var(--s-2);font-size:15px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">lighter context &times;' + rw.context_multiplier + ' &middot; lighter models &times;' + rw.routing_multiplier + '. A per-token throughput multiplier, shown separately from the window headroom and dollar figures below.</div>' +
         // Stands alone. An earlier revision opened with "before you hit your usage
         // limits.", a continuation of the headline that reads as a truncated
         // fragment once it wraps to its own line, and the limit panels below

--- a/skills/token-optimizer/assets/dashboard.html
+++ b/skills/token-optimizer/assets/dashboard.html
@@ -3885,17 +3885,17 @@ var DB = (function() {
         // No glow on this headline. `.metric-large` carries a text-shadow built
         // from --c-border-strong, which is a light veil on dark but resolves to a
         // DARK halo in light mode, so the words read as smudged rather than lit.
-        // USD-per-window is the headline; the throughput multiplier is
-        // demoted to the secondary line below.
-        (usdHeadline
-          ? '<div class="metric-large" style="text-wrap:balance;text-shadow:none;">' + usdHeadline + '</div>'
-          : '<div class="metric-large" style="text-wrap:balance;text-shadow:none;"><em style="font-style:normal;color:var(--c-accent-cyan);">' + rw.extra_work_pct + '%</em> more work</div>') +
-        // Demoted secondary: the per-token throughput multiplier is real but
-        // a DIFFERENT unit from the window headroom points and the dollar figure.
-        // Stated as a separate line with a one-line units note so it is never
-        // presented as combinable with the per-window numbers (the old
-        // 40.2 / 8.4 / 20.1 display implied 8.4 + 20.1 combined into 40.2).
-        '<div style="margin-top:var(--s-2);font-size:15px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">&asymp;' + rw.extra_work_pct + '% more work per token (lighter context &times;' + rw.context_multiplier + ' &middot; lighter models &times;' + rw.routing_multiplier + '). A per-token throughput multiplier, shown separately from the window headroom and dollar figures below.</div>' +
+        // Headline = the per-token throughput multiplier ("X% more work per token").
+        // The dollar figures live in the per-window cards below, NOT the headline, so
+        // the top line stays a single honest unit (a %) instead of mixing $ and %.
+        // The USD-per-window string is kept only as a fallback for the rare case where
+        // the throughput multiplier is not yet computable.
+        ((isFinite(Number(rw.extra_work_pct)) && Number(rw.extra_work_pct) > 0)
+          ? '<div class="metric-large" style="text-wrap:balance;text-shadow:none;"><em style="font-style:normal;color:var(--c-accent-cyan);">&asymp;' + rw.extra_work_pct + '%</em> more work per token</div>'
+          : '<div class="metric-large" style="text-wrap:balance;text-shadow:none;">' + (usdHeadline || '<em style="font-style:normal;color:var(--c-accent-cyan);">more work</em>') + '</div>') +
+        // Secondary: the composition of the multiplier, plus a one-line units note so it
+        // is never presented as combinable with the per-window dollar/headroom numbers.
+        '<div style="margin-top:var(--s-2);font-size:15px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">lighter context &times;' + rw.context_multiplier + ' &middot; lighter models &times;' + rw.routing_multiplier + '. A per-token throughput multiplier, shown separately from the window headroom and dollar figures below.</div>' +
         // Stands alone. An earlier revision opened with "before you hit your usage
         // limits.", a continuation of the headline that reads as a truncated
         // fragment once it wraps to its own line, and the limit panels below

--- a/tests/test_dashboard_usd_savings.py
+++ b/tests/test_dashboard_usd_savings.py
@@ -237,10 +237,10 @@ def test_proxy_disclosure_mentions_ledger_reuse(m, tmp_path, monkeypatch):
     assert "not derived from the throughput multipliers" in r["proxy"]
 
 
-# ----- extra_work_pct kept, demoted in the surface -----
+# ----- extra_work_pct is the headline surface -----
 
 def test_extra_work_pct_still_present(m, tmp_path, monkeypatch):
-    """The throughput multiplier is kept as a demoted secondary, not deleted."""
+    """The throughput multiplier is present in the snapshot; it drives the headline."""
     _temp_trends(m, tmp_path, monkeypatch)
     monkeypatch.setattr(m, "_input_rate_mix_ratio", lambda days=30: 1.4)
     monkeypatch.setattr(m, "_keepwarm_read_meters", _fresh_meters())
@@ -253,24 +253,28 @@ def test_extra_work_pct_still_present(m, tmp_path, monkeypatch):
     assert r["routing_multiplier"] is not None
 
 
-# ----- surface: USD headline, demoted %, no combination implication -----
+# ----- surface: % throughput headline, USD in per-window cards, no combination implication -----
 
-def test_dashboard_renders_usd_per_window_headline():
-    """The USD-per-window is the headline; the % is demoted to a secondary line."""
+def test_dashboard_leads_with_pct_headline_usd_in_cards():
+    """The per-token throughput % is the headline; the $ figures live in the per-window
+    cards, not the lead line. (Reversed the earlier USD-lead design at product's request:
+    a headline that mixed $ and % read as confusing.)"""
     html = (Path(SCRIPTS).parent / "assets" / "dashboard.html").read_text(encoding="utf-8")
     start = html.index("function runwayCardHtml(")
     body = html[start:start + 16000]
-    # USD headline construction from the windows' saved_usd.
+    # The headline metric-large leads with the throughput %, phrased "more work per token".
+    assert "more work per token</div>" in body, (
+        "the % throughput is not the headline metric-large"
+    )
+    # It is built from extra_work_pct in the PRIMARY (truthy) branch of the headline.
+    assert "rw.extra_work_pct + '%</em> more work per token</div>'" in body, (
+        "the headline is not driven by extra_work_pct as the lead metric-large"
+    )
+    # The USD-per-window string is kept only as the FALLBACK, never the lead.
+    assert "usdHeadline" in body, "usdHeadline fallback construction missing"
+    # The dollar figures still come from the per-window saved_usd (rendered in the cards).
     assert "w.saved_usd" in body, "surface no longer reads per-window saved_usd"
-    assert "usdHeadline" in body, "USD headline construction missing"
-    # The headline uses the USD figure when present, falls back to the % otherwise.
-    assert "usdHeadline" in body and "? '<div class=\"metric-large" in body, (
-        "USD headline is not the lead metric-large"
-    )
-    # The % is demoted to a secondary line with a units note.
-    assert "more work per token" in body, (
-        "extra_work_pct is not demoted to a per-token secondary line"
-    )
+    # The units note distinguishing the multiplier from the window figures stays.
     assert "shown separately" in body, (
         "the units note distinguishing the multiplier from the window figures is missing"
     )


### PR DESCRIPTION
## Problem
The "Your plan goes further" hero headline had become `$4.15 5h slice · $139 weekly slice` — a single line mixing dollars and a per-token percentage, which reads as confusing. The dollar figures are already shown (in green) in the per-window cards directly below.

## Fix
Lead the headline with the per-token throughput multiplier again — **`≈31.3% more work per token`** — and keep the USD-per-window string only as a fallback for the (unreachable-in-practice) case where the multiplier isn't computable. Dollars stay in the per-window cards.

- `skills/token-optimizer/assets/dashboard.html` — headline ternary now leads with `rw.extra_work_pct`; secondary line carries the `×context · ×models` composition.
- Codex mirror regenerated (byte-identical tree check passes).
- The guardrail test `test_dashboard_usd_savings.py` was updated to encode the new intent (`%` leads, `$` in cards) instead of the old USD-lead assertion; stale "demoted %" comments corrected.

## Verification
- Full Python suite: **1168 passed, 13 skipped**. Dashboard suite: 12/12.
- Regenerated dashboard confirmed rendering the `%` headline; old `$`-lead gone.
- Reviewed (correctness of the ternary edge cases, HTML escaping — values are numeric/non-user, XSS-safe, test-quality): no critical/high.
- version-master: version coherence CLEAN; no CI-sensitive paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
