### PR TITLE
fix: #129 cold-resume safety + dedupe savings-card copy

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -3953,8 +3953,13 @@ var DB = (function() {
             '<div id="to-regen-error" hidden style="margin-top:10px;padding:10px 14px;font-size:15px;font-weight:500;color:var(--c-waste);background:rgba(255,95,95,.08);border:1px solid rgba(255,95,95,.35);border-radius:8px;line-height:1.5;text-wrap:pretty;"></div></div>';
         })() +
         '<div style="margin-top:var(--s-4);padding-top:var(--s-3);border-top:1px solid var(--c-border);font-size:14px;color:var(--c-text-dim);line-height:1.7;text-wrap:pretty;">' +
-          'Your usage is measured. The window comparison and the routing dollars are estimated: ' + esc(rw.proxy) + ' ' +
-          'Per-window dollars reuse the metered savings ledger (context tokens never sent, priced at input rates) plus an estimated model-routing counterfactual; they are not derived from the throughput multipliers. The &asymp;' + rw.extra_work_pct + '% is a separate per-token throughput multiplier, not a sum of the per-window figures.' +
+          // rw.proxy is now the single source of the measured-vs-estimated boundary
+          // AND the ledger detail (deduped: this used to repeat the ledger sentence
+          // and re-state "usage is measured"). We add only the one fact proxy can't
+          // carry -- the throughput-% is its own unit, not a sum of the dollars --
+          // because it needs the live JS value.
+          esc(rw.proxy) + ' ' +
+          'The &asymp;' + rw.extra_work_pct + '% is a separate per-token throughput multiplier, not a sum of the per-window dollar figures.' +
         '</div>' +
       '</div>';
     }

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -28664,6 +28664,39 @@ _RESUME_INTENT_RE = re.compile(
 # session") so we fall back to the most-recent same-project checkpoint.
 _RESUME_NAMED_TOPIC_BAR = _float_env("TOKEN_OPTIMIZER_RESUME_TOPIC_BAR", 0.22)
 
+# Staleness cap for the VAGUE-continue fallback (GitHub #129): when the prompt
+# names no distinguishing topic we may only surface the most-recent same-project
+# checkpoint if it is fresher than this. Beyond it, blindly reopening whichever
+# sibling session was last active in the same folder is how an UNRELATED session's
+# checkpoint gets injected -- so we return nothing instead of guessing. The
+# keyword-winner path (topic named) is NOT capped; only the recency fallback is.
+_RESUME_RECENCY_CAP_MIN = _int_env("TOKEN_OPTIMIZER_RESUME_RECENCY_MIN", 480)
+
+# A session id named IN the prompt ("continue session 328c85e9", full UUID, or
+# "session id: <uuid>"). Two shapes: an 8-40 hex run (or full 8-4-4-4-12 UUID)
+# that immediately follows the word "session" (optionally "id"), OR a bare full
+# UUID anywhere. A bare short hex token NOT after "session" is deliberately NOT
+# matched, so ordinary hex words in the prompt aren't mistaken for a session id.
+# The "session" branch is listed first and captures a full UUID greedily so
+# "...session <uuid>" yields the whole id, not just its first 8-hex chunk.
+_UUID_RE_SRC = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+_PROMPT_SESSION_ID_RE = re.compile(
+    r"\bsession(?:[\s_-]*id)?[\s:#]+(" + _UUID_RE_SRC + r"|[0-9a-f]{8,40})\b"
+    r"|\b(" + _UUID_RE_SRC + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_session_id_from_prompt(text):
+    """Return a session id token the user named in the prompt, or None.
+
+    Group 1 = id after "session"; group 2 = a bare full UUID. Lowercased so it
+    matches sanitize_session_id output. Never raises."""
+    m = _PROMPT_SESSION_ID_RE.search(str(text or ""))
+    if not m:
+        return None
+    return (m.group(1) or m.group(2)).lower()
+
 
 def _resume_intent(text):
     """True when the prompt asks to continue/recall prior work."""
@@ -28968,12 +29001,50 @@ def _continuity_resume_block(text, checkpoints, sid_safe, cwd):
     reconstruction of the right same-project session, or "" to fall through to
     the lightweight hint.
 
-    Selection ("both"): keyword winner when the prompt names a topic
-    (best same-project score >= _RESUME_NAMED_TOPIC_BAR), else the most-recent
-    same-project session. Token-free: reuses build_lean_resume_context.
+    Selection order (GitHub #129): (1) a session id NAMED in the prompt wins and
+    is scoped strictly to that session -- never silently substituted; (2) else the
+    keyword winner when the prompt names a topic (best same-project score >=
+    _RESUME_NAMED_TOPIC_BAR); (3) else the most-recent same-project session, but
+    ONLY if fresher than _RESUME_RECENCY_CAP_MIN -- otherwise "" (blindly reopening
+    the last-active sibling in the folder is how an UNRELATED session leaks in).
+    A topic/recency guess carries the CONDITIONAL footer; an explicitly named
+    session carries the confident one. Token-free: reuses build_lean_resume_context.
     """
     if not cwd:
         return ""
+
+    # (1) Explicit session id in the prompt -> scope strictly to it. Honor it
+    # exactly and never fall back to a different session; if no on-disk checkpoint
+    # matches, return "" rather than silently substituting an unrelated one (#129).
+    named_id = _extract_session_id_from_prompt(text)
+    if named_id:
+        for cp in checkpoints:
+            fn = cp.get("filename", "")
+            if sid_safe and sid_safe in fn:
+                continue  # same-session recovery is SessionStart/compact's job
+            if fn.lower().startswith(named_id):
+                # Reconstruct the session whose FILENAME the named id matched, using the
+                # filename-derived id -- NOT _checkpoint_session_id, which prefers a
+                # sidecar session_id that, if it disagreed with the filename, would
+                # confidently reopen a DIFFERENT session (the #129 harm via another
+                # trigger). The user named this id, so a match warrants confident wording.
+                m = re.match(r"([0-9a-fA-F-]{8,})-\d{8}-\d{6}-", fn)
+                cp_sid = m.group(1) if m else None
+                if not cp_sid:
+                    continue
+                block = build_lean_resume_context(cp_sid, prompt_text=text, cwd=cwd,
+                                                  footer_mode="confident")
+                if block:
+                    _log_resume_lean_savings(cp_sid, block)
+                    return block
+        # No checkpoint matches the named id. If the id was the WHOLE ask (no separate
+        # resume verb) never substitute a different session -- return "" (#129). But when
+        # the prompt independently asks to resume ("continue the auth refactor ... the
+        # failing test references session a1b2c3d4"), the id is incidental, so fall
+        # through to the topic/recency selection below instead of suppressing a good match.
+        if not _resume_intent(text):
+            return ""
+
     same_project = []
     for cp in checkpoints[:50]:
         if sid_safe and sid_safe in cp.get("filename", ""):
@@ -28988,13 +29059,17 @@ def _continuity_resume_block(text, checkpoints, sid_safe, cwd):
 
     best_score = max(s for s, _, _ in same_project)
     if best_score >= _RESUME_NAMED_TOPIC_BAR:
-        # Named a topic -> keyword winner (recency breaks ties).
+        # (2) Named a topic -> keyword winner (recency breaks ties).
         same_project.sort(key=lambda x: (x[0], x[1]["created"].timestamp()), reverse=True)
         chosen = same_project[0]
     else:
-        # Vague "continue last session" -> most-recent same-project (list is
-        # already recency-sorted by list_checkpoints).
+        # (3) Vague "continue last session" -> most-recent same-project, but only
+        # if fresh. A stale freshest pick is almost certainly an unrelated sibling
+        # session (GitHub #129), so decline rather than guess.
         chosen = max(same_project, key=lambda x: x[1]["created"].timestamp())
+        age_min = (datetime.now() - chosen[1]["created"]).total_seconds() / 60
+        if age_min > _RESUME_RECENCY_CAP_MIN:
+            return ""
 
     _, cp, sidecar = chosen
     sid = sidecar.get("session_id") if isinstance(sidecar, dict) else None
@@ -29003,7 +29078,9 @@ def _continuity_resume_block(text, checkpoints, sid_safe, cwd):
         sid = m.group(1) if m else None
     if not sid:
         return ""
-    block = build_lean_resume_context(sid, prompt_text=text, cwd=cwd)
+    # Topic/recency match is a best guess -> CONDITIONAL footer so the assistant
+    # verifies against the user's actual request before claiming a reopen (#129).
+    block = build_lean_resume_context(sid, prompt_text=text, cwd=cwd, footer_mode="conditional")
     if block:
         # Count the cold-resume cost this lean reconstruction avoided (idempotent
         # per target session). Token-free; never blocks the injection.
@@ -29060,7 +29137,11 @@ def _continuity_prompt_hint(prompt_text="", session_id=None, cwd=None, max_age_m
     sid_safe = sanitize_session_id(session_id) if session_id else None
 
     # Deliberate "continue prior work" path: full lean reconstruction, same project.
-    if _resume_intent(text):
+    # An explicit session id named in the prompt ("continue session <id>", "resume
+    # session <id>") is its own resume cue: _RESUME_INTENT_RE's verb list does not
+    # include "session", so without this the strict id-scoped branch (#129 Fix 3)
+    # would never fire for the exact phrasing a user types to name a session.
+    if _resume_intent(text) or _extract_session_id_from_prompt(text):
         try:
             block = _continuity_resume_block(text, checkpoints, sid_safe, cwd)
         except Exception:
@@ -29489,7 +29570,8 @@ def _lean_list(items, n, width=140, keep_tokens=None):
     return cleaned
 
 
-def build_lean_resume_context(session_id, max_chars=3500, prompt_text=None, cwd=None):
+def build_lean_resume_context(session_id, max_chars=3500, prompt_text=None, cwd=None,
+                              footer_mode="confident"):
     """Reconstruct a LEAN, paste-ready context block for a cold session.
 
     Faithful tier (checkpoint present): active task, continuation/handover, open
@@ -29644,11 +29726,24 @@ def build_lean_resume_context(session_id, max_chars=3500, prompt_text=None, cwd=
             except (json.JSONDecodeError, ValueError, TypeError):
                 pass
 
-    footer = [
-        "Use this to re-orient a fresh session on the prior work. Tell the user "
-        "you reopened the cold session (mention its date/topic) so the recovery "
-        "is transparent.",
-    ]
+    if footer_mode == "conditional":
+        # Auto-injected best-guess match (#129): the plugin GUESSED which prior
+        # session the user meant, so the assistant must verify before claiming a
+        # reopen. Mirrors the lightweight-hint / compact_restore wording.
+        footer = [
+            "Use this only if it matches the user's current request. If you do use "
+            "it, briefly tell the user you found a relevant prior session (mention "
+            "its date/topic) so the recovery is transparent, not silent. If it does "
+            "not match what you are working on now, ignore it silently.",
+        ]
+    else:
+        # Confident path: the caller named this exact session (CLI --resume-lean, or
+        # an explicit session id in the prompt), so a reopen claim is warranted.
+        footer = [
+            "Use this to re-orient a fresh session on the prior work. Tell the user "
+            "you reopened the cold session (mention its date/topic) so the recovery "
+            "is transparent.",
+        ]
 
     # Assemble within the char budget: header + as many body lines as fit + footer.
     out = list(header)
@@ -33673,13 +33768,18 @@ def runway_snapshot(days=30, now=None):
             "meter_age_s": meters.get("age_s"),
             "meter_ts": meters.get("ts"),
             "meter_stale": meter_stale,
-            "proxy": ("Model weighting inside the provider's rate-limit windows is "
-                      "not published; public input-rate ratios are used as a "
-                      "stand-in. Window state is measured, the counterfactual is "
-                      "estimated. Per-window dollars reuse the metered savings "
-                      "ledger (context tokens never sent, priced at input rates, "
-                      "plus an estimated model-routing counterfactual) and are not "
-                      "derived from the throughput multipliers."),
+            # Single authoritative methodology note (GitHub: dashboard wall-of-text
+            # fix). Folds the measured-vs-estimated boundary in here so the HTML no
+            # longer repeats it. Keep the phrases "metered savings ledger" and "not
+            # derived from the throughput multipliers" -- guarded by
+            # test_proxy_disclosure_mentions_ledger_reuse.
+            "proxy": ("Your window usage is measured; the “without” "
+                      "comparison and routing dollars are estimated (the provider "
+                      "does not publish how it weights models inside a window, so "
+                      "public input-rate ratios stand in). Per-window dollars reuse "
+                      "the metered savings ledger (context tokens never sent, priced "
+                      "at input rates, plus a routing estimate) and are not derived "
+                      "from the throughput multipliers."),
         }
     except Exception:
         return None

--- a/skills/token-optimizer/assets/dashboard.html
+++ b/skills/token-optimizer/assets/dashboard.html
@@ -3953,8 +3953,13 @@ var DB = (function() {
             '<div id="to-regen-error" hidden style="margin-top:10px;padding:10px 14px;font-size:15px;font-weight:500;color:var(--c-waste);background:rgba(255,95,95,.08);border:1px solid rgba(255,95,95,.35);border-radius:8px;line-height:1.5;text-wrap:pretty;"></div></div>';
         })() +
         '<div style="margin-top:var(--s-4);padding-top:var(--s-3);border-top:1px solid var(--c-border);font-size:14px;color:var(--c-text-dim);line-height:1.7;text-wrap:pretty;">' +
-          'Your usage is measured. The window comparison and the routing dollars are estimated: ' + esc(rw.proxy) + ' ' +
-          'Per-window dollars reuse the metered savings ledger (context tokens never sent, priced at input rates) plus an estimated model-routing counterfactual; they are not derived from the throughput multipliers. The &asymp;' + rw.extra_work_pct + '% is a separate per-token throughput multiplier, not a sum of the per-window figures.' +
+          // rw.proxy is now the single source of the measured-vs-estimated boundary
+          // AND the ledger detail (deduped: this used to repeat the ledger sentence
+          // and re-state "usage is measured"). We add only the one fact proxy can't
+          // carry -- the throughput-% is its own unit, not a sum of the dollars --
+          // because it needs the live JS value.
+          esc(rw.proxy) + ' ' +
+          'The &asymp;' + rw.extra_work_pct + '% is a separate per-token throughput multiplier, not a sum of the per-window dollar figures.' +
         '</div>' +
       '</div>';
     }

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -28664,6 +28664,39 @@ _RESUME_INTENT_RE = re.compile(
 # session") so we fall back to the most-recent same-project checkpoint.
 _RESUME_NAMED_TOPIC_BAR = _float_env("TOKEN_OPTIMIZER_RESUME_TOPIC_BAR", 0.22)
 
+# Staleness cap for the VAGUE-continue fallback (GitHub #129): when the prompt
+# names no distinguishing topic we may only surface the most-recent same-project
+# checkpoint if it is fresher than this. Beyond it, blindly reopening whichever
+# sibling session was last active in the same folder is how an UNRELATED session's
+# checkpoint gets injected -- so we return nothing instead of guessing. The
+# keyword-winner path (topic named) is NOT capped; only the recency fallback is.
+_RESUME_RECENCY_CAP_MIN = _int_env("TOKEN_OPTIMIZER_RESUME_RECENCY_MIN", 480)
+
+# A session id named IN the prompt ("continue session 328c85e9", full UUID, or
+# "session id: <uuid>"). Two shapes: an 8-40 hex run (or full 8-4-4-4-12 UUID)
+# that immediately follows the word "session" (optionally "id"), OR a bare full
+# UUID anywhere. A bare short hex token NOT after "session" is deliberately NOT
+# matched, so ordinary hex words in the prompt aren't mistaken for a session id.
+# The "session" branch is listed first and captures a full UUID greedily so
+# "...session <uuid>" yields the whole id, not just its first 8-hex chunk.
+_UUID_RE_SRC = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+_PROMPT_SESSION_ID_RE = re.compile(
+    r"\bsession(?:[\s_-]*id)?[\s:#]+(" + _UUID_RE_SRC + r"|[0-9a-f]{8,40})\b"
+    r"|\b(" + _UUID_RE_SRC + r")\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_session_id_from_prompt(text):
+    """Return a session id token the user named in the prompt, or None.
+
+    Group 1 = id after "session"; group 2 = a bare full UUID. Lowercased so it
+    matches sanitize_session_id output. Never raises."""
+    m = _PROMPT_SESSION_ID_RE.search(str(text or ""))
+    if not m:
+        return None
+    return (m.group(1) or m.group(2)).lower()
+
 
 def _resume_intent(text):
     """True when the prompt asks to continue/recall prior work."""
@@ -28968,12 +29001,50 @@ def _continuity_resume_block(text, checkpoints, sid_safe, cwd):
     reconstruction of the right same-project session, or "" to fall through to
     the lightweight hint.
 
-    Selection ("both"): keyword winner when the prompt names a topic
-    (best same-project score >= _RESUME_NAMED_TOPIC_BAR), else the most-recent
-    same-project session. Token-free: reuses build_lean_resume_context.
+    Selection order (GitHub #129): (1) a session id NAMED in the prompt wins and
+    is scoped strictly to that session -- never silently substituted; (2) else the
+    keyword winner when the prompt names a topic (best same-project score >=
+    _RESUME_NAMED_TOPIC_BAR); (3) else the most-recent same-project session, but
+    ONLY if fresher than _RESUME_RECENCY_CAP_MIN -- otherwise "" (blindly reopening
+    the last-active sibling in the folder is how an UNRELATED session leaks in).
+    A topic/recency guess carries the CONDITIONAL footer; an explicitly named
+    session carries the confident one. Token-free: reuses build_lean_resume_context.
     """
     if not cwd:
         return ""
+
+    # (1) Explicit session id in the prompt -> scope strictly to it. Honor it
+    # exactly and never fall back to a different session; if no on-disk checkpoint
+    # matches, return "" rather than silently substituting an unrelated one (#129).
+    named_id = _extract_session_id_from_prompt(text)
+    if named_id:
+        for cp in checkpoints:
+            fn = cp.get("filename", "")
+            if sid_safe and sid_safe in fn:
+                continue  # same-session recovery is SessionStart/compact's job
+            if fn.lower().startswith(named_id):
+                # Reconstruct the session whose FILENAME the named id matched, using the
+                # filename-derived id -- NOT _checkpoint_session_id, which prefers a
+                # sidecar session_id that, if it disagreed with the filename, would
+                # confidently reopen a DIFFERENT session (the #129 harm via another
+                # trigger). The user named this id, so a match warrants confident wording.
+                m = re.match(r"([0-9a-fA-F-]{8,})-\d{8}-\d{6}-", fn)
+                cp_sid = m.group(1) if m else None
+                if not cp_sid:
+                    continue
+                block = build_lean_resume_context(cp_sid, prompt_text=text, cwd=cwd,
+                                                  footer_mode="confident")
+                if block:
+                    _log_resume_lean_savings(cp_sid, block)
+                    return block
+        # No checkpoint matches the named id. If the id was the WHOLE ask (no separate
+        # resume verb) never substitute a different session -- return "" (#129). But when
+        # the prompt independently asks to resume ("continue the auth refactor ... the
+        # failing test references session a1b2c3d4"), the id is incidental, so fall
+        # through to the topic/recency selection below instead of suppressing a good match.
+        if not _resume_intent(text):
+            return ""
+
     same_project = []
     for cp in checkpoints[:50]:
         if sid_safe and sid_safe in cp.get("filename", ""):
@@ -28988,13 +29059,17 @@ def _continuity_resume_block(text, checkpoints, sid_safe, cwd):
 
     best_score = max(s for s, _, _ in same_project)
     if best_score >= _RESUME_NAMED_TOPIC_BAR:
-        # Named a topic -> keyword winner (recency breaks ties).
+        # (2) Named a topic -> keyword winner (recency breaks ties).
         same_project.sort(key=lambda x: (x[0], x[1]["created"].timestamp()), reverse=True)
         chosen = same_project[0]
     else:
-        # Vague "continue last session" -> most-recent same-project (list is
-        # already recency-sorted by list_checkpoints).
+        # (3) Vague "continue last session" -> most-recent same-project, but only
+        # if fresh. A stale freshest pick is almost certainly an unrelated sibling
+        # session (GitHub #129), so decline rather than guess.
         chosen = max(same_project, key=lambda x: x[1]["created"].timestamp())
+        age_min = (datetime.now() - chosen[1]["created"]).total_seconds() / 60
+        if age_min > _RESUME_RECENCY_CAP_MIN:
+            return ""
 
     _, cp, sidecar = chosen
     sid = sidecar.get("session_id") if isinstance(sidecar, dict) else None
@@ -29003,7 +29078,9 @@ def _continuity_resume_block(text, checkpoints, sid_safe, cwd):
         sid = m.group(1) if m else None
     if not sid:
         return ""
-    block = build_lean_resume_context(sid, prompt_text=text, cwd=cwd)
+    # Topic/recency match is a best guess -> CONDITIONAL footer so the assistant
+    # verifies against the user's actual request before claiming a reopen (#129).
+    block = build_lean_resume_context(sid, prompt_text=text, cwd=cwd, footer_mode="conditional")
     if block:
         # Count the cold-resume cost this lean reconstruction avoided (idempotent
         # per target session). Token-free; never blocks the injection.
@@ -29060,7 +29137,11 @@ def _continuity_prompt_hint(prompt_text="", session_id=None, cwd=None, max_age_m
     sid_safe = sanitize_session_id(session_id) if session_id else None
 
     # Deliberate "continue prior work" path: full lean reconstruction, same project.
-    if _resume_intent(text):
+    # An explicit session id named in the prompt ("continue session <id>", "resume
+    # session <id>") is its own resume cue: _RESUME_INTENT_RE's verb list does not
+    # include "session", so without this the strict id-scoped branch (#129 Fix 3)
+    # would never fire for the exact phrasing a user types to name a session.
+    if _resume_intent(text) or _extract_session_id_from_prompt(text):
         try:
             block = _continuity_resume_block(text, checkpoints, sid_safe, cwd)
         except Exception:
@@ -29489,7 +29570,8 @@ def _lean_list(items, n, width=140, keep_tokens=None):
     return cleaned
 
 
-def build_lean_resume_context(session_id, max_chars=3500, prompt_text=None, cwd=None):
+def build_lean_resume_context(session_id, max_chars=3500, prompt_text=None, cwd=None,
+                              footer_mode="confident"):
     """Reconstruct a LEAN, paste-ready context block for a cold session.
 
     Faithful tier (checkpoint present): active task, continuation/handover, open
@@ -29644,11 +29726,24 @@ def build_lean_resume_context(session_id, max_chars=3500, prompt_text=None, cwd=
             except (json.JSONDecodeError, ValueError, TypeError):
                 pass
 
-    footer = [
-        "Use this to re-orient a fresh session on the prior work. Tell the user "
-        "you reopened the cold session (mention its date/topic) so the recovery "
-        "is transparent.",
-    ]
+    if footer_mode == "conditional":
+        # Auto-injected best-guess match (#129): the plugin GUESSED which prior
+        # session the user meant, so the assistant must verify before claiming a
+        # reopen. Mirrors the lightweight-hint / compact_restore wording.
+        footer = [
+            "Use this only if it matches the user's current request. If you do use "
+            "it, briefly tell the user you found a relevant prior session (mention "
+            "its date/topic) so the recovery is transparent, not silent. If it does "
+            "not match what you are working on now, ignore it silently.",
+        ]
+    else:
+        # Confident path: the caller named this exact session (CLI --resume-lean, or
+        # an explicit session id in the prompt), so a reopen claim is warranted.
+        footer = [
+            "Use this to re-orient a fresh session on the prior work. Tell the user "
+            "you reopened the cold session (mention its date/topic) so the recovery "
+            "is transparent.",
+        ]
 
     # Assemble within the char budget: header + as many body lines as fit + footer.
     out = list(header)
@@ -33673,13 +33768,18 @@ def runway_snapshot(days=30, now=None):
             "meter_age_s": meters.get("age_s"),
             "meter_ts": meters.get("ts"),
             "meter_stale": meter_stale,
-            "proxy": ("Model weighting inside the provider's rate-limit windows is "
-                      "not published; public input-rate ratios are used as a "
-                      "stand-in. Window state is measured, the counterfactual is "
-                      "estimated. Per-window dollars reuse the metered savings "
-                      "ledger (context tokens never sent, priced at input rates, "
-                      "plus an estimated model-routing counterfactual) and are not "
-                      "derived from the throughput multipliers."),
+            # Single authoritative methodology note (GitHub: dashboard wall-of-text
+            # fix). Folds the measured-vs-estimated boundary in here so the HTML no
+            # longer repeats it. Keep the phrases "metered savings ledger" and "not
+            # derived from the throughput multipliers" -- guarded by
+            # test_proxy_disclosure_mentions_ledger_reuse.
+            "proxy": ("Your window usage is measured; the “without” "
+                      "comparison and routing dollars are estimated (the provider "
+                      "does not publish how it weights models inside a window, so "
+                      "public input-rate ratios stand in). Per-window dollars reuse "
+                      "the metered savings ledger (context tokens never sent, priced "
+                      "at input rates, plus a routing estimate) and are not derived "
+                      "from the throughput multipliers."),
         }
     except Exception:
         return None

--- a/tests/test_129_cold_resume_safety.py
+++ b/tests/test_129_cold_resume_safety.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""GitHub #129 — cold-resume-lean must not inject an UNRELATED session's
+checkpoint with an unconditional "tell the user you reopened it" instruction.
+
+Three fixes, one test file:
+  1. build_lean_resume_context grows a ``footer_mode`` arg. The auto-inject path
+     (_continuity_resume_block) passes "conditional" so the assistant VERIFIES the
+     match before claiming a reopen; the explicit/CLI path stays "confident".
+  2. _continuity_resume_block's vague-continue fallback (no topic named) only
+     surfaces the most-recent same-project checkpoint when it is fresher than
+     _RESUME_RECENCY_CAP_MIN; a stale freshest pick is declined ("" ) instead of
+     blindly reopening whichever sibling session was last active in the folder.
+  3. A session id NAMED in the prompt ("continue session <id>", full UUID) is
+     honored strictly and never silently substituted; an id with no on-disk
+     checkpoint returns "" rather than a different session.
+
+Selection logic is exercised by calling _continuity_resume_block directly, which
+bypasses the resume-intent gate and takes the checkpoint list explicitly.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+
+_UUID_A = "328c85e9-ada2-4bc7-8d0e-c7d03ff1313b"
+_UUID_B = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+
+
+@pytest.fixture
+def measure(monkeypatch):
+    tmp = tempfile.mkdtemp(prefix="to-129-test-")
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", tmp)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", tmp)
+    sys.path.insert(0, str(SCRIPTS))
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    importlib.reload(mod)
+    cp_dir = Path(tmp) / "checkpoints"
+    cp_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(mod, "CHECKPOINT_DIR", cp_dir, raising=True)
+    monkeypatch.setattr(mod, "TRENDS_DB", Path(tmp) / "trends.db", raising=True)
+    # Isolate the selection logic: no savings-ledger writes, always in-project.
+    monkeypatch.setattr(mod, "_log_resume_lean_savings", lambda *a, **k: None, raising=True)
+    monkeypatch.setattr(mod, "_checkpoint_in_project", lambda sc, cwd: True, raising=True)
+    yield mod, cp_dir
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+def _sidecar(sid, task="work on the widget"):
+    return {
+        "session_id": sid,
+        "active_task": task,
+        "continuation": "left off mid-refactor",
+        "decisions": ["Chose approach X"],
+        "modified_files": [{"path": "/home/u/proj/src/widget.py"}],
+        "recent_reads": ["/home/u/proj/README.md"],
+        "git": {"branch": "main", "sha": "abc123"},
+    }
+
+
+def _write_checkpoint(cp_dir, sid, sidecar, age_minutes=0):
+    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
+    base = f"{sid}-{ts}-auto"
+    md = cp_dir / f"{base}.md"
+    md.write_text("# checkpoint\n", encoding="utf-8")
+    (cp_dir / f"{base}.json").write_text(json.dumps(sidecar), encoding="utf-8")
+    if age_minutes:
+        old = time.time() - age_minutes * 60
+        os.utime(md, (old, old))
+    return md
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — footer_mode wording
+# ---------------------------------------------------------------------------
+
+_CONFIDENT = "Tell the user you reopened the cold session"
+_CONDITIONAL = "Use this only if it matches the user's current request"
+
+
+def test_footer_default_is_confident(measure):
+    """Default (CLI --resume-lean, no footer_mode) keeps the confident wording."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A))
+    block = mod.build_lean_resume_context(_UUID_A)
+    assert _CONFIDENT in block
+    assert _CONDITIONAL not in block
+
+
+def test_footer_conditional_mode(measure):
+    """footer_mode='conditional' swaps to verify-before-claiming wording."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A))
+    block = mod.build_lean_resume_context(_UUID_A, footer_mode="conditional")
+    assert _CONDITIONAL in block
+    assert _CONFIDENT not in block
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — vague fallback is staleness-capped + conditional
+# ---------------------------------------------------------------------------
+
+def test_vague_fresh_uses_conditional_footer(measure, monkeypatch):
+    """Vague 'continue' + a FRESH same-project checkpoint: surfaced, but with the
+    conditional footer (the plugin guessed, so the assistant must verify)."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A), age_minutes=5)
+    monkeypatch.setattr(mod, "_resume_topic_score", lambda text, path: 0.0)  # below bar
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block("continue what we were doing", cps, None, "/home/u/proj")
+    assert block
+    assert _CONDITIONAL in block
+    assert _CONFIDENT not in block
+
+
+def test_vague_stale_is_declined(measure, monkeypatch):
+    """Vague 'continue' + a STALE freshest checkpoint (older than the recency cap):
+    declined entirely. This is the exact #129 harm — reopening whichever sibling
+    session was last active in the folder — so we inject NOTHING."""
+    mod, cp_dir = measure
+    stale = mod._RESUME_RECENCY_CAP_MIN + 120
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A), age_minutes=stale)
+    monkeypatch.setattr(mod, "_resume_topic_score", lambda text, path: 0.0)  # below bar
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block("continue what we were doing", cps, None, "/home/u/proj")
+    assert block == ""
+
+
+def test_named_topic_uses_conditional_footer(measure, monkeypatch):
+    """Even the keyword-winner (topic named, score >= bar) is a best guess, so it
+    also carries the conditional footer."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A), age_minutes=5)
+    monkeypatch.setattr(mod, "_resume_topic_score", lambda text, path: 0.9)  # above bar
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block("continue the widget refactor", cps, None, "/home/u/proj")
+    assert block
+    assert _CONDITIONAL in block
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — explicit session id in the prompt is honored strictly
+# ---------------------------------------------------------------------------
+
+def test_extract_session_id_from_prompt(measure):
+    mod, _ = measure
+    f = mod._extract_session_id_from_prompt
+    assert f(f"continue the work of session {_UUID_A}") == _UUID_A
+    assert f("resume session 328c85e9") == "328c85e9"
+    assert f("session id: deadbeefcafe1234") == "deadbeefcafe1234"
+    # No id-shaped token -> None. A bare hex-ish word NOT after 'session' is ignored.
+    assert f("continue what we were doing") is None
+    assert f("refactor the deadbeef module") is None
+
+
+def test_explicit_id_scopes_strictly(measure, monkeypatch):
+    """Prompt names session A explicitly while B is the FRESHER sibling. The named
+    id wins (not recency), and it gets the confident footer (user named it)."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A, "the alpha task"), age_minutes=200)
+    _write_checkpoint(cp_dir, _UUID_B, _sidecar(_UUID_B, "the beta task"), age_minutes=1)
+    # Would-be recency winner is B; explicit id must override that.
+    monkeypatch.setattr(mod, "_resume_topic_score", lambda text, path: 0.0)
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block(
+        f"continue session {_UUID_A}", cps, None, "/home/u/proj")
+    assert "the alpha task" in block
+    assert "the beta task" not in block
+    assert _CONFIDENT in block  # explicitly named -> confident reopen is warranted
+
+
+def test_explicit_id_no_match_returns_empty(measure, monkeypatch):
+    """Naming an id with no on-disk checkpoint returns "" — never substitutes a
+    different session (the core #129 guarantee)."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_B, _sidecar(_UUID_B, "the beta task"), age_minutes=1)
+    monkeypatch.setattr(mod, "_resume_topic_score", lambda text, path: 0.0)
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block(
+        "continue session ffffffffffff", cps, None, "/home/u/proj")
+    assert block == ""
+
+
+# ---------------------------------------------------------------------------
+# CE review follow-ups (P1/P2/P3): drive the REAL hook path, not the internal fn
+# ---------------------------------------------------------------------------
+
+def test_hook_path_explicit_id_triggers_without_resume_verb(measure):
+    """P1: the real hook entry (_continuity_prompt_hint) must reach the strict
+    explicit-id branch for 'continue session <id>' even though _resume_intent
+    rejects that phrasing. The gate now also fires on a named id."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A, "the alpha task"), age_minutes=5)
+    # The phrasing genuinely does NOT trip _resume_intent, so only the id-gate can fire it:
+    assert mod._resume_intent(f"continue session {_UUID_A}") is False
+    hint = mod._continuity_prompt_hint(
+        prompt_text=f"continue session {_UUID_A}",
+        session_id=_UUID_B,          # a different current session
+        cwd="/home/u/proj")
+    assert "the alpha task" in hint
+    assert _CONFIDENT in hint        # explicitly named -> confident reopen warranted
+
+
+def test_incidental_id_falls_through_to_topic(measure, monkeypatch):
+    """P2: resume_intent True + an incidental id matching NO checkpoint must NOT
+    suppress the good topic match -- it falls through to topic/recency."""
+    mod, cp_dir = measure
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_A, "the widget refactor"), age_minutes=5)
+    monkeypatch.setattr(mod, "_resume_topic_score", lambda text, path: 0.9)  # topic match
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block(
+        "continue the widget refactor; see session ffffffffffff",
+        cps, None, "/home/u/proj")
+    assert "the widget refactor" in block   # topic match surfaced, not suppressed by the id
+    assert _CONDITIONAL in block            # topic guess -> conditional footer
+
+
+def test_explicit_id_uses_filename_not_sidecar(measure):
+    """P3: when a checkpoint's sidecar session_id DISAGREES with its filename, the
+    explicit-id match reconstructs the FILENAME's session (the one the user named),
+    not the sidecar's -- else it could confidently reopen a different session."""
+    mod, cp_dir = measure
+    # filename carries _UUID_A; sidecar lies that it is _UUID_B
+    _write_checkpoint(cp_dir, _UUID_A, _sidecar(_UUID_B, "the alpha task"), age_minutes=5)
+    cps = mod.list_checkpoints()
+    block = mod._continuity_resume_block(
+        f"continue session {_UUID_A}", cps, None, "/home/u/proj")
+    # Reconstructed via the filename id (_UUID_A) -> finds the file -> renders its task.
+    # Had it used the sidecar id (_UUID_B), _best_checkpoint_for_session(_UUID_B) would
+    # find no file and return "".
+    assert "the alpha task" in block
+    assert _CONFIDENT in block


### PR DESCRIPTION
## What

Two safe, reviewed fixes:

### 1. Fix #129 — cold-resume no longer injects an unrelated session's checkpoint
The `prompt-continuity` UserPromptSubmit hook could reconstruct a **different** session's checkpoint (whichever sibling was last active in the same project dir) and tell the assistant, unconditionally, to claim it "reopened" that session. Reproduced live: a fresh session opened with an injected checkpoint from an unrelated `/reload-plugins` cleanup session.

Three changes in `measure.py`:
- **Conditional footer.** `build_lean_resume_context` gains `footer_mode`. The auto-inject path (a *guess*) now uses verify-before-claiming wording mirroring the lightweight-hint/`compact_restore` branches; the CLI `--resume-lean` and explicit-id paths stay confident.
- **Staleness-capped recency.** The vague-"continue" fallback only surfaces the freshest same-project checkpoint when it is newer than `TOKEN_OPTIMIZER_RESUME_RECENCY_MIN` (default 480 min); otherwise it declines (`""`) rather than blindly reopening a stale sibling.
- **Explicit session id honored.** A session id named in the prompt ("continue session `<id>`", full UUID) is scoped strictly to that session and never substituted; the resume-intent gate now also fires on a named id (it previously rejected the exact phrasing), and the match resolves by filename (not a possibly-disagreeing sidecar id).

### 2. Dashboard: dedupe the methodology wall-of-text
The savings-card footnote rendered the "Per-window dollars reuse the metered savings ledger…" sentence **twice** (once from `rw.proxy`, once hardcoded in the HTML) plus a redundant "usage is measured" prefix. Consolidated into a single authoritative note; the HTML now adds only the one live-value fact it must.

## Tests
- New `tests/test_129_cold_resume_safety.py`: 11 tests covering footer routing, the staleness cap, explicit-id scoping, and (per code review) the **real hook path** for "continue session `<id>`", incidental-id fall-through, and filename-vs-sidecar resolution.
- Full suite: **1188 passed, 13 skipped**.

## Review
- Sol (Codex, cross-model adversarial): no findings.
- CE correctness lens: caught that the explicit-id branch was gated behind a resume-intent regex that rejected its own phrasings (fixed; regression-tested through the real hook entry).
- Not in scope (separate change per plan): dashboard auto-regen, stuck-session hook latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
