### PR TITLE
fix(statusline): reflow segments to new lines on narrow terminals

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/statusline.js
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/statusline.js
@@ -262,7 +262,19 @@ process.stdin.on('end', () => {
     }
 
     const dirname = path.basename(dir);
-    const row1 = `${DIM}${model}${RESET}${effort}${SEP}${DIM}${dirname}${RESET}${branch}${ctx}${qScore}`;
+    // Row 1 as BARE segments (no baked-in SEP) so a narrow terminal can reflow them
+    // across physical rows instead of the host clipping the overflow. The effort/
+    // branch/ctx/qScore builders each prepend SEP, so strip that leading separator;
+    // packRows re-inserts it between whatever segments land on the same row.
+    const _stripLeadSep = s => (s && s.startsWith(SEP) ? s.slice(SEP.length) : s);
+    const row1Segs = [
+      `${DIM}${model}${RESET}`,
+      _stripLeadSep(effort),
+      `${DIM}${dirname}${RESET}`,
+      _stripLeadSep(branch),
+      _stripLeadSep(ctx),
+      _stripLeadSep(qScore),
+    ].filter(Boolean);
 
     // ---- ROW 2: Session details ----
     const row2Parts = [];
@@ -369,8 +381,30 @@ process.stdin.on('end', () => {
       row2Parts.push(`${DIM}7d:${p}%${RESET}`);
     }
 
-    const row2 = row2Parts.join(SEP);
-    process.stdout.write(`${row1}\n${row2}`);
+    // Responsive layout: when Claude Code exports COLUMNS (v2.1.153+), greedily pack
+    // each row's segments into physical rows no wider than the terminal, so narrow
+    // windows drop segments to the next line instead of the host clipping them.
+    // COLUMNS unset (older Claude Code) -> the exact prior two-row output, byte-for-byte.
+    const vlen = s => stripAnsi(s).length;   // visible width; SEP (" | ") is 3 cols
+    const packRows = (segs, width) => {
+      const rows = [];
+      let cur = '';
+      for (const seg of segs) {
+        if (cur === '') { cur = seg; continue; }
+        if (vlen(cur) + 3 + vlen(seg) <= width) cur += SEP + seg;
+        else { rows.push(cur); cur = seg; }   // a lone over-wide segment still clips (unsplittable)
+      }
+      if (cur !== '') rows.push(cur);
+      return rows;
+    };
+    const _cols = parseInt(process.env.COLUMNS, 10);
+    const _width = Number.isFinite(_cols) && _cols > 4 ? _cols : null;
+    if (_width) {
+      const rows = [...packRows(row1Segs, _width), ...packRows(row2Parts, _width)];
+      process.stdout.write(rows.join('\n'));
+    } else {
+      process.stdout.write(`${row1Segs.join(SEP)}\n${row2Parts.join(SEP)}`);
+    }
   } catch (e) {
     // Silent fail - never break the status line
   }

--- a/skills/token-optimizer/scripts/statusline.js
+++ b/skills/token-optimizer/scripts/statusline.js
@@ -262,7 +262,19 @@ process.stdin.on('end', () => {
     }
 
     const dirname = path.basename(dir);
-    const row1 = `${DIM}${model}${RESET}${effort}${SEP}${DIM}${dirname}${RESET}${branch}${ctx}${qScore}`;
+    // Row 1 as BARE segments (no baked-in SEP) so a narrow terminal can reflow them
+    // across physical rows instead of the host clipping the overflow. The effort/
+    // branch/ctx/qScore builders each prepend SEP, so strip that leading separator;
+    // packRows re-inserts it between whatever segments land on the same row.
+    const _stripLeadSep = s => (s && s.startsWith(SEP) ? s.slice(SEP.length) : s);
+    const row1Segs = [
+      `${DIM}${model}${RESET}`,
+      _stripLeadSep(effort),
+      `${DIM}${dirname}${RESET}`,
+      _stripLeadSep(branch),
+      _stripLeadSep(ctx),
+      _stripLeadSep(qScore),
+    ].filter(Boolean);
 
     // ---- ROW 2: Session details ----
     const row2Parts = [];
@@ -369,8 +381,30 @@ process.stdin.on('end', () => {
       row2Parts.push(`${DIM}7d:${p}%${RESET}`);
     }
 
-    const row2 = row2Parts.join(SEP);
-    process.stdout.write(`${row1}\n${row2}`);
+    // Responsive layout: when Claude Code exports COLUMNS (v2.1.153+), greedily pack
+    // each row's segments into physical rows no wider than the terminal, so narrow
+    // windows drop segments to the next line instead of the host clipping them.
+    // COLUMNS unset (older Claude Code) -> the exact prior two-row output, byte-for-byte.
+    const vlen = s => stripAnsi(s).length;   // visible width; SEP (" | ") is 3 cols
+    const packRows = (segs, width) => {
+      const rows = [];
+      let cur = '';
+      for (const seg of segs) {
+        if (cur === '') { cur = seg; continue; }
+        if (vlen(cur) + 3 + vlen(seg) <= width) cur += SEP + seg;
+        else { rows.push(cur); cur = seg; }   // a lone over-wide segment still clips (unsplittable)
+      }
+      if (cur !== '') rows.push(cur);
+      return rows;
+    };
+    const _cols = parseInt(process.env.COLUMNS, 10);
+    const _width = Number.isFinite(_cols) && _cols > 4 ? _cols : null;
+    if (_width) {
+      const rows = [...packRows(row1Segs, _width), ...packRows(row2Parts, _width)];
+      process.stdout.write(rows.join('\n'));
+    } else {
+      process.stdout.write(`${row1Segs.join(SEP)}\n${row2Parts.join(SEP)}`);
+    }
   } catch (e) {
     // Silent fail - never break the status line
   }

--- a/tests/test_statusline_wrap.py
+++ b/tests/test_statusline_wrap.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Statusline responsive wrap (Alex request): narrowing the terminal must reflow
+segments onto new physical rows instead of the host clipping the overflow. Width
+comes from the COLUMNS env var (Claude Code v2.1.153+ exports it, live on resize).
+When COLUMNS is unset (older Claude Code), output stays byte-identical to the prior
+two-row form -- no regression.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+STATUSLINE = REPO / "skills" / "token-optimizer" / "scripts" / "statusline.js"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(
+    NODE is None or not STATUSLINE.exists(), reason="node or statusline.js unavailable"
+)
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _vlen(s):
+    return len(_ANSI.sub("", s))
+
+
+def _run(payload, cols=None):
+    env = dict(os.environ)
+    env.pop("COLUMNS", None)
+    if cols is not None:
+        env["COLUMNS"] = str(cols)
+    p = subprocess.run(
+        [NODE, str(STATUSLINE)], input=json.dumps(payload),
+        capture_output=True, text=True, env=env, timeout=15,
+    )
+    return p.stdout
+
+
+PAYLOAD = {
+    "model": {"display_name": "Opus 4.8"},
+    "workspace": {"current_dir": str(REPO)},
+    "session_id": "abc123",
+    "context_window": {"used_percentage": 42},
+}
+
+
+def test_narrow_window_reflows_and_no_packed_line_over_budget():
+    """At 40 cols the two logical rows reflow to >=3 physical rows, and no line that
+    packed multiple segments exceeds the budget. A lone unsplittable segment (no
+    SEP inside) may exceed -- the host clips that one, nothing can wrap inside it."""
+    lines = _run(PAYLOAD, cols=40).split("\n")
+    assert len(lines) >= 3, f"expected reflow to >=3 rows at 40 cols, got {len(lines)}: {lines!r}"
+    for ln in lines:
+        if _vlen(ln) > 40:
+            # allowed only if it is a single segment (no ' | ' separator inside)
+            assert " | " not in _ANSI.sub("", ln), f"packed line over 40 cols: {ln!r}"
+
+
+def test_narrow_wraps_more_than_wide():
+    narrow = _run(PAYLOAD, cols=40).split("\n")
+    wide = _run(PAYLOAD, cols=200).split("\n")
+    assert len(narrow) > len(wide)
+
+
+def test_wide_window_stays_two_rows():
+    assert len(_run(PAYLOAD, cols=200).split("\n")) == 2
+
+
+def test_columns_unset_is_backcompat_two_rows():
+    """COLUMNS unset -> exactly two rows, and byte-identical to the wide-fallback
+    shape (row1Segs.join(SEP) + '\\n' + row2Parts.join(SEP))."""
+    unset = _run(PAYLOAD, cols=None)
+    assert len(unset.split("\n")) == 2
+    # a very wide window packs each row to a single line, i.e. the same join the
+    # unset fallback produces -> they must match byte-for-byte.
+    assert unset == _run(PAYLOAD, cols=500)
+
+
+def test_every_line_ends_reset_no_color_bleed():
+    """Each emitted physical row must terminate its own color so nothing bleeds
+    into the host shell after the status line."""
+    for cols in (40, 200, None):
+        out = _run(PAYLOAD, cols=cols)
+        for ln in out.split("\n"):
+            if _ANSI.search(ln):  # only lines that opened a color must close it
+                assert ln.endswith("\x1b[0m") or "\x1b[0m" in ln, f"unreset line: {ln!r}"


### PR DESCRIPTION
Narrowing the terminal clipped trailing status-line segments (context bar, ContextQ, agents, limits) instead of dropping them to a new line, so you needed a wide window to see the session-quality score.

**Fix:** read the `COLUMNS` env var (Claude Code v2.1.153+, live on resize), collect each row as bare segments, and greedily pack them into physical rows no wider than the terminal. `COLUMNS` unset (older Claude Code) → byte-identical two-row output, no regression. Pure string ops, no new spawns.

**Tests:** `tests/test_statusline_wrap.py` — narrow reflow (no packed line over budget), narrow>wide row count, wide stays 2 rows, COLUMNS-unset back-compat, no ANSI bleed. 5 new + 33 existing statusline tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)