### PR TITLE
docs: add Korean, Chinese, and Japanese READMEs with language nav

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,687 @@
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <b>日本語</b>
+</p>
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/logo.svg" alt="Token Optimizer" width="780">
+</p>
+
+<p align="center">
+  <a href="https://github.com/alexgreensh/token-optimizer/releases/latest"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=version&color=green" alt="最新安定バージョン"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/commits/main"><img src="https://badgen.net/github/last-commit/alexgreensh/token-optimizer?label=last%20commit" alt="最終コミット"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer"><img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet" alt="Claude Code Plugin"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/openclaw"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2Fopenclaw%2Fpackage.json&query=%24.version&prefix=v&label=OpenClaw&color=brightgreen" alt="OpenClaw バージョン"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/opencode"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2Fopencode%2Fpackage.json&query=%24.version&prefix=v&label=OpenCode&color=58a6ff" alt="OpenCode バージョン"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/docs/codex.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.codex-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Codex&color=orange" alt="Codex バージョン"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/hermes"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Hermes&color=0d9488" alt="Hermes バージョン"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/docs/copilot.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Copilot&color=6e40c9&logo=githubcopilot&logoColor=white" alt="GitHub Copilot バージョン"></a>
+</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/cuts%20context%20waste-3fb950" alt="コンテキストの無駄を削減">
+  <img src="https://img.shields.io/badge/survives%20compaction-checkpoint%20%2B%20restore-58a6ff" alt="圧縮を生き残る">
+  <img src="https://img.shields.io/badge/saves%20real%20%24-every%20session-2ea043" alt="毎セッション実際のドルを節約">
+  <img src="https://img.shields.io/badge/live%20dashboard-tokens%20%2B%20%24%20%2B%20turns-8B5CF6?logo=chartdotjs&logoColor=white" alt="ライブダッシュボード">
+  <img src="https://img.shields.io/badge/context%20quality-live%20score-blue" alt="ライブコンテキスト品質スコア">
+  <img src="https://img.shields.io/badge/tests-passing-brightgreen" alt="テスト合格">
+</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="依存関係ゼロ">
+  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="テレメトリゼロ">
+  <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9+">
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="プラットフォーム">
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="ライセンス: PolyForm Noncommercial"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/stargazers"><img src="https://badgen.net/github/stars/alexgreensh/token-optimizer" alt="GitHub Stars"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/commits/main"><img src="https://badgen.net/github/commits/alexgreensh/token-optimizer?label=commits" alt="コミット"></a>
+  <a href="https://linkedin.com/in/alexgreensh"><img src="https://img.shields.io/badge/LinkedIn-Connect-0A66C2?logo=linkedin&logoColor=white" alt="LinkedInでつながる"></a>
+</p>
+<p align="center">
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/%E2%99%A5%20Support%20this%20project%20to%20keep%20it%20open%20source-ea4aaa?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="このプロジェクトをオープンソースに保つために支援する"></a>
+</p>
+
+<h2 align="center">無駄にしているトークンを削る。失うはずだった仕事を残す。</h2>
+
+<p align="center"><em>バックグラウンドで自動的に動きます。いつも通り作業を続けてください。全体像が欲しいときに監査を実行します。</em></p>
+
+<p align="center">
+  <a href="https://alexgreensh.github.io/token-optimizer/"><img src="https://img.shields.io/badge/%F0%9F%93%96%20Read%20the%20Docs-alexgreensh.github.io%2Ftoken--optimizer-e85329?style=for-the-badge&logoColor=white" alt="ドキュメントを読む"></a>
+  <a href="https://alexgreensh.github.io/token-optimizer/start/quickstart/"><img src="https://img.shields.io/badge/Quickstart-2%20minutes-3fb950?style=for-the-badge" alt="2分のクイックスタート"></a>
+</p>
+
+## 30秒バージョン
+
+Token Optimizerは、AIコーディングアシスタントが無駄にするトークンを削り、セッションと圧縮(compaction)をまたいで仕事を生かし、毎ドルがどこに行ったかをライブダッシュボードで示します。**ほとんどは自動で動きます。インストールして監査を一度実行すれば、あとはフックが処理します。**
+
+**なぜHeadroomやRTKで済ませないのか?** どちらもコマンド出力を圧縮しますが、それはコンテキストの15〜25%しかカバーしません。Token Optimizerはそれに加えて残り75%をカバーします:膨張した設定、未使用のスキル、古いメモリ、圧縮ロス、モデルの誤ルーティング、振る舞いの無駄。すべての節約はキャッシュセーフで測定されます。ダッシュボードは毎セッション後に自動更新されます。
+
+**Claude Code**(CLIとVS Code)、**OpenCode**、**OpenClaw**、**Codex**、**Hermes**、**GitHub Copilot**で動作します。WindsurfとCursorがロードマップの次です。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/hero-terminal.svg" alt="Token Optimizer クイックスキャン" width="800">
+</p>
+
+## インストール
+
+**Claude Code(推奨):**
+
+```
+/plugin marketplace add alexgreensh/token-optimizer
+/plugin install token-optimizer@alexgreensh-token-optimizer
+```
+
+その後Claude Codeで: `/token-optimizer`
+
+> **インストール後に自動更新を有効にしてください。** Claude Codeはサードパーティのマーケットプレースをデフォルトで自動更新オフで配布します。`/plugin` → **Marketplaces**タブ → `alexgreensh-token-optimizer`を選択 → **Enable auto-update**。一回限り、10秒です。
+>
+> インストール後、`/token-optimizer`を一度実行してフックを設定してください。それ以降はすべて自動で動きます:圧縮、チェックポイント、品質スコア、ダッシュボード更新。監査が欲しいとき以外、コマンドを再実行する必要はありません。
+
+<details>
+<summary><b>その他のプラットフォームとインストール方法</b></summary>
+
+**Codex:**
+```bash
+codex plugin marketplace add alexgreensh/token-optimizer
+```
+その後Codex TUIで: `/plugins`からToken Optimizerをインストール。[`docs/codex.md`](docs/codex.md)を参照。
+
+**OpenCode:** `opencode.json`の`plugin`配列に`token-optimizer-opencode`を追加:
+```jsonc
+{ "$schema": "https://opencode.ai/config.json", "plugin": ["token-optimizer-opencode"] }
+```
+[`opencode/README.md`](opencode/README.md)を参照。
+
+**OpenClaw:**
+```bash
+openclaw plugins install github:alexgreensh/token-optimizer
+```
+[`openclaw/README.md`](openclaw/README.md)を参照。
+
+**Hermes:**
+```bash
+git clone https://github.com/alexgreensh/token-optimizer.git
+token-optimizer/install.sh --hermes
+```
+[`hermes/README.md`](hermes/README.md)を参照。
+
+**GitHub Copilot:**
+```bash
+git clone --depth 1 https://github.com/alexgreensh/token-optimizer.git
+cd token-optimizer
+bash install.sh --copilot
+```
+[`docs/copilot.md`](docs/copilot.md)を参照。
+
+**macOS/Linuxスクリプトインストール(プラグインの代替):**
+```bash
+tmp="$(mktemp -d)"
+release_json="$(curl -fsSL https://api.github.com/repos/alexgreensh/token-optimizer/releases/latest)"
+tag="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])' <<<"$release_json")"
+git clone --branch "$tag" --depth 1 https://github.com/alexgreensh/token-optimizer.git ~/.claude/token-optimizer
+bash ~/.claude/token-optimizer/install.sh
+rm -rf "$tmp"
+```
+
+**Windowsユーザー:** プラグインインストールのみ使用してください。Windowsで`install.sh`を実行しないでください。`EBUSY`エラーが出たら、すべてのClaude CodeとGit Bashウィンドウを閉じ、残った`git.exe`プロセスをkillし、`C:\Users\<you>\.claude\token-optimizer`と`C:\Users\<you>\.claude\plugins\marketplaces\alexgreensh-token-optimizer`を削除してから再試行してください。
+
+**`install.sh`が`$'\r': command not found`で失敗する場合**(LF強制前に作られたクローンがスクリプトをCRLFに変換した)、キャリッジリターンを一度取り除いて再実行してください。リポジトリは新しいクローンでこれを防ぐ`.gitattributes`を同梱するようになりました:
+```bash
+sed -i 's/\r$//' ~/.claude/token-optimizer/install.sh
+# すでにリポジトリがある? 改行をその場で再正規化:
+git -C ~/.claude/token-optimizer add --renormalize . && git -C ~/.claude/token-optimizer checkout -- .
+```
+
+</details>
+
+<details>
+<summary>アンインストール</summary>
+
+Token Optimizerは付加的で可逆です。すべてのランタイムに、私たちがインストールしたものだけを削除し、あなた自身のフック、設定、セッションデータをそのまま残すクリーンなアンインストールがあります。ランタイム別の完全な手順は **[docs/uninstall.md](docs/uninstall.md)** にあります。
+
+最短経路(Claude Codeプラグインインストール):
+
+```
+/plugin uninstall token-optimizer@alexgreensh-token-optimizer
+```
+
+</details>
+
+## 何が得られるか
+
+**毎セッション自動で動き、あなたは何もしない:**
+
+- 🔄 **スマート圧縮(Smart Compaction)**: 自動圧縮前にチェックポイント、後に復元
+- 🗄️ **セッション継続性(Session Continuity)**: セッション間ヒント、コールドリジューム、チェックポイント採点
+- 📦 **アクティブ圧縮(Active Compression)**: 9機能、すべてデフォルトオン(delta diff、スケルトン、bash/検索圧縮、リーン出力ナッジ、品質ナッジ、ループ検出、アクティビティモード、意思決定抽出)
+- 📊 **品質スコアリング(Quality Scoring)**: 7シグナル、リアルタイム、S〜Fの文字等級
+- 🗃️ **セッションデータベース(Session Database)**: SQLite、15テーブル、完全な監査証跡、ゼロネットワーク
+- 🔍 **プログレッシブ開示(Progressive Disclosure)**: 大きな出力はアーカイブ、要求時に展開
+- 🧠 **コンテキストインテル要約(Context Intel Digest)**: 圧縮後の再読込なしの再位置づけ
+- 🔀 **モデルルーティングナッジ(Model Routing Nudges)**: タスクに合ったティアへ誘導
+
+**あなたが求めたとき:**
+
+- 🩺 `/token-optimizer`: ガイド付き修正を伴う完全監査
+- 📈 `/token-coach`: 具体的な修正を伴う30日トレンド分析
+- ⚡ `quick`: 10秒ヘルスチェック
+- 🎯 `route`: お金を使う前に、このタスクが実際に必要とするモデルとeffort
+- 🔧 `doctor`: インストールチェック
+- 💰 `savings`: ドル節約レポート
+- 📋 `report`: コンポーネント別トークン内訳
+- 🌐 `dashboard`: 完全ダッシュボードを開く
+- 📝 `memory-review`: MEMORY.md構造監査
+- 📂 `expand`: アーカイブされたツール結果を取得
+- 🔙 `resume-lean`: コールドセッションを再開
+
+インストールして`/token-optimizer`を一度実行すれば、あとはすべて自動で動きます。
+
+## 何が違うのか
+
+ほとんどのトークンツールはコマンド出力を圧縮します。それはコンテキストの15〜25%をカバーします。残り75%は手つかずです。
+
+**圧縮カバレッジ。** Headroom、RTK、JFrog Boostはbashとコマンド出力を圧縮します。Token Optimizerは出力スタックの8つの面を圧縮します。状態: 🟢 サポート、🟡 部分、🔴 非サポート。
+
+| 圧縮面 | Token Optimizer | Headroom | RTK | Boost |
+|---|---|---|---|---|
+| **Bash / コマンド出力**(git、テスト、lint、ビルド、ログ) | 🟢 22パターンファミリにわたる111コマンド、クレデンシャルセーフ;pytest実行で564 → 115トークン | 🟢 SmartCrusher、CodeCompressor、Kompress-v2 | 🟢 100以上のフィルタ | 🟢 コマンド認識フィルタ |
+| **検索 / grep出力** | 🟢 トップヒットとカウント;500行 → 20 | 🔴 | 🔴 | — |
+| **表形式 / JSON出力**(jq、yq、csvtool、mlr) | 🟢 値保存の列形式 | 🟢 SmartCrusher | 🔴 | — |
+| **ファイル再読込、deltaモード** | 🟢 diffのみ;2,000トークン再読込 → ~50 | 🔴 | 🔴 | — |
+| **ファイル再読込、構造マップ** | 🟢 シグネチャとimportのスケルトン;720KB → 250トークン | 🔴 | 🔴 | — |
+| **大きなツール結果**(4K文字超) | 🟢 ディスクにアーカイブ、要求時に展開可能 | 🔴 | 🔴 | — |
+| **モデル出力の冗長さ** | 🟢 リーン出力ナッジ、キャッシュセーフ(節約は推定、計測ではない) | 🔴 | 🔴 | 🔴 |
+| **構造的コンテキスト**(設定、スキル、MCP、メモリ) | 🟢 コンポーネント別監査、各ソースを採点 | 🔴 | 🔴 | 🔴 |
+
+RTKとBoostは最初の面に到達します。Headroomは最初と3番目に到達します。Token Optimizerは8つすべてをカバーし、圧縮の周りで何が起きるかへ進み続けます:
+
+- **1つではなく3種類の無駄。** 構造的(膨張した設定、未使用スキル、古いメモリ)、ランタイム(冗長な出力、再読込)、振る舞い(モデル誤ルーティング、キャッシュ期限、再試行ループ)。[それぞれの仕組み →](https://alexgreensh.github.io/token-optimizer/features/active-compression/)
+- **節約は圧縮を生き残る。** 自動圧縮前にチェックポイント、後に復元。これがないと、圧縮の節約は圧縮が発火した瞬間に消えます。
+- **役に立ったか測る。** 前後のトークン差分、4つの価格ティアにわたるドル節約、劣化を追跡する品質スコア。単なる「圧縮した」ではありません。
+- **ゼロのベースラインオーバーヘッド。** 外部プロセス、コンテキストに常時オンの指示なし、MCPサーバーなし、依存関係なし、テレメトリなし。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/automated-flow.svg" alt="Token Optimizerが毎セッション自動でどう動くか" width="900">
+</p>
+
+この10行は、Token Optimizerがその行で唯一🟢の行です: 圧縮を超えて生き残るもの、そしてどの圧縮器も探さない無駄。圧縮の仕組み、コストと安全性、そして私たちが負ける2行は折りたたみの後ろにあります。
+
+|  | Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
+|---|---|---|---|---|---|---|
+| 圧縮生き残り | 🟢 プログレッシブチェックポイント、復元、ツール出力要約 | 🔴 | 🔴 | — | 🟡 セッションガイドのみ | 🔴 |
+| セッション継続性 | 🟢 セッション間ヒント、コールドリジューム、チェックポイント採点 | 🔴 | 🔴 | — | 🟡 セッションガイド | 🔴 |
+| 構造的無駄の監査 | 🟢 コンポーネント別の深掘り(CLAUDE.md、スキル、MCP、メモリ) | 🔴 | 🔴 | 🔴 | 🔴 | 🟡 要約のみ |
+| CLAUDE.mdとMEMORY.mdの健康 | 🟢 8監査器 + アテンションカーブ採点 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 |
+| モデルルーティングと振る舞いのコーチング | 🟢 12検出器、サブエージェントコスト内訳、アンチパターン | 🔴 | 🔴 | — | 🔴 | 🟡 基本的な提案 |
+| 過去トレンド分析 | 🟢 30日トレンド、品質/コスト/キャッシュ/期間の相関、モデル切替検出 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| コンテキスト品質スコア | 🟢 等級付き7シグナル品質スコア | 🔴 | 🔴 | — | 🔴 | 🟡 容量%のみ |
+| ループと空転の検出 | 🟢 トークンを燃やす前に振る舞いループを捕捉 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 圧縮が役立ったか測定 | 🟢 ローカルテレメトリ、前後トークン、ドル節約 | 🔴 | 🟡 `rtk gain`(トークンカウントのみ) | 🟡 `boost report`、ベンダー側 | 🔴 | 🔴 |
+| フリートレベルのクロスエージェント分析 | 🟢 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+
+<details>
+<summary><b>残り13行を表示</b>(圧縮の仕組み; コスト、安全性と到達; チューニング、証明とインストール)</summary>
+
+|  | Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
+|---|---|---|---|---|---|---|
+| コマンド書き換え不要 | 🟢 フック接続、自動発火 | 🟢 透過プロキシ | 🟢 フックベースの書き換え | 🟢 `boost init`が対応エージェントを接続; ターミナル使用はプレフィックス可能 | 🟡 フック対応プラットフォームで自動 | N/A ネイティブコマンド |
+| 完全なオリジナルが復元可能 | 🟢 圧縮前に生をアーカイブ、`expand`で取得; 失敗は圧縮されない | 🟢 可逆な取得 | 🟡 コマンド失敗時に完全出力を保存 | 🟢 ベンダーがコマンド出力復元を文書化 | — | N/A 圧縮しない |
+| カスタムコマンドフィルタの登録 | 🔴 組み込みコマンドセット; ユーザーフィルタAPIなし | — | 🟢 カスタムTOMLフィルタ | 🟢 TOMLフィルタ | — | N/A |
+| ユーザー調整可能な設定 | 🟢 92のコード参照`TOKEN_OPTIMIZER_*`名、ユーザー向けと内部制御に明示分割; 追加的許可リスト; `.contextignore` | 🟢 文書化された設定 | 🟢 `config.toml`と環境制御 | 🟢 フィルタTOML | 🟢 文書化された設定 | N/A |
+| キャッシュセーフ | 🟢 既存のコンテキストプレフィックスを変更しない | 🟡 プロキシモードが進行中を書き換え | 🟢 pre-shellのみ | 🟢 pre-shellのみ | 🟡 MCPオーバーヘッド | 🟢 |
+| ゼロベースラインコンテキストオーバーヘッド | 🟢 外部プロセス、コンテキスト注入なし | 🔴 指示を注入 | 🟢 シェルレベルのみ | 🟢 シェルレベルのみ | 🔴 MCPサーバーオーバーヘッド | 🟢 ネイティブ |
+| ゼロランタイム依存 | 🟢 純標準ライブラリ(Python/TypeScript) | 🟡 Python + Rust + オプションモデル | 🟢 単一Rustバイナリ | 🟢 単一バイナリ | 🟡 SQLiteアダプタが必要 | 🟢 N/A |
+| ゼロテレメトリ | 🟢 マシンから何も出ない | 🟡 `HEADROOM_TELEMETRY`オプトイン、デフォルトオフ | 🟡 オプトイン | 🔴 呼び出されたコマンド、コマンド引数、終了コード、期間、CI属性、IPを収集 | 🟡 様々 | 🟢 |
+| マルチプラットフォーム | 🟢 Claude Code、VS Code、Codex、OpenClaw、OpenCode、Hermes、Copilot | 🟢 Claude Code、Cursor、Codex、Aider、Copilot | 🟢 15統合 | 🟡 Cursor、Claude Code、Copilot、Codex CLI | 🟢 17統合 | 🔴 Claude Codeのみ |
+| タスク別のモデルとeffortの助言 | 🟢 `route`がお金を使う前にタスクを計量 | — | — | — | — | — |
+| Keep-Warm(キャッシュTTLリフレッシュ) | 🟢 キャッシュ期限前のオプトインping、トリップワイヤー自動オフ | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| エンドツーエンドのタスク結果ベンチマーク | 🔴 出力トークンA/Bのみ | — | — | 🟢 ベンダーが同じ合格率と約12%低コストでTerminal-Bench 2.0を報告 | — | N/A |
+| 署名とチェックサム検証インストール | 🟢 リリースごとの`CHECKSUMS.sha256`、インストール時に検証、CI強制 | — | — | 🔴 インストーラはチェックサムも署名も検証しない | — | N/A |
+
+</details>
+ダッシュ(em dash)は、その能力が2026-07-26のソース監査で第一資料から検証されなかったことを意味します; 能力が不在だと主張するものではありません。Boostの「pre-shell」と「shell-level」セルは文書化されたラッパー形式(`boost <command>`)に由来します; `boost init`がエージェントを接続するのに使う仕組みは第一資料に記述されていません。Token Optimizerの圧縮の主張は実際のセッションと、あなたが自分で実行できる87フィクスチャスイートに対してテストされています。**[完全なベンチマーク方法論と結果 →](BENCHMARK.md)**
+
+<p align="center">
+  <a href="https://alexgreensh.github.io/token-optimizer/reference/comparison/"><img src="https://img.shields.io/badge/Read%20the%20official%20full%20comparison-in%20our%20docs-0b7285?style=for-the-badge" alt="ドキュメントで公式の完全比較ページを読む"></a>
+</p>
+
+## ダッシュボード
+
+![Token Optimizer ダッシュボード](skills/token-optimizer/assets/dashboard-demo.gif)
+
+1つのHTMLページ、SessionEndフック経由で毎セッション後に自動再生成、手動トリガー不要。ブックマーク可能なURL `http://localhost:24842/token-optimizer`はオプトインです: `python3 skills/token-optimizer/scripts/measure.py setup-daemon`を実行してローカルサーバーを起動した後にのみ動作します。それまでは、`measure.py dashboard`が`  Dashboard: `行に出力するファイルパスを開いてください。
+
+ターンごとのトークン内訳、4つの価格ティアにわたるコスト、TTLミックスとヒット率を伴うキャッシュ分析、すべてのセッションに重ねられた品質スコア、サブエージェントコスト内訳、4つの重複しないプールを持つ節約トラッカー。インストール後ゼロ設定。[完全なダッシュボードドキュメント →](https://alexgreensh.github.io/token-optimizer/features/dashboard/)
+
+## 何を節約するか
+
+節約は2つのティアで追跡される、重複しない4つのプールから来ます:
+
+| プール | カバーするもの |
+|---|---|
+| モデルルーティング + キャッシング | より軽いプレフィックス、より軽いモデルミックス、キャッシュ書き込みをルーティングのレバーとして |
+| サブエージェントルーティング | サイドチェーンコスト最適化(Claude Codeのみ) |
+| 圧縮加戻し | deltaモード、構造マップ、bash/検索圧縮で削除されたトークン |
+| リーン出力加戻し | 簡潔ナッジのために生成されなかった出力トークン |
+
+**2つの数字、別々に保持:**
+
+- **計測済み(~$313/月)**、アクションごとに記録。Token Optimizerがより軽いモデルに切り替え、大きな結果を切り詰め、繰り返し読込をスキップするたびに足します: より賢い習慣 ~$260/月、作業中の圧縮 ~$53/月。これはイベントごとに計量されたスライスなので、より小さく正確です。
+- **全体像(~$1,877/月、~18%)**、完全な反事実。Token Optimizer以前のやり方(~95% Opus)で作業していたら、~$10,585/月を払っていたところが今は~$8,708/月です。その差はほとんどより軽いモデルミックス(95% Opusから60%へ、メインルーティング + キャッシングで~$1,076/月)、より安いサブエージェント(~$741/月)、計測された圧縮加戻し(~$60/月)から来ます。
+
+これらの数字は合算されません。計測済みは硬い領収書のある床です。全体像はあなたの凍結されたToken Optimizer以前のベースラインに対して価格設定されたモデルです。[完全な方法論を見る →](BENCHMARK.md)
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/real-savings.svg" alt="30日節約レポート: 計測済み ~$313、全体像 ~$1,877" width="900">
+</p>
+
+30日間にわたる684セッションに基づく(2026-06-15終了スナップショット)、凍結されたToken Optimizer以前のベースライン(~95% Opus)に対して価格設定。あなたの数字はあなた自身のものです。[方法論を見る →](BENCHMARK.md)
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/user-profiles.svg" alt="1Mセッション内で何が起きるか" width="800">
+</p>
+
+## アクティブ圧縮
+
+コンテキストを能動的に減らす9機能、すべてデフォルトオン、すべて自動、すべてダッシュボードまたはCLIからトグル可能。
+
+内部では、**PreToolUseフック**がすべてのReadとBash呼び出しをコンテキストに入る前にインターセプトします。ファイルがすでに読まれていれば、diffだけが戻ります。コードファイルの再読込なら、構造スケルトンが完全内容を置き換えます。CLIコマンドなら、出力が圧縮されます。**PostToolUseフック**は完全なオリジナルをディスクにアーカイブし、圧縮イベントをSQLiteに記録します。何も失われず、すべてが取得可能です。**あなたは何もしない。フックがすべて処理します。**
+
+![アクティブ圧縮の概要](skills/token-optimizer/assets/active-compression-hero.svg)
+
+| 機能 | 何をするか | 節約 |
+|---|---|---|
+| Deltaモード | 再読込は変化したものだけを返す | 再読込で ~20% |
+| 構造マップ | 変更のないファイル再読込は構造スケルトンを返す | ~30%(ファイルごとに最大99%) |
+| Bash圧縮 | CLI出力を要点に凝縮 | ~10% |
+| 検索圧縮 | grep/web結果をトップヒット + カウントに凝縮 | ~15% |
+| リーン出力ナッジ | コンテキストが埋まる時モデルを簡潔出力に誘導 | 推定10-15%; 反事実的には計測されない |
+| 品質ナッジ | コンテキスト品質が落ちた時に警告 | 圧縮ロスを防ぐ |
+| ループ検出 | トークンを燃やす前に再試行ループを捕捉 | ループごとに計測 |
+| アクティビティモード | セッションフェーズに合わせて圧縮を適応 | 意思決定ロスを防ぐ |
+| 意思決定抽出 | 圧縮をまたいで意思決定を保存 | 意思決定ドリフトを防ぐ |
+
+ダッシュボードのManageタブ、CLI(`measure.py v5 enable|disable <feature>`)、または環境変数からトグル。`v5`動詞は現在の機能を制御するレガシーコマンド名です。
+
+[各機能の仕組みを読む →](https://alexgreensh.github.io/token-optimizer/features/active-compression/)
+
+<details>
+<summary><b>機能別の詳細</b></summary>
+
+### Deltaモード
+
+AIが編集後にファイルを再読込すると、Read呼び出しはdiffだけを返します。実際のセッションの65%以上のRead呼び出しは再読込です。2,000トークンのファイル再読込が50トークンのdiffになります。
+
+![Deltaモード: スマートな再読込](skills/token-optimizer/assets/delta-mode.svg)
+
+無効化: `TOKEN_OPTIMIZER_READ_CACHE_DELTA=0`
+
+### 構造マップ
+
+Claudeがすでに見たコードファイルを再読込すると、Read呼び出しはブロックされ、構造サマリに置き換えられます: 関数シグネチャ、クラス階層、import。720KBのPythonファイル(180,000トークン)が250トークンのスケルトンになります。
+
+無効化: `TOKEN_OPTIMIZER_READ_CACHE_MODE=shadow`
+
+### 初回読込スケルトン
+
+履歴検証コホートでの大型**コード**ファイル(PythonまたはTypeScript、16KB〜256KB)の**最初の**読込で、Readは完全ファイルの代わりに構造スケルトン(シグネチャ/import)を返し、1行の通知と共に、完全内容は常に1歩のところにあります: `expand <key>`、範囲Read(`offset`/`limit`)、または直接Edit。オリジナルはいかなる置換の前にもアーカイブされ、フェイルオープン、アーカイブできない場合は完全ファイルが提供されます。
+
+これは**コードのみ**に適用されます。Markdownや他の散文は初回読込でスケルトン化**されません**(v5.11.27時点): 見出しのみのアウトラインは荷重を担う散文を落とすので、ドキュメントは常に完全に戻ります。ランタイムのトリップワイヤーは、ライブ編集率が上がるとコードコホートを計測のみに自動降格します。
+
+提供の無効化(計測は保持): `TOKEN_OPTIMIZER_FIRST_READ_ACTIVE=0`。完全に無効化: `TOKEN_OPTIMIZER_FIRST_READ_SHADOW=0`。両方は`measure.py v5 status`とダッシュボードのManageタブでも表示・トグル可能です。
+
+### Bash出力圧縮
+
+一般的なCLIコマンドを書き換えて圧縮サマリを返します。lint、ログ末尾、tree、docker pull、長いリスト、ビルド出力、テストランナーをカバー。564トークンのpytest出力が115トークンになります。
+
+![Bash出力圧縮](skills/token-optimizer/assets/bash-compression.svg)
+
+無効化: `TOKEN_OPTIMIZER_BASH_COMPRESS=0`
+
+### 検索結果圧縮
+
+AIがgrep、rg、または長い結果リストを返すweb検索を実行すると、出力はトップヒットとカウントに凝縮されます。500行のgrep結果が20行とサマリになります。
+
+無効化: `TOKEN_OPTIMIZER_BASH_COMPRESS=0`(検索圧縮はbash圧縮の一部です; 別のスイッチはありません)
+
+### リーン出力ナッジ
+
+コンテキストが25%を超えて埋まると、短いナッジがモデルに深く推論しつつ可視出力は簡潔に保つよう伝えます。充填が唯一の条件で、品質はもはやこれをゲートしないため、普通の健全なセッションもナッジを受け取ります、長く退化したものだけでなく。節約は**10-15%と推定され、計測されません**: 反事実(ナッジなしでモデルが何を書いたか)は観察できないため、Token Optimizerはこれを推定ティアで報告し、計測された節約に折り込みません。キャッシュセーフ: `additionalContext`として注入、既存のプレフィックスを変更しない。
+
+今日オン/オフのスイッチはありません(`v5`機能ではない)。`TOKEN_OPTIMIZER_VERBOSITY_MIN_FILL`(デフォルト`25`)でトリガーポイントを調整。
+
+### 品質ナッジ
+
+コンテキスト品質をリアルタイムで監視。スコアが15ポイント以上下がるか60を下回ると、インラインノートがコンテキストに入ります。Claudeは次のターンでそれを見て警告を浮上させるか振る舞いを調整します。5分のクールダウン、セッションあたり最大3回。
+
+無効化: `TOKEN_OPTIMIZER_QUALITY_NUDGES=0`
+
+### ループ検出
+
+AIが再試行ループに囚われているのを捕捉。最後の4つのユーザーメッセージと最後の5つのツール結果を類似度で比較します。信頼度 ≥0.7で発火、セッションあたり2ノートの上限。実際のループターン内容から計測された節約。
+
+無効化: `TOKEN_OPTIMIZER_LOOP_DETECTION=0`
+
+### アクティビティモード検出
+
+最後の10回のツール呼び出しを使ってセッションを5つのモード(コード、デバッグ、レビュー、インフラ、一般)のいずれかに分類します。このモードは圧縮ガイダンスに入り、PRESERVE/DROPの優先順位があなたのしていることに適応します。
+
+### 意思決定抽出
+
+ツール出力から意思決定ステートメントをリアルタイムで検出し、セッションデータベースに保存します。圧縮時に、これらの意思決定はサマリが逐字保存しなければならないCRITICAL DECISIONSとして注入されます。セッションあたり10の上限。
+
+### 実際の節約を計測
+
+すべての圧縮機能はローカルのSQLiteテーブルに記録されます。マシンから何も出ません。
+
+```bash
+python3 measure.py compression-stats --days 30
+```
+
+</details>
+
+## セッションデータベース
+
+Token Optimizerが行うすべては2つのローカルSQLiteデータベースで支えられています。マシンから何も出ません。ゼロのネットワーク呼び出し。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/session-database-flow.svg" alt="セッションデータベースの流れ: ツール呼び出しが圧縮、アーカイブ、SQLiteに記録、取得可能" width="900">
+</p>
+
+**セッション別DB**(`~/.claude/token-optimizer/snapshots/session-store/<session>.db`)はファイル読込、ツール出力、コマンド出力、キャッシュされた内容、コンテキストインテルイベント、アクティビティログ、意思決定ログ、ヒント提供を追跡する8テーブルを持ちます。フックプロセスからの並行読み書きのためのWALモード。セッションあたり50MBの上限。
+
+**トレンドDB**(`~/.claude/token-optimizer/snapshots/trends.db`)はセッション履歴、日次集計、スキル/モデル/サブエージェント使用、節約イベント、圧縮イベントを追跡する7テーブルを持ちます。O(log n)の結合のためにセッションUUIDでインデックス。これがダッシュボード、コーチモード、30日トレンド分析を駆動します。
+
+すべての圧縮イベント、すべての節約、すべての品質計測はクエリ可能な1行です。ダッシュボードはこのデータの読み取り専用ビューです。`measure.py compression-stats`はSQLクエリです。あなたのデータはあなたのものです。
+
+## プログレッシブ開示
+
+大きなツール結果(>4KB)はディスクにアーカイブされ、短いプレビューと取得ポインタで置き換えられます。完全な出力は圧縮を生き残ります。モデルが必要な時、コマンドの再実行や失われた出力なしに`expand`でオリジナルを引っ張ります。
+
+これは単なる保存ではありません。システムはアーカイブされた結果対再展開された結果の数を追跡するので、折りたたまれたまま残ったネットトークンを見られます。再展開は節約合計から相殺されるので、実際に圧縮されたまま残ったものだけを数えます。
+
+```bash
+python3 measure.py expand --list          # アーカイブされたツール結果を一覧
+python3 measure.py expand <tool-use-id>   # 特定の結果を取得
+```
+
+一部のMCPツールは、メタデータプレビューが要点を損なうような、大きな逐語ペイロードを返すよう*文書化*されています(ソースフェッチャー、ドキュメント検索器)。それらを許可リストに入れて、完全な結果が置換されずにコンテキストに届くようにしてください(まだアーカイブされるので`expand`は動きます)。完全ツール名にマッチする`fnmatch` globのカンマ区切りリストを設定:
+
+`TOKEN_OPTIMIZER_ARCHIVE_EXEMPT_TOOLS="mcp__context7__*,*github_repository_file"`
+
+デフォルトは空です、ツールをオプトインしない限り何も免除されません。
+
+## セッション継続性
+
+圧縮も重要ですが、Token Optimizerが行う最も重要なことは、セッションと圧縮をまたいで仕事を自動的に生かしておくことです。
+
+セッションを終える時、Token Optimizerはあなたの状態をSQLiteにチェックポイントします: アクティブタスク、主要な意思決定、変更されたファイル、gitブランチ、最近の読込。新しいセッションを始める時、プロンプトに対してすべての最近のチェックポイントを採点し、最も関連するものをヒントとして浮上させます。ゼロからではなく、コンテキストと共に再開します。
+
+**自動的に何が起きるか:**
+
+- **セッション間ヒント**: 関連性採点されたチェックポイントが新しいセッション開始時に浮上。ヒントは前のセッションのタスク、意思決定、ファイル、ブランチを含む。すべてRECOVERED DATAとしてフェンス、決して指示ではない。
+- **コールドリジュームリーン**: 完全なトランスクリプトコストを払わずに古いセッションを再開。Token Optimizerはチェックポイントからリーンなコンテキストを再構築。LLM呼び出しなし、完全トランスクリプトのコールドリジュームなし。SQLiteからのトークン不要の再構築。
+- **ヒントフォロー計測**: 継続性ヒントがファイルパスを浮上しモデルがその後その一つを読むと、Token Optimizerは回避された探索的検索としてクレジット。計測された因果、推測ではない。
+
+```bash
+python3 measure.py resume-lean                    # 再開可能なコールドセッションを一覧
+python3 measure.py resume-lean <#|session_id> --print  # リーンコンテキストブロックを出力
+```
+
+圧縮の節約はセッションが圧縮を生き残る時にのみ定着します。セッション継続性がそれを実現します。
+
+## スマート圧縮
+
+自動圧縮が発火すると、会話の60〜70%が消えます。意思決定、エラー修正シーケンス、エージェント状態、すべて消えます。
+
+Token Optimizerは圧縮前にセッションをチェックポイントし、フック経由でサマリが落としたものを自動的に復元します。また**コンテキストインテル要約**を注入します: モデルがすでに処理した大きなツール出力のヒューリスティックなサマリ(触れたファイルパス、見たエラー、行数)。圧縮後、モデルはすべてを再読込せずに自分が見たものを知ります。
+
+**アクティビティモード検出**は最後の10回のツール呼び出しを使ってセッションをリアルタイムで分類します(コード、デバッグ、レビュー、インフラ、一般)。このモードは圧縮ガイダンスに入り、PRESERVE/DROPの優先順位が汎用ヒューリスティックではなく今あなたのしていることに適応します。
+
+**意思決定抽出**は意思決定ステートメントをツール出力から発生時に捕捉し、セッションDBに保存します。圧縮時に、これらはサマリが逐字保存しなければならないCRITICAL DECISIONSとして注入されます。セッションあたり10の上限。
+
+圧縮の節約はセッションが圧縮を生き残る時にのみ定着します。`git status`でトークンを節約しても、次の自動圧縮がそれを実行させた意思決定を消し去れば役に立ちません。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/quality-nudges-loops.svg" alt="動作中の品質ナッジとループ検出" width="800">
+</p>
+
+<details>
+<summary><b>スマート圧縮の仕組み</b></summary>
+
+### プログレッシブチェックポイント
+
+複数の閾値でセッション状態を捕捉: 20%、35%、50%、65%、80%のコンテキスト充填、加上品質が80、70、50、40を下回る時。エージェントファンアウト前と大きな編集バッチ後にもスナップショット。復元時、最も豊かな適格チェックポイントを選択。
+
+### コンテキストインテル要約
+
+圧縮後、Token Optimizerはセッションの最大ツール出力の要約を注入: 触れたファイルパス、検出されたエラー、行数。<30msでヒューリスティックに生成、LLM呼び出しなし。モデルはすべてを再読込せずに再位置づけします。
+
+```bash
+python3 measure.py setup-smart-compact    # チェックポイント + 復元フック
+```
+
+</details>
+
+## 出力トークン: リーン vs 冗長
+
+出力トークンはあなたのセッションで最も高価な部分です。Opusでは入力トークンの5倍のコストで、キャッシュ読み取りではなく生成ごとに課金されます。簡単な質問への冗長な応答は、決して費やす必要のなかったドルを燃やします。
+
+Token Optimizerは**リーン出力ナッジ**でこれを自動的に処理します。コンテキストが25%を超えて埋まると、短いナッジがモデルに深く推論しつつ可視出力は簡潔に保つよう伝えます。充填が唯一のトリガーで、コンテキスト品質は条件ではありません。削減は**10-15%と推定され、反事実的には計測されない**ため、推定ティアで報告され、計測された節約とは別です。
+
+**仕組み:**
+
+- ナッジは`additionalContext`として注入、既存のプレフィックスを変更しないので、キャッシュは無傷のまま
+- コンテキストが埋まりつつある時にのみ発火、十分な余裕がある時ではない
+- モデルは依然として問題を考える; より簡潔な可視回答を生成するだけ
+- 今日オン/オフのスイッチはない; `TOKEN_OPTIMIZER_VERBOSITY_MIN_FILL`(デフォルト`25`)でトリガーポイントを調整
+
+これは9つのアクティブ圧縮機能の一つで、トークンが最も高価な出力側で節約する機能です。
+
+## 品質スコアリング
+
+品質スコアは2つを追跡します: **リソースヘルス**(退化の崖にどれだけ近いか)と**セッション効率**(あなたのトークンが有用な仕事をしているか)。SからFまでの文字等級がトリアージを即時にします。
+
+コンテキストが埋まるにつれ、品質は下がります。MRCRは256Kと1Mのコンテキスト間で93%から76%に下がります。ウィンドウが埋まるにつれAIは計測可能に馬鹿になります。品質スコアはそれがいつ起きるか正確に示します。
+
+![実際のセッション品質の内訳](skills/token-optimizer/assets/quality-example.svg)
+
+ステータスバーは品質が退化するにつれ色が変わります: 緑、黄、オレンジ、赤。品質が75を下回ると、セッション期間が警告として現れます。実行中のサブエージェントはモデルと経過時間と共に表示されます。
+
+![ステータスバーの退化](skills/token-optimizer/assets/status-bar.svg)
+
+```bash
+python3 measure.py setup-quality-bar      # 一回限りのインストール
+```
+
+[スコアリングの仕組みを読む →](https://alexgreensh.github.io/token-optimizer/features/quality-signals/)
+
+<details>
+<summary><b>品質スコアの詳細</b></summary>
+
+| スコア | シグナル | 意味 |
+|--------|--------|----------------|
+| **リソースヘルス** | コンテキスト充填、圧縮深度、絶対無駄トークン | 退化の崖にどれだけ近いか |
+| **セッション効率** | 古い読込、膨張した結果、意思決定密度、エージェント効率 | セッションが今トークンをうまく使っているか |
+
+| 等級 | 範囲 | 意味 |
+|-------|-------|---------|
+| **S** | 90-100 | ピーク効率 |
+| **A** | 80-89 | 健全、小さな最適化が可能 |
+| **B** | 70-79 | 退化が始まっている |
+| **C** | 55-69 | 顕著な無駄 |
+| **D** | 40-54 | 深刻な問題 |
+| **F** | 0-39 | コンテキストが腐敗中、即時の行動が必要 |
+
+**品質バーが消えた?** Claude Codeの`/statusline`を実行するとToken Optimizerのエントリを上書きします。SessionStartが自動復元。新しいセッションを始めれば戻ります。
+
+**永久にオフにしたい?**
+```bash
+python3 measure.py setup-quality-bar --uninstall
+```
+
+</details>
+
+## コーチモード
+
+```
+> /token-coach
+```
+
+目標を伝えます。正確なトークン節約を伴う、具体的で優先順位付けされた修正を受け取ります。30日間のセッションデータを読み、単一セッションでは示せないものを浮上させます: 品質の下方ドリフト、セッションが長くなること、キャッシュヒット率の低下、セッションあたりコストの上昇。
+
+すべてのインサイトはあなたの実際の数字に基づきます。「短いセッションは68点、長いセッションは60点」は「より短いセッションを検討してください」とは違った響きがあります。コーチモードはまたプロジェクトレベルの最適化機会(決して使わないスキル、熱心にロードするMCPサーバー、キャッシュを壊すCLAUDE.mdパターン)を特定し、将来のセッションがよりリーンに始まるよう直し方を教えます。
+
+[コーチモードについて読む →](https://alexgreensh.github.io/token-optimizer/features/token-coach/)
+
+<details>
+<summary><b>コーチモードの詳細</b></summary>
+
+### 検出される過去のパターン
+
+| パターン | 何を検出するか |
+|---|---|
+| 品質ドリフト | 週ごとの平均品質の低下 |
+| セッション期間の這い上がり | セッションが長くなり、コンテキストがより早く埋まる |
+| キャッシュ退化 | キャッシュヒット率の低下(およびモデル切替が原因か) |
+| 等級分布 | D等級セッションが蓄積しすぎ |
+| コスト意識 | セッションあたりコストの上昇、ルーティングの助言付き |
+| 期間-品質の相関 | 短いセッションがより高得点、長いものを分割するよう示唆 |
+| 圧縮ギャップ | shadowのみの節約がアクティブ圧縮を大きく超過 |
+| モデル切替 | 頻繁なセッション途中のモデル切替がプロンプトキャッシュを無効化 |
+
+### 無駄検出器
+
+11の自動検出器があなたのセッションパターンを分析:
+
+| 検出器 | 何を捕捉するか |
+|---|---|
+| PDF/バイナリ摂取 | コンテキストを消費する大きなファイル |
+| Web検索オーバーヘッド | コンテキストにダンプされるweb結果が多すぎる |
+| 再試行チャーン | 同じツールをエラーで3回以上再試行 |
+| ツールカスケード | 3回以上の連続ツールエラー |
+| ルーピング | 繰り返される類似メッセージ |
+| 強すぎるモデル | 簡単な編集にOpusを使用 |
+| 弱すぎるモデル | 複雑なタスクにHaiku |
+| 悪い分解 | モノリシックな500+語のプロンプト |
+| 無駄な思考 | 小さな編集に2倍を超える拡張思考 |
+| 出力の無駄 | 簡単な操作への冗長な応答 |
+| キャッシュ不安定 | プロンプトキャッシュを壊すCLAUDE.mdパターン |
+
+### Keep-Warm
+
+API課金セッション向けのオプトイン機能。プロンプトキャッシュエントリが期限切れになる直前に小さなキャッシュ読み取りpingを発行し、TTLをリフレッシュします。再開時に払う1.25-2倍の再書き込みに対し、プレフィックスの約0.1倍のコスト。pingが自分のコストを賄わなくなるとトリップワイヤーが自動オフ。
+
+```bash
+python3 measure.py keepwarm-enable          # オプトイン(API課金のみ)
+python3 measure.py keepwarm-report            # 正味節約、支出、トリップワイヤー状態
+python3 measure.py keepwarm-disable           # いつでもオプトアウト
+```
+
+### フリート監査器
+
+Claude Code、Codex、カスタムトランスクリプト設定を横断スキャンし、アイドル燃焼、モデル誤ルーティング、設定膨張を発見ごとのドル節約と共に見つけます。
+
+### CLAUDE.mdルーティング注入
+
+あなたの実際の使用データからモデルルーティング指示を生成し、CLAUDE.mdに注入します。48時間の陳腐化ガードが古い助言を自動削除。
+
+```bash
+python3 measure.py inject-routing --dry-run   # プレビュー
+python3 measure.py inject-routing              # 注入
+```
+
+</details>
+
+## FAQ
+
+<details>
+<summary><b>🔒 コンテキスト品質を劣化させることがありますか?</b></summary>
+
+いいえ。構造的最適化は本当に未使用のコンポーネントのみを削除します。アクティブ圧縮の制御は単一のコマンドまたは環境変数で無効化できます。品質スコアリングシステムが劣化をリアルタイムで追跡します。
+
+</details>
+
+<details>
+<summary><b>💾 プロンプトキャッシュを壊しますか?</b></summary>
+
+いいえ。Token Optimizerはすでにコンテキストにある内容には決して触れません。ウィンドウに入る新しい内容と圧縮の境界で動作します。キャッシュプレフィックスは無傷のままで、これは2回節約することを意味します: ターンあたりの入力がより少なく、以降の毎ターンのキャッシュ読み取りがより安く。
+
+</details>
+
+<details>
+<summary><b>📡 どこかにデータを送信しますか?</b></summary>
+
+分析なし、テレメトリエンドポイントなし、製品データはマシンから出ません。計測イベントはあなたが所有するローカルSQLiteの行です。ゼロのネットワーク呼び出し。
+
+</details>
+
+<details>
+<summary><b>⚠️ セッションに害を与えることがありますか?</b></summary>
+
+いいえ。すべてのフックはフェイルオープン設計のノンブロッキングです。Token Optimizerのスクリプトがエラーになっても、コマンドは通常通り実行されます。
+
+</details>
+
+<details>
+<summary><b>📦 ランタイム依存はありますか?</b></summary>
+
+いいえ。Claude CodeとCodexでは純粋なPython標準ライブラリ。OpenCodeとOpenClawではランタイム依存ゼロのTypeScript。
+
+</details>
+
+<details>
+<summary><b>🔐 install.shはファイルの完全性をどう検証しますか?</b></summary>
+
+最新のGitHub Releaseタグを解決し、そのタグをチェックアウトし、同じリリースからCHECKSUMS.sha256を取得し、すべてのスクリプトファイルを検証します。帯域外の検証は、侵害されたコミットがコードとチェックサムの両方を同時にすり替えられないことを意味します。
+
+</details>
+
+## すべてのコマンド
+
+<details>
+<summary><b>すべてのコマンドを表示</b></summary>
+
+| コマンド | 何をするか | ドキュメント |
+|---|---|---|
+| `/token-optimizer` | 6並列エージェントによる完全監査、ガイド付き修正 | [→](https://alexgreensh.github.io/token-optimizer/start/quickstart/) |
+| `/token-coach` | 30日トレンド分析、優先順位付き修正 | [→](https://alexgreensh.github.io/token-optimizer/features/token-coach/) |
+| `quick` | 10秒ヘルスチェック | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `doctor` | インストールチェック、10点満点で採点 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `dashboard` | HTMLダッシュボードを開く | [→](https://alexgreensh.github.io/token-optimizer/features/dashboard/) |
+| `savings` | ドル節約レポート | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `report` | コンポーネント別トークン内訳 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `quality` | ライブセッションのコンテキスト品質分析 | [→](https://alexgreensh.github.io/token-optimizer/features/quality-signals/) |
+| `trends` | スキル採用、モデルミックス、時間経過のオーバーヘッド | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `compression-stats` | アクティブ圧縮からの計測された節約 | [→](https://alexgreensh.github.io/token-optimizer/features/active-compression/) |
+| `memory-review` | MEMORY.md構造監査 | [→](https://alexgreensh.github.io/token-optimizer/features/memory-health/) |
+| `git-context` | 現在のdiffに対するファイルを提案 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `drift` | 最後のスナップショットとの並列比較 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `conversation` | メッセージごとのトークンとコストの内訳 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `pricing-tier` | 価格ティアの表示または切替 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `expand` | アーカイブされたツール結果を取得(プログレッシブ開示) | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `resume-lean` | トークン不要の再構築でコールドセッションを再開 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+
+[完全なCLIリファレンス →](https://alexgreensh.github.io/token-optimizer/reference/cli/)
+
+</details>
+
+## ライセンス
+
+**PolyForm Noncommercial 1.0.0**。ソース公開。個人、研究、教育、非商用の使用にはライセンス購入は不要です。
+
+### 個人 / ホビー / 研究 / 教育?
+どうぞ。完全なソース、ローカルで動作、ライセンス購入不要。
+
+### 小さなチーム(5人未満または月収$20k未満)?
+小さなチームは自動的に無償の商用ライセンスを得ます。ただ使ってください。
+
+### 個人で始めたが、ビジネスになりつつある?
+過去の使用は全く問題ありません。ライセンスには書面通知後32日間の猶予期間が組み込まれています。準備ができたら商用ライセンスについて連絡してください。
+
+### より大きな会社 / 商用利用?
+[Alex Greenshpun](https://linkedin.com/in/alexgreensh)またはme@alexgreenshpun.comに連絡してください。
+
+---
+
+[Alex Greenshpun](https://linkedin.com/in/alexgreensh)によって作成。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,687 @@
+<p align="center">
+  <a href="README.md">English</a> ·
+  <b>한국어</b> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/logo.svg" alt="Token Optimizer" width="780">
+</p>
+
+<p align="center">
+  <a href="https://github.com/alexgreensh/token-optimizer/releases/latest"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=version&color=green" alt="최신 안정 버전"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/commits/main"><img src="https://badgen.net/github/last-commit/alexgreensh/token-optimizer?label=last%20commit" alt="최근 커밋"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer"><img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet" alt="Claude Code Plugin"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/openclaw"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2Fopenclaw%2Fpackage.json&query=%24.version&prefix=v&label=OpenClaw&color=brightgreen" alt="OpenClaw 버전"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/opencode"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2Fopencode%2Fpackage.json&query=%24.version&prefix=v&label=OpenCode&color=58a6ff" alt="OpenCode 버전"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/docs/codex.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.codex-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Codex&color=orange" alt="Codex 버전"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/hermes"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Hermes&color=0d9488" alt="Hermes 버전"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/docs/copilot.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Copilot&color=6e40c9&logo=githubcopilot&logoColor=white" alt="GitHub Copilot 버전"></a>
+</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/cuts%20context%20waste-3fb950" alt="컨텍스트 낭비 절감">
+  <img src="https://img.shields.io/badge/survives%20compaction-checkpoint%20%2B%20restore-58a6ff" alt="압축 생존">
+  <img src="https://img.shields.io/badge/saves%20real%20%24-every%20session-2ea043" alt="매 세션 실제 달러 절감">
+  <img src="https://img.shields.io/badge/live%20dashboard-tokens%20%2B%20%24%20%2B%20turns-8B5CF6?logo=chartdotjs&logoColor=white" alt="실시간 대시보드">
+  <img src="https://img.shields.io/badge/context%20quality-live%20score-blue" alt="실시간 컨텍스트 품질 점수">
+  <img src="https://img.shields.io/badge/tests-passing-brightgreen" alt="테스트 통과">
+</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="의존성 없음">
+  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="텔레메트리 없음">
+  <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9 이상">
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="플랫폼">
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="라이선스: PolyForm Noncommercial"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/stargazers"><img src="https://badgen.net/github/stars/alexgreensh/token-optimizer" alt="GitHub 스타"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/commits/main"><img src="https://badgen.net/github/commits/alexgreensh/token-optimizer?label=commits" alt="커밋"></a>
+  <a href="https://linkedin.com/in/alexgreensh"><img src="https://img.shields.io/badge/LinkedIn-Connect-0A66C2?logo=linkedin&logoColor=white" alt="LinkedIn에서 연결"></a>
+</p>
+<p align="center">
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/%E2%99%A5%20Support%20this%20project%20to%20keep%20it%20open%20source-ea4aaa?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="이 프로젝트를 오픈소스로 유지하려면 후원해 주세요"></a>
+</p>
+
+<h2 align="center">낭비하는 토큰을 줄이세요. 잃을 뻔한 작업은 보존하세요.</h2>
+
+<p align="center"><em>백그라운드에서 자동으로 실행됩니다. 평소처럼 계속 작업하시면 됩니다. 전체 현황을 보고 싶을 때 감사를 실행하세요.</em></p>
+
+<p align="center">
+  <a href="https://alexgreensh.github.io/token-optimizer/"><img src="https://img.shields.io/badge/%F0%9F%93%96%20Read%20the%20Docs-alexgreensh.github.io%2Ftoken--optimizer-e85329?style=for-the-badge&logoColor=white" alt="문서 읽기"></a>
+  <a href="https://alexgreensh.github.io/token-optimizer/start/quickstart/"><img src="https://img.shields.io/badge/Quickstart-2%20minutes-3fb950?style=for-the-badge" alt="2분 퀵스타트"></a>
+</p>
+
+## 30초 요약
+
+Token Optimizer는 AI 코딩 보조 도구가 낭비하는 토큰을 줄이고, 세션과 압축(compaction) 사이에서 작업을 살려두며, 모든 달러가 어디에 쓰였는지 실시간 대시보드로 보여줍니다. **대부분은 자동으로 실행됩니다. 설치하고 감사를 한 번 실행하면, 나머지는 훅(hook)이 처리합니다.**
+
+**왜 그냥 Headroom이나 RTK를 쓰지 않나요?** 둘 다 명령 출력을 압축하는데, 이는 컨텍스트의 15~25%만 다룹니다. Token Optimizer는 그 부분과 나머지 75%까지 다룹니다: 부풀려진 설정, 사용하지 않는 스킬, 오래된 메모리, 압축 손실, 모델 잘못된 라우팅, 행동적 낭비. 모든 절감은 캐시에 안전하고 측정됩니다. 대시보드는 매 세션 후 자동으로 갱신됩니다.
+
+**Claude Code**(CLI 및 VS Code), **OpenCode**, **OpenClaw**, **Codex**, **Hermes**, **GitHub Copilot**에서 작동합니다. Windsurf와 Cursor는 로드맵의 다음 순서입니다.
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/hero-terminal.svg" alt="Token Optimizer 빠른 스캔" width="800">
+</p>
+
+## 설치
+
+**Claude Code (권장):**
+
+```
+/plugin marketplace add alexgreensh/token-optimizer
+/plugin install token-optimizer@alexgreensh-token-optimizer
+```
+
+그런 다음 Claude Code에서: `/token-optimizer`
+
+> **설치 후 자동 업데이트를 활성화하세요.** Claude Code는 서드파티 마켓플레이스를 기본적으로 자동 업데이트 꺼짐으로 배포합니다. `/plugin` → **Marketplaces** 탭 → `alexgreensh-token-optimizer` 선택 → **Enable auto-update**. 일회성, 10초면 됩니다.
+>
+> 설치 후, `/token-optimizer`를 한 번 실행하여 훅을 설정하세요. 그 이후로는 모든 것이 자동으로 실행됩니다: 압축, 체크포인트, 품질 점수, 대시보드 갱신. 감사를 원하지 않는 한 어떤 명령도 다시 실행할 필요가 없습니다.
+
+<details>
+<summary><b>다른 플랫폼 및 설치 방법</b></summary>
+
+**Codex:**
+```bash
+codex plugin marketplace add alexgreensh/token-optimizer
+```
+그런 다음 Codex TUI에서: `/plugins`로 Token Optimizer를 설치하세요. [`docs/codex.md`](docs/codex.md)를 참조하세요.
+
+**OpenCode:** `opencode.json`의 `plugin` 배열에 `token-optimizer-opencode`를 추가하세요:
+```jsonc
+{ "$schema": "https://opencode.ai/config.json", "plugin": ["token-optimizer-opencode"] }
+```
+[`opencode/README.md`](opencode/README.md)를 참조하세요.
+
+**OpenClaw:**
+```bash
+openclaw plugins install github:alexgreensh/token-optimizer
+```
+[`openclaw/README.md`](openclaw/README.md)를 참조하세요.
+
+**Hermes:**
+```bash
+git clone https://github.com/alexgreensh/token-optimizer.git
+token-optimizer/install.sh --hermes
+```
+[`hermes/README.md`](hermes/README.md)를 참조하세요.
+
+**GitHub Copilot:**
+```bash
+git clone --depth 1 https://github.com/alexgreensh/token-optimizer.git
+cd token-optimizer
+bash install.sh --copilot
+```
+[`docs/copilot.md`](docs/copilot.md)를 참조하세요.
+
+**macOS/Linux 스크립트 설치 (플러그인의 대안):**
+```bash
+tmp="$(mktemp -d)"
+release_json="$(curl -fsSL https://api.github.com/repos/alexgreensh/token-optimizer/releases/latest)"
+tag="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])' <<<"$release_json")"
+git clone --branch "$tag" --depth 1 https://github.com/alexgreensh/token-optimizer.git ~/.claude/token-optimizer
+bash ~/.claude/token-optimizer/install.sh
+rm -rf "$tmp"
+```
+
+**Windows 사용자:** 플러그인 설치만 사용하세요. Windows에서 `install.sh`를 실행하지 마세요. `EBUSY` 오류가 발생하면, 모든 Claude Code 및 Git Bash 창을 닫고, 남아있는 `git.exe` 프로세스를 종료하고, `C:\Users\<you>\.claude\token-optimizer`와 `C:\Users\<you>\.claude\plugins\marketplaces\alexgreensh-token-optimizer`를 삭제한 뒤 다시 시도하세요.
+
+**`install.sh`가 `$'\r': command not found`로 실패하는 경우** (LF 줄바꿈이 적용되기 전에 복제된 저장소가 스크립트를 CRLF로 변환한 경우), 캐리지 리턴을 한 번 제거하고 다시 실행하세요. 저장소는 이제 새 복제에서 이를 방지하는 `.gitattributes`를 함께 배포합니다:
+```bash
+sed -i 's/\r$//' ~/.claude/token-optimizer/install.sh
+# 이미 저장소가 있다면? 줄바꿈을 제자리에서 재정규화하세요:
+git -C ~/.claude/token-optimizer add --renormalize . && git -C ~/.claude/token-optimizer checkout -- .
+```
+
+</details>
+
+<details>
+<summary>제거</summary>
+
+Token Optimizer는 추가적이고 되돌릴 수 있습니다. 모든 런타임은 우리가 설치한 것만 제거하는 깔끔한 제거 방법을 제공하며, 사용자의 훅, 설정, 세션 데이터는 그대로 둡니다. 런타임별 전체 단계는 **[docs/uninstall.md](docs/uninstall.md)**에 있습니다.
+
+가장 빠른 방법 (Claude Code 플러그인 설치):
+
+```
+/plugin uninstall token-optimizer@alexgreensh-token-optimizer
+```
+
+</details>
+
+## 제공되는 기능
+
+**매 세션 자동으로 실행되며, 사용자가 할 일은 없습니다:**
+
+- 🔄 **스마트 압축(Smart Compaction)**: 자동 압축 전 체크포인트, 이후 복원
+- 🗄️ **세션 연속성(Session Continuity)**: 세션 간 힌트, 콜드 리줌, 체크포인트 점수
+- 📦 **능동 압축(Active Compression)**: 9가지 기능, 모두 기본 켜짐 (델타 diff, 스켈레톤, bash/검색 압축, 간결 출력 넛지, 품질 넛지, 루프 감지, 활동 모드, 결정 추출)
+- 📊 **품질 점수(Quality Scoring)**: 7개 신호, 실시간, S~F 등급
+- 🗃️ **세션 데이터베이스(Session Database)**: SQLite, 15개 테이블, 전체 감사 추적, 네트워크 없음
+- 🔍 **점진적 공개(Progressive Disclosure)**: 큰 출력은 보관되고, 요청 시 펼침
+- 🧠 **컨텍스트 인텔 요약(Context Intel Digest)**: 압축 후 재읽기 없는 재정위치
+- 🔀 **모델 라우팅 넛지(Model Routing Nudges)**: 작업에 맞는 티어로 안내
+
+**요청할 때:**
+
+- 🩺 `/token-optimizer`: 가이드된 수정과 함께 전체 감사
+- 📈 `/token-coach`: 구체적 수정과 함께 30일 추세 분석
+- ⚡ `quick`: 10초 건강 검사
+- 🎯 `route`: 돈을 쓰기 전, 이 작업에 실제로 필요한 모델과 노력
+- 🔧 `doctor`: 설치 검사
+- 💰 `savings`: 달러 절감 보고서
+- 📋 `report`: 컴포넌트별 토큰 분석
+- 🌐 `dashboard`: 전체 대시보드 열기
+- 📝 `memory-review`: MEMORY.md 구조 감사
+- 📂 `expand`: 보관된 도구 결과 검색
+- 🔙 `resume-lean`: 콜드 세션 다시 열기
+
+설치하고 `/token-optimizer`를 한 번 실행하면, 나머지는 모두 자동으로 실행됩니다.
+
+## 차별성
+
+대부분의 토큰 도구는 명령 출력을 압축합니다. 이는 컨텍스트의 15~25%를 다룹니다. 나머지 75%는 손대지 않습니다.
+
+**압축 적용 범위.** Headroom, RTK, JFrog Boost는 bash와 명령 출력을 압축합니다. Token Optimizer는 출력 스택의 여덟 표면을 압축합니다. 상태: 🟢 지원됨, 🟡 부분적, 🔴 지원되지 않음.
+
+| 압축 표면 | Token Optimizer | Headroom | RTK | Boost |
+|---|---|---|---|---|
+| **Bash / 명령 출력** (git, 테스트, lint, 빌드, 로그) | 🟢 22개 패턴 패밀리에 걸쳐 111개 명령, 자격증명 안전; pytest 실행 시 564 → 115 토큰 | 🟢 SmartCrusher, CodeCompressor, Kompress-v2 | 🟢 100개 이상 필터 | 🟢 명령 인식 필터 |
+| **검색 / grep 출력** | 🟢 상위 적중과 개수; 500줄 → 20 | 🔴 | 🔴 | — |
+| **표 형식 / JSON 출력** (jq, yq, csvtool, mlr) | 🟢 값 보존 열 형식 | 🟢 SmartCrusher | 🔴 | — |
+| **파일 재읽기, 델타 모드** | 🟢 diff만; 2,000토큰 재읽기 → ~50 | 🔴 | 🔴 | — |
+| **파일 재읽기, 구조 맵** | 🟢 서명과 임포트의 스켈레톤; 720KB → 250 토큰 | 🔴 | 🔴 | — |
+| **큰 도구 결과** (4K자 이상) | 🟢 디스크에 보관, 요청 시 펼침 가능 | 🔴 | 🔴 | — |
+| **모델 출력 장황함** | 🟢 간결 출력 넛지, 캐시 안전 (절감은 추정됨, 측정 아님) | 🔴 | 🔴 | 🔴 |
+| **구조적 컨텍스트** (설정, 스킬, MCP, 메모리) | 🟢 컴포넌트별 감사, 각 소스 점수 | 🔴 | 🔴 | 🔴 |
+
+RTK와 Boost는 첫 번째 표면에 도달합니다. Headroom은 첫 번째와 세 번째에 도달합니다. Token Optimizer는 여덟 모두를 다루고, 압축 주변에서 일어나는 일로 계속 나아갍니다:
+
+- **한 가지가 아닌 세 종류의 낭비.** 구조적(부풀려진 설정, 사용하지 않는 스킬, 오래된 메모리), 런타임(장황한 출력, 재읽기), 행동적(모델 잘못된 라우팅, 캐시 만료, 재시도 루프). [각각 어떻게 작동하는지 →](https://alexgreensh.github.io/token-optimizer/features/active-compression/)
+- **절감은 압축을 넘겨살립니다.** 자동 압축 전 체크포인트, 이후 복원. 이게 없으면 압축 절감은 압축이 발동하는 순간 사라집니다.
+- **도움이 되었는지 측정합니다.** 이전/이후 토큰 델타, 네 가지 가격 티어에 걸친 달러 절감, 저하를 추적하는 품질 점수. 단순히 "압축했다"가 아닙니다.
+- **기준선 오버헤드 없음.** 외부 프로세스, 컨텍스트에 항상 켜진 지시 없음, MCP 서버 없음, 의존성 없음, 텔레메트리 없음.
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/automated-flow.svg" alt="Token Optimizer가 매 세션 자동으로 작동하는 방식" width="900">
+</p>
+
+이 열 줄은 Token Optimizer가 행에서 유일한 🟢인 행들입니다: 압축 너머로 살아남는 것, 그리고 어떤 압축기도 찾지 않는 낭비. 압축 메커니즘, 비용과 안전성, 그리고 우리가 지는 두 행은 접힌 부분 뒤에 있습니다.
+
+|| Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
+|---|---|---|---|---|---|---|
+| 압축 생존 | 🟢 점진적 체크포인트, 복원, 도구 출력 요약 | 🔴 | 🔴 | — | 🟡 세션 가이드만 | 🔴 |
+| 세션 연속성 | 🟢 세션 간 힌트, 콜드 리줌, 체크포인트 점수 | 🔴 | 🔴 | — | 🟡 세션 가이드 | 🔴 |
+| 구조적 낭비 감사 | 🟢 컴포넌트별 심층 (CLAUDE.md, 스킬, MCP, 메모리) | 🔴 | 🔴 | 🔴 | 🔴 | 🟡 요약만 |
+| CLAUDE.md와 MEMORY.md 건강 | 🟢 8개 감사자 + 주의 곡선 점수 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 |
+| 모델 라우팅 및 행동 코칭 | 🟢 12개 감지기, 서브에이전트 비용 분석, 안티 패턴 | 🔴 | 🔴 | — | 🔴 | 🟡 기본 제안 |
+| 과거 추세 분석 | 🟢 30일 추세, 품질/비용/캐시/지속 시간 상관, 모델 전환 감지 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 컨텍스트 품질 점수 | 🟢 등급이 있는 7신호 품질 점수 | 🔴 | 🔴 | — | 🔴 | 🟡 용량 %만 |
+| 루프와 회전 감지 | 🟢 토큰을 태우기 전에 행동 루프 포착 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 압축이 도움이 되었는지 측정 | 🟢 로컬 텔레메트리, 이전/이후 토큰, 달러 절감 | 🔴 | 🟡 `rtk gain` (토큰 개수만) | 🟡 `boost report`, 벤더 측 | 🔴 | 🔴 |
+| 플릿 수준 교차 에이전트 분석 | 🟢 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+
+<details>
+<summary><b>나머지 13행 보기</b> (압축 메커니즘; 비용, 안전성 및 도달; 튜닝, 증명 및 설치)</summary>
+
+|| Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
+|---|---|---|---|---|---|---|
+| 명령 재작성 불필요 | 🟢 훅 연결, 자동 발동 | 🟢 투명 프록시 | 🟢 훅 기반 재작성 | 🟢 `boost init`이 지원 에이전트에 연결; 터미널 사용은 접두사 가능 | 🟡 훅 가능 플랫폼에서 자동 | N/A 네이티브 명령 |
+| 전체 원본 복구 가능 | 🟢 압축 전 원본 보관, `expand`로 검색; 실패는 압축 안 됨 | 🟢 되돌릴 수 있는 검색 | 🟡 명령 실패 시 전체 출력 저장 | 🟢 벤더가 명령 출력 복구 문서화 | — | N/A 압축 안 함 |
+| 커스텀 명령 필터 등록 | 🔴 내장 명령 집합; 사용자 필터 API 없음 | — | 🟢 커스텀 TOML 필터 | 🟢 TOML 필터 | — | N/A |
+| 사용자 조정 가능한 설정 | 🟢 92개 코드 참조 `TOKEN_OPTIMIZER_*` 이름, 사용자 대면과 내부 제어로 명시적 분리; 추가적 허용 목록; `.contextignore` | 🟢 문서화된 설정 | 🟢 `config.toml` 및 환경 제어 | 🟢 필터 TOML | 🟢 문서화된 설정 | N/A |
+| 캐시 안전 | 🟢 기존 컨텍스트 접두사 수정 안 함 | 🟡 프록시 모드가 진행 중 재작성 | 🟢 사전 셸만 | 🟢 사전 셸만 | 🟡 MCP 오버헤드 | 🟢 |
+| 기준선 컨텍스트 오버헤드 없음 | 🟢 외부 프로세스, 컨텍스트 주입 없음 | 🔴 지시 주입 | 🟢 셸 수준만 | 🟢 셸 수준만 | 🔴 MCP 서버 오버헤드 | 🟢 네이티브 |
+| 런타임 의존성 없음 | 🟢 순수 표준 라이브러리 (Python/TypeScript) | 🟡 Python + Rust + 선택적 모델 | 🟢 단일 Rust 바이너리 | 🟢 단일 바이너리 | 🟡 SQLite 어댑터 필요 | 🟢 N/A |
+| 텔레메트리 없음 | 🟢 기계 밖으로 아무것도 나가지 않음 | 🟡 `HEADROOM_TELEMETRY` 옵트인, 기본 꺼짐 | 🟡 옵트인 | 🔴 호출된 명령, 명령 인자, 종료 코드, 지속 시간, CI 속성, IP 수집 | 🟡 다양함 | 🟢 |
+| 멀티 플랫폼 | 🟢 Claude Code, VS Code, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15개 통합 | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17개 통합 | 🔴 Claude Code만 |
+| 작업별 모델 및 노력 조언 | 🟢 `route`가 돈 쓰기 전에 작업 크기 측정 | — | — | — | — | — |
+| 킵 웜(Keep-Warm) (캐시 TTL 갱신) | 🟢 캐시 만료 전 옵트인 핑, 트립와이어 자동 꺼짐 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 엔드투엔드 작업 결과 벤치마크 | 🔴 출력 토큰 A/B만 | — | — | 🟢 벤더가 동일한 통과율과 ~12% 낮은 비용으로 Terminal-Bench 2.0 보고 | — | N/A |
+| 서명 및 체크섬 검증 설치 | 🟢 릴리스마다 `CHECKSUMS.sha256`, 설치 시 검증, CI 강제 | — | — | 🔴 설치 관리자가 체크섬이나 서명 모두 검증 안 함 | — | N/A |
+
+</details>
+대시(em dash)는 해당 기능이 2026-07-26 소스 감사에서 자사 자료로부터 검증되지 않았음을 의미합니다; 기능이 없다는 주장이 아닙니다. Boost의 "사전 셸"과 "셸 수준" 셀은 문서화된 래퍼 형태(`boost <command>`)에서 가져온 것입니다; `boost init`이 에이전트를 연결하는 데 사용하는 메커니즘은 자사 자료에 설명되어 있지 않습니다. Token Optimizer의 압축 주장은 실제 세션과 사용자가 직접 실행할 수 있는 87개 픽스처 제품군에 대해 테스트되었습니다. **[전체 벤치마크 방법론과 결과 →](BENCHMARK.md)**
+
+<p align="center">
+  <a href="https://alexgreensh.github.io/token-optimizer/reference/comparison/"><img src="https://img.shields.io/badge/Read%20the%20official%20full%20comparison-in%20our%20docs-0b7285?style=for-the-badge" alt="문서에서 공식 전체 비교 페이지 읽기"></a>
+</p>
+
+## 대시보드
+
+![Token Optimizer 대시보드](skills/token-optimizer/assets/dashboard-demo.gif)
+
+하나의 HTML 페이지, SessionEnd 훅을 통해 매 세션 후 자동 재생, 수동 트리거 불필요. 북마크 가능한 URL `http://localhost:24842/token-optimizer`는 옵트인입니다: 로컬 서버를 시작하려면 `python3 skills/token-optimizer/scripts/measure.py setup-daemon`을 실행한 후에만 작동합니다. 그 전에는 `measure.py dashboard`가 `  Dashboard: ` 줄에 출력하는 파일 경로를 여세요.
+
+턴별 토큰 분석, 네 가지 가격 티어에 걸친 비용, TTL 믹스와 적중률이 있는 캐시 분석, 모든 세션에 겹쳐진 품질 점수, 서브에이전트 비용 분석, 네 개의 겹치지 않는 풀을 가진 절감 추적기. 설치 후 설정 불필요. [전체 대시보드 문서 →](https://alexgreensh.github.io/token-optimizer/features/dashboard/)
+
+## 절감 내역
+
+절감은 두 티어에서 추적되는, 겹치지 않는 네 개의 풀에서 나옵니다:
+
+| 풀 | 다루는 내용 |
+|---|---|
+| 모델 라우팅 + 캐싱 | 더 가벼운 접두사, 더 가벼운 모델 믹스, 캐시 쓰기를 라우팅 지렛대로 |
+| 서브에이전트 라우팅 | 사이드체인 비용 최적화 (Claude Code만) |
+| 압축 추가 환원 | 델타 모드, 구조 맵, bash/검색 압축으로 제거된 토큰 |
+| 간결 출력 추가 환원 | 간결 넛지로 인해 생성되지 않은 출력 토큰 |
+
+**두 숫자, 분리해서 유지:**
+
+- **계산됨(\~$313/월)**, 행동별로 기록. Token Optimizer가 더 가벼운 모델로 교체하거나, 큰 결과를 다듬거나, 반복 읽기를 건너뛸 때마다 합산합니다: 더 똑똑한 습관 \~$260/월, 작업 중 압축 \~$53/월. 이는 이벤트별로 측정된 부분이므로 더 작고 정확합니다.
+- **큰 그림(\~$1,877/월, \~18%)**, 전체 반사실적(counterfactual). Token Optimizer 이전의 방식(\~95% Opus)으로 작업했다면, \~$10,585/월을 지불했을 것이고 지금은 \~$8,708/월입니다. 그 차이는 대부분 더 가벼운 모델 믹스(95% Opus에서 60%로, 메인 라우팅 + 캐싱에 \~$1,076/월), 더 저렴한 서브에이전트(\~$741/월), 그리고 측정된 압축 추가 환원(\~$60/월)입니다.
+
+이 숫자들은 합산되지 않습니다. 계산됨은 영수증이 있는 최소치입니다. 큰 그림은 동결된 Token Optimizer 이전 기준선에 대해 가격 책정된 모델입니다. [전체 방법론 보기 →](BENCHMARK.md)
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/real-savings.svg" alt="30일 절감 보고서: 계산됨 ~$313, 큰 그림 ~$1,877" width="900">
+</p>
+
+30일간 684개 세션 기반(2026-06-15 종료 스냅샷), 동결된 Token Optimizer 이전 기준선(\~95% Opus)에 대해 가격 책정. 당신의 숫자는 당신만의 것입니다. [방법론 보기 →](BENCHMARK.md)
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/user-profiles.svg" alt="1M 세션 내부에서 일어나는 일" width="800">
+</p>
+
+## 능동 압축
+
+컨텍스트를 능동적으로 줄이는 9가지 기능, 모두 기본 켜짐, 모두 자동, 모두 대시보드나 CLI에서 토글 가능.
+
+내부적으로, **PreToolUse 훅**이 모든 Read와 Bash 호출이 컨텍스트에 들어가기 전에 가로챕니다. 파일이 이미 읽혔다면, diff만 돌아옵니다. 코드 파일 재읽기라면, 구조적 스켈레톤이 전체 내용을 대체합니다. CLI 명령이라면, 출력이 압축됩니다. **PostToolUse 훅**은 전체 원본을 디스크에 보관하고 압축 이벤트를 SQLite에 기록합니다. 아무것도 손실되지 않으며, 모든 것이 검색 가능합니다. **사용자가 할 일은 없습니다. 훅이 전부 처리합니다.**
+
+![능동 압축 개요](skills/token-optimizer/assets/active-compression-hero.svg)
+
+| 기능 | 하는 일 | 절감 |
+|---|---|---|
+| 델타 모드 | 재읽기는 변경된 부분만 반환 | 재읽기 시 ~20% |
+| 구조 맵 | 변경 없는 파일 재읽기는 구조적 스켈레톤 반환 | ~30% (파일당 최대 99%) |
+| Bash 압축 | CLI 출력을 필수로 요약 | ~10% |
+| 검색 압축 | grep/웹 결과를 상위 적중 + 개수로 요약 | ~15% |
+| 간결 출력 넛지 | 컨텍스트가 찰 때 모델을 간결 출력으로 안내 | 추정 10-15%; 반사실적 측정 아님 |
+| 품질 넛지 | 컨텍스트 품질이 떨어질 때 경고 | 압축 손실 방지 |
+| 루프 감지 | 토큰을 태우기 전에 재시도 루프 포착 | 루프별 측정 |
+| 활동 모드 | 세션 단계에 맞춰 압축 조정 | 결정 손실 방지 |
+| 결정 추출 | 압축 간 결정 보존 | 결정 드리프트 방지 |
+
+대시보드 Manage 탭, CLI(`measure.py v5 enable|disable <feature>`), 또는 환경 변수에서 토글. `v5` 동사는 현재 기능을 제어하는 레거시 명령 이름입니다.
+
+[각 기능이 어떻게 작동하는지 읽기 →](https://alexgreensh.github.io/token-optimizer/features/active-compression/)
+
+<details>
+<summary><b>기능별 세부 정보</b></summary>
+
+### 델타 모드
+
+AI가 편집 후 파일을 재읽기하면, Read 호출은 diff만 반환합니다. 실제 세션의 65% 이상 Read 호출이 재읽기입니다. 2,000토큰 파일 재읽기가 50토큰 diff가 됩니다.
+
+![델타 모드: 스마트 재읽기](skills/token-optimizer/assets/delta-mode.svg)
+
+비활성화: `TOKEN_OPTIMIZER_READ_CACHE_DELTA=0`
+
+### 구조 맵
+
+Claude가 이미 본 코드 파일을 재읽기하면, Read 호출이 차단되고 구조적 요약으로 대체됩니다: 함수 서명, 클래스 계층, 임포트. 720KB Python 파일(180,000 토큰)이 250토큰 스켈레톤이 됩니다.
+
+비활성화: `TOKEN_OPTIMIZER_READ_CACHE_MODE=shadow`
+
+### 첫 읽기 스켈레톤
+
+히스토리 검증 코호트에서 큰 **코드** 파일(Python 또는 TypeScript, 16KB~256KB)의 **첫** 읽기 시, Read는 전체 파일 대신 구조적 스켈레톤(서명/임포트)을 반환하며, 한 줄 알림과 함께 전체 내용은 항상 한 단계 거리에 있습니다: `expand <key>`, 범위 Read(`offset`/`limit`), 또는 직접 Edit. 원본은 어떤 대체 전에 보관되며, 실패 시 열림(fail-open)합니다. 보관이 불가능하면 전체 파일이 제공됩니다.
+
+이는 **코드에만** 적용됩니다. Markdown과 다른 산문은 첫 읽기에 스켈레톤화되지 **않습니다** (v5.11.27 기준): 제목 전용 개요는 핵심 산문을 떨어뜨리므로, 문서는 항상 완전히 돌아옵니다. 런타임 트립와이어는 라이브 편집률이 오르면 코드 코호트를 측정 전용으로 자동 강등합니다.
+
+제공 비활성화(측정 유지): `TOKEN_OPTIMIZER_FIRST_READ_ACTIVE=0`. 완전 비활성화: `TOKEN_OPTIMIZER_FIRST_READ_SHADOW=0`. 둘 다 `measure.py v5 status`와 대시보드 Manage 탭에서 보이고 토글 가능합니다.
+
+### Bash 출력 압축
+
+일반 CLI 명령을 재작성하여 압축된 요약을 반환합니다. lint, 로그 꼬리, tree, docker pull, 긴 목록, 빌드 출력, 테스트 러너를 다룹니다. 564토큰 pytest 출력이 115 토큰이 됩니다.
+
+![Bash 출력 압축](skills/token-optimizer/assets/bash-compression.svg)
+
+비활성화: `TOKEN_OPTIMIZER_BASH_COMPRESS=0`
+
+### 검색 결과 압축
+
+AI가 grep, rg, 또는 긴 결과 목록을 반환하는 웹 검색을 실행하면, 출력이 상위 적중과 개수로 요약됩니다. 500줄 grep 결과가 20줄과 요약이 됩니다.
+
+비활성화: `TOKEN_OPTIMIZER_BASH_COMPRESS=0` (검색 압축은 bash 압축의 일부입니다; 별도 스위치가 없습니다)
+
+### 간결 출력 넛지
+
+컨텍스트가 25%를 넘어 차면, 짧은 넛지가 모델에게 깊이 추론하되 보이는 출력은 간결하게 유지하라고 알립니다. 채움량이 유일한 조건입니다. 품질은 더 이상 이를 제어하지 않으므로, 보통의 건강한 세션도 넛지를 받습니다, 길게 저하된 세션만이 아닙니다. 절감은 **10-15%로 추정되며, 측정되지 않습니다**: 반사실적(넛지 없이 모델이 썼을 내용)은 관찰할 수 없으므로, Token Optimizer는 이를 추정 티어에 보고하고 측정된 절감에 절대 포함하지 않습니다. 캐시 안전: `additionalContext`로 주입, 기존 접두사 수정 안 함.
+
+오늘날 켜기/끄기 스위치 없음(`v5` 기능 아님). `TOKEN_OPTIMIZER_VERBOSITY_MIN_FILL`(기본 `25`)로 트리거 지점을 조정하세요.
+
+### 품질 넛지
+
+컨텍스트 품질을 실시간으로 감시합니다. 점수가 15점 이상 떨어지거나 60 아래로 내려가면, 인라인 메모가 컨텍스트에 들어갑니다. Claude는 다음 턴에 이를 보고 경고를 표면화하거나 행동을 조정합니다. 5분 쿨다운, 세션당 최대 3회.
+
+비활성화: `TOKEN_OPTIMIZER_QUALITY_NUDGES=0`
+
+### 루프 감지
+
+AI가 재시도 루프에 갇히는 것을 포착합니다. 마지막 4개 사용자 메시지와 마지막 5개 도구 결과를 유사성으로 비교합니다. 신뢰도 ≥0.7에서 발동, 세션당 2개 메모 상한. 실제 루프 턴 내용에서 측정된 절감.
+
+비활성화: `TOKEN_OPTIMIZER_LOOP_DETECTION=0`
+
+### 활동 모드 감지
+
+마지막 10개 도구 호출을 사용하여 세션을 5가지 모드(코드, 디버그, 리뷰, 인프라, 일반) 중 하나로 분류합니다. 이 모드는 압축 지침에 들어가 PRESERVE/DROP 우선순위가 당신이 하는 일에 적응하게 합니다.
+
+### 결정 추출
+
+도구 출력에서 결정 문을 실시간으로 감지하여 세션 데이터베이스에 저장합니다. 압축 시, 이 결정들은 압축 요약이 축어로 보존해야 하는 CRITICAL DECISIONS로 주입됩니다. 세션당 10개 상한.
+
+### 실제 절감 측정
+
+모든 압축 기능은 로컬 SQLite 테이블에 기록됩니다. 기계 밖으로 아무것도 나가지 않습니다.
+
+```bash
+python3 measure.py compression-stats --days 30
+```
+
+</details>
+
+## 세션 데이터베이스
+
+Token Optimizer가 하는 모든 것은 두 개의 로컬 SQLite 데이터베이스로 뒷받침됩니다. 기계 밖으로 아무것도 나가지 않습니다. 네트워크 호출 없음.
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/session-database-flow.svg" alt="세션 데이터베이스 흐름: 도구 호출이 압축, 보관, SQLite에 기록, 검색 가능" width="900">
+</p>
+
+**세션별 DB**(`~/.claude/token-optimizer/snapshots/session-store/<session>.db`)는 파일 읽기, 도구 출력, 명령 출력, 캐시된 내용, 컨텍스트 인텔 이벤트, 활동 로그, 결정 로그, 힌트 제공을 추적하는 8개 테이블을 가집니다. 훅 프로세스에서 동시 읽기/쓰기를 위한 WAL 모드. 세션당 50MB 상한.
+
+**추세 DB**(`~/.claude/token-optimizer/snapshots/trends.db`)는 세션 히스토리, 일일 집계, 스킬/모델/서브에이전트 사용, 절감 이벤트, 압축 이벤트를 추적하는 7개 테이블을 가집니다. O(log n) 조인을 위해 세션 UUID로 인덱스. 이것이 대시보드, 코치 모드, 30일 추세 분석을 구동합니다.
+
+모든 압축 이벤트, 모든 절감, 모든 품질 측정은 쿼리 가능한 행입니다. 대시보드는 이 데이터의 읽기 전용 뷰입니다. `measure.py compression-stats`는 SQL 쿼리입니다. 당신의 데이터는 당신의 것입니다.
+
+## 점진적 공개
+
+큰 도구 결과(>4KB)는 디스크에 보관되고 짧은 미리 보기와 검색 포인터로 대체됩니다. 전체 출력은 압축을 넘겨살립니다. 모델이 필요할 때, 명령 재실행이나 손실된 출력 없이 `expand`로 원본을 가져옵니다.
+
+이는 단순한 저장이 아닙니다. 시스템은 보관된 결과와 재펼쳐진 결과의 수를 추적하여, 접힌 채로 남은 순 토큰을 볼 수 있습니다. 재펼치기는 절감 총계에서 차감되므로, 실제로 접힌 채로 남은 것만 계산합니다.
+
+```bash
+python3 measure.py expand --list          # 보관된 도구 결과 목록
+python3 measure.py expand <tool-use-id>   # 특정 결과 검색
+```
+
+일부 MCP 도구는 메타데이터 미리 보기가 요점을 무너뜨리는, 큰 축어 페이로드를 반환하도록 *문서화*되어 있습니다(소스 페처, 문서 검색기). 그 결과가 대체되지 않고 컨텍스트에 도달하도록 허용 목록에 추가하세요(여전히 보관되므로 `expand`가 작동합니다). 전체 도구 이름에 대해 일치하는 `fnmatch` 글롭의 쉼표로 구분된 목록을 설정하세요:
+
+`TOKEN_OPTIMIZER_ARCHIVE_EXEMPT_TOOLS="mcp__context7__*,*github_repository_file"`
+
+기본은 비어 있습니다. 도구를 옵트인하지 않는 한 아무것도 면제되지 않습니다.
+
+## 세션 연속성
+
+압축도 중요하지만, Token Optimizer가 하는 가장 중요한 일은 세션과 압축 사이에서 작업을 자동으로 살려두는 것입니다.
+
+세션을 끝낼 때, Token Optimizer는 상태를 SQLite에 체크포인트합니다: 활성 작업, 핵심 결정, 수정된 파일, git 브랜치, 최근 읽기. 새 세션을 시작할 때, 프롬프트에 대해 모든 최근 체크포인트를 점수하고 가장 관련 있는 것을 힌트로 표면화합니다. 제로가 아닌 컨텍스트로 재개합니다.
+
+**자동으로 일어나는 일:**
+
+- **세션 간 힌트**: 관련성 점수가 매겨진 체크포인트가 새 세션 시작 시 표면화. 힌트는 이전 세션의 작업, 결정, 파일, 브랜치를 포함. 모두 RECOVERED DATA로 울타리 침, 지시가 아님.
+- **콜드 리줌 간결**: 전체 전사 비용 없이 오래된 세션 다시 열기. Token Optimizer는 체크포인트에서 간결한 컨텍스트를 재구성. LLM 호출 없음, 전체 전사 콜드 리줌 없음. SQLite에서 토큰 없는 재구성.
+- **힌트 팔로우 측정**: 연속성 힌트가 파일 경로를 표면화하고 모델이 이후에 그 중 하나를 읽으면, Token Optimizer는 회피된 탐색적 검색으로 인정. 추측이 아닌 측정된 인과.
+
+```bash
+python3 measure.py resume-lean                    # 다시 열 수 있는 콜드 세션 목록
+python3 measure.py resume-lean <#|session_id> --print  # 간결 컨텍스트 블록 출력
+```
+
+압축 절감은 세션이 압축을 넘겨살릴 때만 유지됩니다. 세션 연속성이 그것을 가능하게 합니다.
+
+## 스마트 압축
+
+자동 압축이 발동하면, 대화의 60~70%가 사라집니다. 결정, 오류 수정 시퀀스, 에이전트 상태, 전부 사라집니다.
+
+Token Optimizer는 압축 전에 세션을 체크포인트하고, 훅을 통해 요약이 떨어뜨린 것을 자동으로 복원합니다. 또한 **컨텍스트 인텔 요약**을 주입합니다: 모델이 이미 처리한 큰 도구 출력의 휴리스틱 요약(접근한 파일 경로, 본 오류, 줄 수). 압축 후, 모델은 모든 것을 재읽기 없이 자신이 본 것을 압니다.
+
+**활동 모드 감지**는 마지막 10개 도구 호출을 사용하여 세션을 실시간으로 분류합니다(코드, 디버그, 리뷰, 인프라, 일반). 이 모드는 압축 지침에 들어가 PRESERVE/DROP 우선순위가 일반적 휴리스틱이 아닌 지금 당신이 하는 일에 적응하게 합니다.
+
+**결정 추출**은 결정 문을 도구 출력에서 일어나는 대로 감지하여 세션 DB에 저장합니다. 압축 시, 이들은 요약이 축어로 보존해야 하는 CRITICAL DECISIONS로 주입됩니다. 세션당 10개 상한.
+
+압축 절감은 세션이 압축을 넘겨살릴 때만 유지됩니다. `git status`에서 토큰을 절약하는 것은 다음 자동 압축이 그것을 실행하게 한 결정을 지워버리면 도움이 되지 않습니다.
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/quality-nudges-loops.svg" alt="작동 중인 품질 넛지와 루프 감지" width="800">
+</p>
+
+<details>
+<summary><b>스마트 압축 작동 방식</b></summary>
+
+### 점진적 체크포인트
+
+여러 임계값에서 세션 상태를 포착: 20%, 35%, 50%, 65%, 80% 컨텍스트 채움, 품질 80, 70, 50, 40 아래로 떨어질 때. 에이전트 팬아웃 전과 큰 편집 배치 후에도 스냅샷. 복원 시, 가장 풍부한 자격 체크포인트 선택.
+
+### 컨텍스트 인텔 요약
+
+압축 후, Token Optimizer는 세션의 가장 큰 도구 출력의 요약을 주입: 접근한 파일 경로, 감지된 오류, 줄 수. <30ms에 휴리스틱하게 생성, LLM 호출 없음. 모델이 모든 것을 재읽기 없이 재정위치.
+
+```bash
+python3 measure.py setup-smart-compact    # 체크포인트 + 복원 훅
+```
+
+</details>
+
+## 출력 토큰: 간결 vs 장황
+
+출력 토큰은 세션에서 가장 비싼 부분입니다. Opus에서 입력 토큰보다 5배 비싸고, 캐시 읽기가 아닌 생성당 청구됩니다. 간단한 질문에 대한 장황한 응답은 결코 쓸 필요 없었던 달러를 태웁니다.
+
+Token Optimizer는 **간결 출력 넛지**로 이를 자동으로 처리합니다. 컨텍스트가 25%를 넘어 차면, 짧은 넛지가 모델에게 깊이 추론하되 보이는 출력은 간결하게 유지하라고 알립니다. 채움량이 유일한 트리거입니다; 컨텍스트 품질은 조건이 아닙니다. 감소는 **10-15%로 추정되며 반사실적으로 측정되지 않으므로**, 측정된 절감과 분리되어 추정 티어에 보고됩니다.
+
+**작동 방식:**
+
+- 넛지는 `additionalContext`로 주입, 기존 접두사 수정 안 함, 그래서 캐시가 온전히 유지
+- 컨텍스트가 차오를 때만 발동, 여유가 많을 때가 아님
+- 모델은 여전히 문제를 생각; 더 간결한 보이는 답만 생성
+- 오늘날 켜기/끄기 스위치 없음; `TOKEN_OPTIMIZER_VERBOSITY_MIN_FILL`(기본 `25`)로 트리거 지점 조정
+
+이는 9개 능동 압축 기능 중 하나이며, 토큰이 가장 비싼 출력 측에서 절감하는 기능입니다.
+
+## 품질 점수
+
+품질 점수는 두 가지를 추적합니다: **자원 건강**(저하 절벽에 얼마나 가까운지)과 **세션 효율**(토큰이 유용한 일을 하고 있는지). S에서 F까지의 등급이 분류를 즉시 만듭니다.
+
+컨텍스트가 차오르면, 품질이 떨어집니다. MRCR이 256K와 1M 컨텍스트 사이에서 93%에서 76%로 떨어집니다. 창이 차오르면 AI가 측정 가능하게 둔해집니다. 품질 점수는 그것이 언제 일어나는지 정확히 보여줍니다.
+
+![실제 세션 품질 분석](skills/token-optimizer/assets/quality-example.svg)
+
+상태 표시줄은 품질이 저하됨에 따라 색이 바뀝니다: 녹색, 노랑, 주황, 빨강. 품질이 75 아래로 떨어지면, 세션 지속 시간이 경고로 나타납니다. 실행 중인 서브에이전트는 모델과 경과 시간과 함께 표시.
+
+![상태 표시줄 저하](skills/token-optimizer/assets/status-bar.svg)
+
+```bash
+python3 measure.py setup-quality-bar      # 일회성 설치
+```
+
+[점수 작동 방식 읽기 →](https://alexgreensh.github.io/token-optimizer/features/quality-signals/)
+
+<details>
+<summary><b>품질 점수 세부 정보</b></summary>
+
+| 점수 | 신호 | 의미 |
+|--------|--------|----------------|
+| **자원 건강** | 컨텍스트 채움, 압축 깊이, 절대 낭비 토큰 | 저하 절벽에 얼마나 가까운지 |
+| **세션 효율** | 오래된 읽기, 부풀려진 결과, 결정 밀도, 에이전트 효율 | 세션이 지금 토큰을 잘 쓰고 있는지 |
+
+| 등급 | 범위 | 의미 |
+|-------|-------|---------|
+| **S** | 90-100 | 최고 효율 |
+| **A** | 80-89 | 건강, 소폭 최적화 가능 |
+| **B** | 70-79 | 저하 시작 |
+| **C** | 55-69 | 상당한 낭비 |
+| **D** | 40-54 | 심각한 문제 |
+| **F** | 0-39 | 컨텍스트가 부패 중, 즉시 조치 필요 |
+
+**품질 표시줄이 사라졌나요?** Claude Code의 `/statusline` 실행이 Token Optimizer의 항목을 덮어씁니다. SessionStart가 자동 복원. 새 세션을 시작하면 돌아옵니다.
+
+**영구히 끄고 싶나요?**
+```bash
+python3 measure.py setup-quality-bar --uninstall
+```
+
+</details>
+
+## 코치 모드
+
+```
+> /token-coach
+```
+
+목표를 말하세요. 정확한 토큰 절감과 함께 구체적이고 우선순위가 매겨진 수정을 받으세요. 30일의 세션 데이터를 읽고 단일 세션이 보여줄 수 없는 것을 표면화합니다: 품질이 내려가는 것, 세션이 길어지는 것, 캐시 적중률이 떨어지는 것, 세션당 비용이 오르는 것.
+
+모든 인사이트는 실제 숫자에 근거합니다. "짧은 세션이 68점, 긴 세션이 60점"은 "더 짧은 세션을 고려하세요"와는 다르게 와닿습니다. 코치 모드는 또한 프로젝트 수준 최적화 기회(결코 사용하지 않는 스킬, 열심히 로드하는 MCP 서버, 캐시를 깨는 CLAUDE.md 패턴)를 식별하고 미래 세션이 더 간결하게 시작하도록 고치는 방법을 가르칩니다.
+
+[코치 모드에 대해 읽기 →](https://alexgreensh.github.io/token-optimizer/features/token-coach/)
+
+<details>
+<summary><b>코치 모드 세부 정보</b></summary>
+
+### 감지된 과거 패턴
+
+| 패턴 | 감지하는 것 |
+|---|---|
+| 품질 드리프트 | 주 단위로 떨어지는 평균 품질 |
+| 세션 지속 크리프 | 세션이 길어지고, 컨텍스트가 더 빨리 참 |
+| 캐시 저하 | 캐시 적중률 하락 (및 모델 전환이 원인인지) |
+| 등급 분포 | D 등급 세션이 너무 많이 쌓임 |
+| 비용 인식 | 세션당 비용 상승, 라우팅 조언과 함께 |
+| 지속-품질 상관 | 짧은 세션이 더 높은 점수, 긴 세션을 쪼개라는 제안 |
+| 압축 갭 | 섀도 전용 절감이 능동 압축을 크게 초과 |
+| 모델 전환 | 빈번한 세션 중 모델 전환이 프롬프트 캐시 무효화 |
+
+### 낭비 감지기
+
+11개 자동 감지기가 세션 패턴을 분석:
+
+| 감지기 | 잡는 것 |
+|---|---|
+| PDF/바이너리 섭취 | 컨텍스트를 소비하는 큰 파일 |
+| 웹 검색 오버헤드 | 컨텍스트에 너무 많은 웹 결과 덤핑 |
+| 재시도 처닝 | 오류와 함께 같은 도구 3회 이상 재시도 |
+| 도구 캐스케이드 | 3회 이상 연속 도구 오류 |
+| 루핑 | 반복된 유사 메시지 |
+| 과잉 모델 | 간단한 편집에 Opus 사용 |
+| 약한 모델 | 복잡한 작업에 Haiku |
+| 잘못된 분해 | 단일 500자 이상 프롬프트 |
+| 낭비적 사고 | 작은 편집에 출력의 2배 이상 확장 사고 |
+| 출력 낭비 | 간단한 작업에 장황한 응답 |
+| 캐시 불안정 | 프롬프트 캐시를 깨는 CLAUDE.md 패턴 |
+
+### 킵 웜(Keep-Warm)
+
+API 청구 세션을 위한 옵트인 기능. 프롬프트 캐시 항목이 만료되기 직전에 작은 캐시 읽기 핑을 발행하여 TTL을 갱신. 재개 시 지불할 1.25-2배 재작성 대비 접두사의 ~0.1배 비용. 핑이 비용을 스스로 지불하지 못하면 트립와이어 자동 꺼짐.
+
+```bash
+python3 measure.py keepwarm-enable          # 옵트인 (API 청구만)
+python3 measure.py keepwarm-report            # 순 절감, 지출, 트립와이어 상태
+python3 measure.py keepwarm-disable           # 언제든 옵트아웃
+```
+
+### 플릿 감사자
+
+Claude Code, Codex, 커스텀 전사 설정을 스캔하여 유휴 소모, 모델 잘못된 라우팅, 설정 부풀림을 발견하고 발견별 달러 절감을 보여줍니다.
+
+### CLAUDE.md 라우팅 주입
+
+실제 사용 데이터에서 모델 라우팅 지시를 생성하여 CLAUDE.md에 주입. 48시간 부실 가드가 부실한 조언을 자동 제거.
+
+```bash
+python3 measure.py inject-routing --dry-run   # 미리 보기
+python3 measure.py inject-routing              # 주입
+```
+
+</details>
+
+## FAQ
+
+<details>
+<summary><b>🔒 컨텍스트 품질을 저하시킬 수 있나요?</b></summary>
+
+아니요. 구조적 최적화는 진정으로 사용하지 않는 컴포넌트만 제거합니다. 능동 압축 제어는 단일 명령이나 환경 변수로 비활성화할 수 있습니다. 품질 점수 시스템이 저하를 실시간으로 추적합니다.
+
+</details>
+
+<details>
+<summary><b>💾 프롬프트 캐시를 깨나요?</b></summary>
+
+아니요. Token Optimizer는 컨텍스트에 이미 있는 내용을 결코 건드리지 않습니다. 창에 들어오는 새 내용과 압축 경계에서 작동합니다. 캐시 접두사가 온전히 유지되어, 두 번 절약합니다: 턴당 더 적은 입력, 그리고 이후 매 턴 더 저렴한 캐시 읽기.
+
+</details>
+
+<details>
+<summary><b>📡 어디론가 데이터를 보내나요?</b></summary>
+
+분석 없음, 텔레메트리 엔드포인트 없음, 제품 데이터가 기계 밖으로 나가지 않음. 측정 이벤트는 사용자가 소유한 로컬 SQLite 행. 네트워크 호출 없음.
+
+</details>
+
+<details>
+<summary><b>⚠️ 세션을 해칠 수 있나요?</b></summary>
+
+아니요. 모든 훅은 실패 시 열림(fail-open) 설계로 비차단입니다. Token Optimizer 스크립트가 오류나면, 명령이 정상적으로 실행됩니다.
+
+</details>
+
+<details>
+<summary><b>📦 런타임 의존성이 있나요?</b></summary>
+
+아니요. Claude Code와 Codex에서 순수 Python 표준 라이브러리. OpenCode와 OpenClaw에서 런타임 의존성 없는 TypeScript.
+
+</details>
+
+<details>
+<summary><b>🔐 install.sh는 파일 무결성을 어떻게 검증하나요?</b></summary>
+
+최신 GitHub Release 태그를 해결하고, 그 태그를 체크아웃하고, 같은 릴리스에서 CHECKSUMS.sha256을 가져와, 모든 스크립트 파일을 검증합니다. 대역 외 검증은 손상된 커밋이 코드와 체크섬을 동시에 바꿀 수 없음을 의미합니다.
+
+</details>
+
+## 모든 명령
+
+<details>
+<summary><b>모든 명령 보기</b></summary>
+
+| 명령 | 하는 일 | 문서 |
+|---|---|---|
+| `/token-optimizer` | 6개 병렬 에이전트로 전체 감사, 가이드된 수정 | [→](https://alexgreensh.github.io/token-optimizer/start/quickstart/) |
+| `/token-coach` | 30일 추세 분석, 우선순위 수정 | [→](https://alexgreensh.github.io/token-optimizer/features/token-coach/) |
+| `quick` | 10초 건강 검사 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `doctor` | 설치 검사, 10점 만점 점수 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `dashboard` | HTML 대시보드 열기 | [→](https://alexgreensh.github.io/token-optimizer/features/dashboard/) |
+| `savings` | 달러 절감 보고서 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `report` | 컴포넌트별 토큰 분석 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `quality` | 라이브 세션의 컨텍스트 품질 분석 | [→](https://alexgreensh.github.io/token-optimizer/features/quality-signals/) |
+| `trends` | 스킬 채택, 모델 믹스, 시간에 따른 오버헤드 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `compression-stats` | 능동 압축의 측정된 절감 | [→](https://alexgreensh.github.io/token-optimizer/features/active-compression/) |
+| `memory-review` | MEMORY.md 구조 감사 | [→](https://alexgreensh.github.io/token-optimizer/features/memory-health/) |
+| `git-context` | 현재 diff에 대한 파일 제안 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `drift` | 마지막 스냅샷과 나란히 비교 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `conversation` | 메시지별 토큰과 비용 분석 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `pricing-tier` | 가격 티어 보기 또는 전환 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `expand` | 보관된 도구 결과 검색 (점진적 공개) | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `resume-lean` | 토큰 없는 재구성으로 콜드 세션 다시 열기 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+
+[전체 CLI 참조 →](https://alexgreensh.github.io/token-optimizer/reference/cli/)
+
+</details>
+
+## 라이선스
+
+**PolyForm Noncommercial 1.0.0**. 소스 공개. 개인, 연구, 교육, 비상업적 사용은 라이선스 구매가 필요 없습니다.
+
+### 개인 / 취미 / 연구 / 교육?
+하세요. 전체 소스, 로컬 실행, 라이선스 구매 불필요.
+
+### 소규모 팀 (5인 미만 또는 월 $20k 미만 수익)?
+소규모 팀은 무료 상업 라이선스를 자동으로 받습니다. 그냥 사용하세요.
+
+### 개인으로 시작했는데, 이제 비즈니스로 변하고 있나요?
+과거 사용은 완전히 괜찮습니다. 라이선스에는 서면 통지 후 32일 유예 기간이 내장되어 있습니다. 준비되면 상업 라이선스를 위해 연락하세요.
+
+### 더 큰 회사 / 상업적 사용?
+[Alex Greenshpun](https://linkedin.com/in/alexgreensh) 또는 me@alexgreenshpun.com에 연락하세요.
+
+---
+
+[Alex Greenshpun](https://linkedin.com/in/alexgreensh)이 제작.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 <p align="center">
+  <b>English</b> ·
+  <a href="README.ko.md">한국어</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
   <img src="skills/token-optimizer/assets/logo.svg" alt="Token Optimizer" width="780">
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,687 @@
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.ko.md">한국어</a> ·
+  <b>简体中文</b> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/logo.svg" alt="Token Optimizer" width="780">
+</p>
+
+<p align="center">
+  <a href="https://github.com/alexgreensh/token-optimizer/releases/latest"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=version&color=green" alt="最新稳定版本"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/commits/main"><img src="https://badgen.net/github/last-commit/alexgreensh/token-optimizer?label=last%20commit" alt="最近提交"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer"><img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet" alt="Claude Code Plugin"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/openclaw"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2Fopenclaw%2Fpackage.json&query=%24.version&prefix=v&label=OpenClaw&color=brightgreen" alt="OpenClaw 版本"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/opencode"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2Fopencode%2Fpackage.json&query=%24.version&prefix=v&label=OpenCode&color=58a6ff" alt="OpenCode 版本"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/docs/codex.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.codex-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Codex&color=orange" alt="Codex 版本"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/tree/main/hermes"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Hermes&color=0d9488" alt="Hermes 版本"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/docs/copilot.md"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Falexgreensh%2Ftoken-optimizer%2Fmain%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=Copilot&color=6e40c9&logo=githubcopilot&logoColor=white" alt="GitHub Copilot 版本"></a>
+</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/cuts%20context%20waste-3fb950" alt="减少上下文浪费">
+  <img src="https://img.shields.io/badge/survives%20compaction-checkpoint%20%2B%20restore-58a6ff" alt="在压缩中存活">
+  <img src="https://img.shields.io/badge/saves%20real%20%24-every%20session-2ea043" alt="每个会话节省真实美元">
+  <img src="https://img.shields.io/badge/live%20dashboard-tokens%20%2B%20%24%20%2B%20turns-8B5CF6?logo=chartdotjs&logoColor=white" alt="实时仪表盘">
+  <img src="https://img.shields.io/badge/context%20quality-live%20score-blue" alt="实时上下文质量评分">
+  <img src="https://img.shields.io/badge/tests-passing-brightgreen" alt="测试通过">
+</p>
+<p align="center">
+  <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="零依赖">
+  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="零遥测">
+  <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9+">
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="平台">
+  <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="许可证: PolyForm Noncommercial"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/stargazers"><img src="https://badgen.net/github/stars/alexgreensh/token-optimizer" alt="GitHub Stars"></a>
+  <a href="https://github.com/alexgreensh/token-optimizer/commits/main"><img src="https://badgen.net/github/commits/alexgreensh/token-optimizer?label=commits" alt="提交"></a>
+  <a href="https://linkedin.com/in/alexgreensh"><img src="https://img.shields.io/badge/LinkedIn-Connect-0A66C2?logo=linkedin&logoColor=white" alt="在 LinkedIn 上联系"></a>
+</p>
+<p align="center">
+  <a href="https://github.com/sponsors/alexgreensh"><img src="https://img.shields.io/badge/%E2%99%A5%20Support%20this%20project%20to%20keep%20it%20open%20source-ea4aaa?style=for-the-badge&logo=githubsponsors&logoColor=white" alt="支持本项目以保持开源"></a>
+</p>
+
+<h2 align="center">砍掉你浪费的 token。留住你本会丢失的工作。</h2>
+
+<p align="center"><em>它在后台自动运行。你照常工作。想要全貌时运行审计即可。</em></p>
+
+<p align="center">
+  <a href="https://alexgreensh.github.io/token-optimizer/"><img src="https://img.shields.io/badge/%F0%9F%93%96%20Read%20the%20Docs-alexgreensh.github.io%2Ftoken--optimizer-e85329?style=for-the-badge&logoColor=white" alt="阅读文档"></a>
+  <a href="https://alexgreensh.github.io/token-optimizer/start/quickstart/"><img src="https://img.shields.io/badge/Quickstart-2%20minutes-3fb950?style=for-the-badge" alt="2 分钟快速开始"></a>
+</p>
+
+## 30 秒版本
+
+Token Optimizer 砍掉你的 AI 编程助手浪费的 token，让你的工作在会话和压缩(compaction)之间存活，并在实时仪表盘上展示每一美元去了哪里。**大部分自动运行。你安装它，运行一次审计，剩下的交给 hook。**
+
+**为什么不直接用 Headroom 或 RTK?** 它们压缩命令输出，只覆盖你上下文的 15-25%。Token Optimizer 覆盖这部分加上另外 75%:臃肿的配置、未使用的 skill、陈旧的记忆、压缩损失、模型误路由、行为浪费。每一项节省都对缓存安全且经过测量。仪表盘在每个会话后自动更新。
+
+可在 **Claude Code**(CLI 和 VS Code)、**OpenCode**、**OpenClaw**、**Codex**、**Hermes** 和 **GitHub Copilot** 上运行。Windsurf 和 Cursor 是路线图的下一站。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/hero-terminal.svg" alt="Token Optimizer 快速扫描" width="800">
+</p>
+
+## 安装
+
+**Claude Code(推荐):**
+
+```
+/plugin marketplace add alexgreensh/token-optimizer
+/plugin install token-optimizer@alexgreensh-token-optimizer
+```
+
+然后在 Claude Code 中:`/token-optimizer`
+
+> **安装后请启用自动更新。** Claude Code 默认以自动更新关闭来分发第三方市场。`/plugin` → **Marketplaces** 标签 → 选择 `alexgreensh-token-optimizer` → **Enable auto-update**。一次性,10 秒。
+>
+> 安装后,运行一次 `/token-optimizer` 来设置 hook。此后一切自动运行:压缩、检查点、质量评分、仪表盘更新。除非你想要审计,否则无需再运行任何命令。
+
+<details>
+<summary><b>其他平台和安装方法</b></summary>
+
+**Codex:**
+```bash
+codex plugin marketplace add alexgreensh/token-optimizer
+```
+然后在 Codex TUI 中:`/plugins` 并安装 Token Optimizer。参见 [`docs/codex.md`](docs/codex.md)。
+
+**OpenCode:** 将 `token-optimizer-opencode` 添加到你的 `opencode.json` 的 `plugin` 数组:
+```jsonc
+{ "$schema": "https://opencode.ai/config.json", "plugin": ["token-optimizer-opencode"] }
+```
+参见 [`opencode/README.md`](opencode/README.md)。
+
+**OpenClaw:**
+```bash
+openclaw plugins install github:alexgreensh/token-optimizer
+```
+参见 [`openclaw/README.md`](openclaw/README.md)。
+
+**Hermes:**
+```bash
+git clone https://github.com/alexgreensh/token-optimizer.git
+token-optimizer/install.sh --hermes
+```
+参见 [`hermes/README.md`](hermes/README.md)。
+
+**GitHub Copilot:**
+```bash
+git clone --depth 1 https://github.com/alexgreensh/token-optimizer.git
+cd token-optimizer
+bash install.sh --copilot
+```
+参见 [`docs/copilot.md`](docs/copilot.md)。
+
+**macOS/Linux 脚本安装(插件的替代):**
+```bash
+tmp="$(mktemp -d)"
+release_json="$(curl -fsSL https://api.github.com/repos/alexgreensh/token-optimizer/releases/latest)"
+tag="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])' <<<"$release_json")"
+git clone --branch "$tag" --depth 1 https://github.com/alexgreensh/token-optimizer.git ~/.claude/token-optimizer
+bash ~/.claude/token-optimizer/install.sh
+rm -rf "$tmp"
+```
+
+**Windows 用户:** 仅使用插件安装。不要在 Windows 上运行 `install.sh`。如果遇到 `EBUSY` 错误,关闭所有 Claude Code 和 Git Bash 窗口,杀掉残留的 `git.exe` 进程,删除 `C:\Users\<you>\.claude\token-optimizer` 和 `C:\Users\<you>\.claude\plugins\marketplaces\alexgreensh-token-optimizer`,然后重试。
+
+**如果 `install.sh` 因 `$'\r': command not found` 失败**(在强制 LF 换行之前的克隆把脚本转成了 CRLF),剥离一次回车符再重新运行,仓库现在附带一个 `.gitattributes` 在新克隆上防止此问题:
+```bash
+sed -i 's/\r$//' ~/.claude/token-optimizer/install.sh
+# 已经有仓库了?就地重新规范化换行:
+git -C ~/.claude/token-optimizer add --renormalize . && git -C ~/.claude/token-optimizer checkout -- .
+```
+
+</details>
+
+<details>
+<summary>卸载</summary>
+
+Token Optimizer 是附加且可逆的。每个运行时都有干净的卸载,只移除我们安装的内容,保留你自己的 hook、配置和会话数据。每个运行时的完整步骤见 **[docs/uninstall.md](docs/uninstall.md)**。
+
+最快路径(Claude Code 插件安装):
+
+```
+/plugin uninstall token-optimizer@alexgreensh-token-optimizer
+```
+
+</details>
+
+## 你得到什么
+
+**每个会话自动运行,你什么都不用做:**
+
+- 🔄 **智能压缩(Smart Compaction)**:自动压缩前检查点,之后恢复
+- 🗄️ **会话连续性(Session Continuity)**:跨会话提示、冷恢复、检查点评分
+- 📦 **主动压缩(Active Compression)**:9 项功能,全部默认开启(delta diff、骨架、bash/搜索压缩、精简输出提示、质量提示、循环检测、活动模式、决策提取)
+- 📊 **质量评分(Quality Scoring)**:7 个信号,实时,S–F 字母等级
+- 🗃️ **会话数据库(Session Database)**:SQLite,15 张表,完整审计追踪,零网络
+- 🔍 **渐进式披露(Progressive Disclosure)**:大输出归档,按需展开
+- 🧠 **上下文情报摘要(Context Intel Digest)**:压缩后无需重读的重新定位
+- 🔀 **模型路由提示(Model Routing Nudges)**:引导到适合任务的层级
+
+**你主动要求时:**
+
+- 🩺 `/token-optimizer`:带引导修复的完整审计
+- 📈 `/token-coach`:带具体修复的 30 天趋势分析
+- ⚡ `quick`:10 秒健康检查
+- 🎯 `route`:在你花钱之前,这个任务实际需要的模型和力度
+- 🔧 `doctor`:安装检查
+- 💰 `savings`:美元节省报告
+- 📋 `report`:按组件的 token 分解
+- 🌐 `dashboard`:打开完整仪表盘
+- 📝 `memory-review`:MEMORY.md 结构审计
+- 📂 `expand`:检索归档的工具结果
+- 🔙 `resume-lean`:重开一个冷会话
+
+安装,运行一次 `/token-optimizer`,其余全部自动运行。
+
+## 不同之处
+
+大多数 token 工具压缩命令输出。那覆盖你上下文的 15-25%。另外 75% 无人触及。
+
+**压缩覆盖面。** Headroom、RTK 和 JFrog Boost 压缩 bash 和命令输出。Token Optimizer 压缩输出栈的八个面。状态:🟢 支持,🟡 部分,🔴 不支持。
+
+| 压缩面 | Token Optimizer | Headroom | RTK | Boost |
+|---|---|---|---|---|
+| **Bash / 命令输出**(git、测试、lint、构建、日志) | 🟢 跨 22 个模式家族的 111 个命令,凭证安全;pytest 运行 564 → 115 token | 🟢 SmartCrusher、CodeCompressor、Kompress-v2 | 🟢 100+ 过滤器 | 🟢 命令感知过滤器 |
+| **搜索 / grep 输出** | 🟢 命中顶部加计数;500 行 → 20 | 🔴 | 🔴 | — |
+| **表格 / JSON 输出**(jq、yq、csvtool、mlr) | 🟢 保值的列式 | 🟢 SmartCrusher | 🔴 | — |
+| **文件重读,delta 模式** | 🟢 仅 diff;2,000 token 重读 → ~50 | 🔴 | 🔴 | — |
+| **文件重读,结构图** | 🟢 签名和 import 的骨架;720KB → 250 token | 🔴 | 🔴 | — |
+| **大型工具结果**(超过 4K 字符) | 🟢 归档到磁盘,按需可展开 | 🔴 | 🔴 | — |
+| **模型输出冗长** | 🟢 精简输出提示,缓存安全(节省为估算,非计量) | 🔴 | 🔴 | 🔴 |
+| **结构性上下文**(配置、skill、MCP、记忆) | 🟢 按组件审计,每个来源评分 | 🔴 | 🔴 | 🔴 |
+
+RTK 和 Boost 到达第一个面。Headroom 到达第一个和第三个。Token Optimizer 覆盖全部八个,然后继续深入压缩周围发生的事:
+
+- **三种浪费,不是一种。** 结构性(臃肿配置、未用 skill、陈旧记忆)、运行时(冗长输出、重读)和行为性(模型误路由、缓存过期、重试循环)。[各自如何工作 →](https://alexgreensh.github.io/token-optimizer/features/active-compression/)
+- **节省在压缩中存活。** 自动压缩前检查点,之后恢复。没有这个,压缩节省在压缩触发的瞬间消失。
+- **测量是否有帮助。** 前后 token 差值、跨四个定价层级的美元节省、追踪退化的质量评分。不只是"我们压缩了东西"。
+- **零基线开销。** 外部进程,上下文中没有常开指令,没有 MCP 服务器,没有依赖,没有遥测。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/automated-flow.svg" alt="Token Optimizer 每个会话如何自动工作" width="900">
+</p>
+
+这十行是 Token Optimizer 是该行唯一 🟢 的行:在压缩之外存活的东西,以及没有压缩器去寻找的浪费。压缩机制、成本和安全,以及我们输的两行在折叠部分之后。
+
+|  | Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
+|---|---|---|---|---|---|---|
+| 压缩存活 | 🟢 渐进检查点、恢复、工具输出摘要 | 🔴 | 🔴 | — | 🟡 仅会话指南 | 🔴 |
+| 会话连续性 | 🟢 跨会话提示、冷恢复、检查点评分 | 🔴 | 🔴 | — | 🟡 会话指南 | 🔴 |
+| 结构性浪费审计 | 🟢 按组件深入(CLAUDE.md、skill、MCP、记忆) | 🔴 | 🔴 | 🔴 | 🔴 | 🟡 仅摘要 |
+| CLAUDE.md 和 MEMORY.md 健康 | 🟢 8 个审计器 + 注意力曲线评分 | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 |
+| 模型路由和行为辅导 | 🟢 12 个检测器、子代理成本分解、反模式 | 🔴 | 🔴 | — | 🔴 | 🟡 基本建议 |
+| 历史趋势分析 | 🟢 30 天趋势、质量/成本/缓存/时长相关、模型切换检测 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 上下文质量评分 | 🟢 带等级的 7 信号质量评分 | 🔴 | 🔴 | — | 🔴 | 🟡 仅容量百分比 |
+| 循环和空转检测 | 🟢 在烧 token 前捕捉行为循环 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 测量压缩是否有效 | 🟢 本地遥测、前后 token、美元节省 | 🔴 | 🟡 `rtk gain`(仅 token 计数) | 🟡 `boost report`,厂商侧 | 🔴 | 🔴 |
+| 舰队级跨代理分析 | 🟢 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+
+<details>
+<summary><b>显示其余 13 行</b>(压缩机制;成本、安全和覆盖;调优、证明和安装)</summary>
+
+|  | Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
+|---|---|---|---|---|---|---|
+| 无需命令重写 | 🟢 hook 接线,自动触发 | 🟢 透明代理 | 🟢 基于 hook 的重写 | 🟢 `boost init` 接线支持的代理;终端使用可加前缀 | 🟡 在支持 hook 的平台上自动 | N/A 原生命令 |
+| 完整原始可恢复 | 🟢 压缩前原始归档,`expand` 检索;失败从不压缩 | 🟢 可逆检索 | 🟡 命令失败时保存完整输出 | 🟢 厂商文档化命令输出恢复 | — | N/A 不压缩 |
+| 注册自定义命令过滤器 | 🔴 内置命令集;无用户过滤器 API | — | 🟢 自定义 TOML 过滤器 | 🟢 TOML 过滤器 | — | N/A |
+| 用户可调配置 | 🟢 92 个代码引用的 `TOKEN_OPTIMIZER_*` 名称,显式拆分为面向用户和内部控制;附加式允许列表;`.contextignore` | 🟢 文档化配置 | 🟢 `config.toml` 和环境控制 | 🟢 过滤器 TOML | 🟢 文档化配置 | N/A |
+| 缓存安全 | 🟢 从不修改现有上下文前缀 | 🟡 代理模式重写进行中的 | 🟢 仅 pre-shell | 🟢 仅 pre-shell | 🟡 MCP 开销 | 🟢 |
+| 零基线上下文开销 | 🟢 外部进程,无上下文注入 | 🔴 注入指令 | 🟢 仅 shell 级 | 🟢 仅 shell 级 | 🔴 MCP 服务器开销 | 🟢 原生 |
+| 零运行时依赖 | 🟢 纯标准库(Python/TypeScript) | 🟡 Python + Rust + 可选模型 | 🟢 单个 Rust 二进制 | 🟢 单个二进制 | 🟡 需要 SQLite 适配器 | 🟢 N/A |
+| 零遥测 | 🟢 不离开机器 | 🟡 `HEADROOM_TELEMETRY` opt-in,默认关 | 🟡 opt-in | 🔴 收集调用的命令、命令参数、退出码、时长、CI 属性、IP | 🟡 各异 | 🟢 |
+| 多平台 | 🟢 Claude Code、VS Code、Codex、OpenClaw、OpenCode、Hermes、Copilot | 🟢 Claude Code、Cursor、Codex、Aider、Copilot | 🟢 15 个集成 | 🟡 Cursor、Claude Code、Copilot、Codex CLI | 🟢 17 个集成 | 🔴 仅 Claude Code |
+| 按任务的模型和力度建议 | 🟢 `route` 在你花钱前衡量任务 | — | — | — | — | — |
+| Keep-Warm(缓存 TTL 刷新) | 🟢 缓存过期前 opt-in ping,绊线自动关 | 🔴 | 🔴 | — | 🔴 | 🔴 |
+| 端到端任务结果基准 | 🔴 仅输出 token A/B | — | — | 🟢 厂商报告 Terminal-Bench 2.0 相同通过率和约 12% 更低成本 | — | N/A |
+| 签名和校验和验证安装 | 🟢 每个发布 `CHECKSUMS.sha256`,安装时验证,CI 强制 | — | — | 🔴 安装器既不验证校验和也不验证签名 | — | N/A |
+
+</details>
+破折号(em dash)表示该能力在 2026-07-26 来源审计中未从第一方材料验证;并非声称该能力缺失。Boost 的"pre-shell"和"shell-level"单元格来自其文档化的包装形式(`boost <command>`);`boost init` 用来接线代理的机制未在其第一方材料中描述。Token Optimizer 的压缩声明针对真实会话和一套你可自行运行的 87 个 fixture 测试。**[完整基准方法学和结果 →](BENCHMARK.md)**
+
+<p align="center">
+  <a href="https://alexgreensh.github.io/token-optimizer/reference/comparison/"><img src="https://img.shields.io/badge/Read%20the%20official%20full%20comparison-in%20our%20docs-0b7285?style=for-the-badge" alt="在我们的文档中阅读官方完整对比页面"></a>
+</p>
+
+## 仪表盘
+
+![Token Optimizer 仪表盘](skills/token-optimizer/assets/dashboard-demo.gif)
+
+一个 HTML 页面,通过 SessionEnd hook 在每个会话后自动重新生成,无需手动触发。可书签的 URL `http://localhost:24842/token-optimizer` 是 opt-in:只有在运行 `python3 skills/token-optimizer/scripts/measure.py setup-daemon` 启动本地服务器后才工作。在那之前,打开 `measure.py dashboard` 在 `  Dashboard: ` 行打印的文件路径。
+
+每轮 token 分解、跨四个定价层级的成本、带 TTL 混合和命中率的缓存分析、叠加在每个会话上的质量评分、子代理成本分解、带四个不重叠池的节省追踪器。安装后零设置。[完整仪表盘文档 →](https://alexgreensh.github.io/token-optimizer/features/dashboard/)
+
+## 节省什么
+
+节省来自四个不重叠的池,在两个层级中追踪:
+
+| 池 | 覆盖什么 |
+|---|---|
+| 模型路由 + 缓存 | 更轻的前缀、更轻的模型混合、缓存写入作为路由杠杆 |
+| 子代理路由 | 侧链成本优化(仅 Claude Code) |
+| 压缩回加 | delta 模式、结构图、bash/搜索压缩移除的 token |
+| 精简输出回加 | 因简洁提示而从未产生的输出 token |
+
+**两个数字,分开保持:**
+
+- **已计量(~$313/月)**,逐动作记录。每次 Token Optimizer 换入更轻模型、修剪臃肿结果或跳过重复读取,它都累加:更聪明的习惯 ~$260/月,工作时压缩 ~$53/月。这是逐事件计量的切片,所以更小且精确。
+- **大图(~$1,877/月,~18%)**,完整的反事实。如果你按 Token Optimizer 之前的方式工作(~95% Opus),你会付约 ~$10,585/月而现在是 ~$8,708/月。差距主要来自更轻的模型混合(95% Opus 降到 60%,主路由 + 缓存 ~$1,076/月),加上更便宜的子代理(~$741/月)和计量的压缩回加(~$60/月)。
+
+这些数字从不相加。已计量是有硬收据的底线。大图是针对你冻结的 Token Optimizer 之前基线定价的模型。[查看完整方法学 →](BENCHMARK.md)
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/real-savings.svg" alt="30 天节省报告:已计量 ~$313,大图 ~$1,877" width="900">
+</p>
+
+基于 30 天内 684 个会话(快照截止 2026-06-15),针对冻结的 Token Optimizer 之前基线(~95% Opus)定价。你的数字是你自己的。[查看方法学 →](BENCHMARK.md)
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/user-profiles.svg" alt="1M 会话内部发生什么" width="800">
+</p>
+
+## 主动压缩
+
+九项主动减少上下文的功能,全部默认开启,全部自动,全部可从仪表盘或 CLI 切换。
+
+底层,**PreToolUse hook** 在每次 Read 和 Bash 调用进入你的上下文之前拦截。如果文件已被读取,只返回 diff。如果是代码文件重读,结构骨架替换完整内容。如果是 CLI 命令,输出被压缩。**PostToolUse hook** 把完整原始归档到磁盘并记录压缩事件到 SQLite。没有东西丢失,一切可检索。**你什么都不用做。hook 处理一切。**
+
+![主动压缩概览](skills/token-optimizer/assets/active-compression-hero.svg)
+
+| 功能 | 做什么 | 节省 |
+|---|---|---|
+| Delta 模式 | 重读只返回变化的部分 | 重读时 ~20% |
+| 结构图 | 未变文件重读返回结构骨架 | ~30%(每文件最高 99%) |
+| Bash 压缩 | CLI 输出精简为要点 | ~10% |
+| 搜索压缩 | grep/web 结果精简为命中顶部 + 计数 | ~15% |
+| 精简输出提示 | 上下文填满时引导模型精简输出 | 估算 10-15%;非反事实计量 |
+| 质量提示 | 上下文质量下降时警告 | 防止压缩损失 |
+| 循环检测 | 在烧 token 前捕捉重试循环 | 按循环计量 |
+| 活动模式 | 按你的会话阶段适配压缩 | 防止决策损失 |
+| 决策提取 | 跨压缩保留决策 | 防止决策漂移 |
+
+从仪表盘 Manage 标签、CLI(`measure.py v5 enable|disable <feature>`)或环境变量切换。`v5` 动词是控制当前功能的遗留命令名。
+
+[阅读每项功能如何工作 →](https://alexgreensh.github.io/token-optimizer/features/active-compression/)
+
+<details>
+<summary><b>每项功能详情</b></summary>
+
+### Delta 模式
+
+当 AI 在编辑后重读文件,Read 调用只返回 diff。真实会话中 65%+ 的 Read 调用是重读。一个 2,000 token 的文件重读变成 50 token 的 diff。
+
+![Delta 模式:智能重读](skills/token-optimizer/assets/delta-mode.svg)
+
+禁用:`TOKEN_OPTIMIZER_READ_CACHE_DELTA=0`
+
+### 结构图
+
+当 Claude 重读它已看过的代码文件,Read 调用被阻断并替换为结构摘要:函数签名、类层次、import。一个 720KB Python 文件(180,000 token)变成 250 token 骨架。
+
+禁用:`TOKEN_OPTIMIZER_READ_CACHE_MODE=shadow`
+
+### 首读骨架
+
+在历史验证的队列中,大型**代码**文件(Python 或 TypeScript,16KB–256KB)的**首次**读取,Read 返回结构骨架(签名/import)而非完整文件,带一行提示,完整内容始终一步之遥:`expand <key>`、范围 Read(`offset`/`limit`)或直接 Edit。原始在任何替换前归档,失败开放,如果归档无法发生,提供完整文件。
+
+这仅适用于**代码**。Markdown 和其他散文在首读时**不**骨架化(v5.11.27 起):仅标题大纲会丢掉承重的散文,所以文档始终完整返回。运行时绊线在实时编辑率上升时把代码队列自动降级为仅测量。
+
+禁用提供(保留测量):`TOKEN_OPTIMIZER_FIRST_READ_ACTIVE=0`。完全禁用:`TOKEN_OPTIMIZER_FIRST_READ_SHADOW=0`。两者也可通过 `measure.py v5 status` 和仪表盘 Manage 标签查看和切换。
+
+### Bash 输出压缩
+
+重写常见 CLI 命令以返回压缩摘要。覆盖 lint、日志尾部、tree、docker pull、长列表、构建输出和测试运行器。一个 564 token 的 pytest 输出变成 115 token。
+
+![Bash 输出压缩](skills/token-optimizer/assets/bash-compression.svg)
+
+禁用:`TOKEN_OPTIMIZER_BASH_COMPRESS=0`
+
+### 搜索结果压缩
+
+当 AI 运行 grep、rg 或返回长结果列表的 web 搜索,输出被精简为命中顶部加计数。一个 500 行 grep 结果变成 20 行加摘要。
+
+禁用:`TOKEN_OPTIMIZER_BASH_COMPRESS=0`(搜索压缩是 bash 压缩的一部分;没有单独开关)
+
+### 精简输出提示
+
+当上下文填过 25%,一段简短提示告诉模型深度推理但保持可见输出精简。填充是唯一条件,质量不再门控它,所以一个普通健康会话也得到提示,不只是漫长的退化会话。节省**估算为 10-15%,未计量**:反事实(没有提示模型会写什么)无法观察,所以 Token Optimizer 在估算层级报告它,从不折入计量节省。缓存安全:作为 `additionalContext` 注入,从不修改现有前缀。
+
+今天没有开关(不是 `v5` 功能)。用 `TOKEN_OPTIMIZER_VERBOSITY_MIN_FILL`(默认 `25`)调整触发点。
+
+### 质量提示
+
+实时监视上下文质量。当评分下降超过 15 分或跌破 60,一条内联备注进入上下文。Claude 在下一轮看到它并浮现警告或调整行为。5 分钟冷却,每会话最多 3 次。
+
+禁用:`TOKEN_OPTIMIZER_QUALITY_NUDGES=0`
+
+### 循环检测
+
+捕捉 AI 卡在重试循环。比较最近 4 条用户消息和最近 5 个工具结果的相似度。在置信度 ≥0.7 触发,每会话上限 2 条备注。节省从实际循环轮内容计量。
+
+禁用:`TOKEN_OPTIMIZER_LOOP_DETECTION=0`
+
+### 活动模式检测
+
+用最近 10 次工具调用把你的会话分类为五种模式之一(代码、调试、审查、基础设施、通用)。该模式进入压缩指导,使 PRESERVE/DROP 优先级适配你正在做的事。
+
+### 决策提取
+
+实时从工具输出检测决策语句并存入会话数据库。压缩时,这些决策作为 CRITICAL DECISIONS 注入,摘要必须逐字保留。每会话上限 10 条。
+
+### 测量真实节省
+
+所有压缩功能记录到本地 SQLite 表。没有东西离开你的机器。
+
+```bash
+python3 measure.py compression-stats --days 30
+```
+
+</details>
+
+## 会话数据库
+
+Token Optimizer 所做的一切由两个本地 SQLite 数据库支撑。没有东西离开你的机器。零网络调用。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/session-database-flow.svg" alt="会话数据库流程:工具调用被压缩、归档、记录到 SQLite、可检索" width="900">
+</p>
+
+**每会话 DB**(`~/.claude/token-optimizer/snapshots/session-store/<session>.db`)持有 8 张表,追踪文件读取、工具输出、命令输出、缓存内容、上下文情报事件、活动日志、决策日志和提示服务。WAL 模式用于 hook 进程的并发读/写。每会话 50MB 上限。
+
+**趋势 DB**(`~/.claude/token-optimizer/snapshots/trends.db`)持有 7 张表,追踪会话历史、每日聚合、skill/模型/子代理使用、节省事件和压缩事件。按会话 UUID 索引以实现 O(log n) 连接。这就是仪表盘、coach 模式和 30 天趋势分析的驱动力。
+
+每个压缩事件、每笔节省、每次质量测量都是一行你可查询的数据。仪表盘是此数据的只读视图。`measure.py compression-stats` 是一条 SQL 查询。你的数据是你的。
+
+## 渐进式披露
+
+大型工具结果(>4KB)归档到磁盘并替换为简短预览加检索指针。完整输出在压缩中存活。当模型需要它,通过 `expand` 拉取原始,无需命令重跑,无丢失输出。
+
+这不只是存储。系统追踪多少结果被归档 vs 重新展开,这样你能看到保持折叠的净 token。重新展开从节省总额中扣除,所以你只算实际保持压缩的。
+
+```bash
+python3 measure.py expand --list          # 列出归档的工具结果
+python3 measure.py expand <tool-use-id>   # 检索特定结果
+```
+
+一些 MCP 工具被*文档化*为返回大型逐字载荷(来源抓取器、文档检索器),其中元数据预览会破坏要点。把它们加入允许列表,使完整结果到达上下文而非被替换(仍然归档,所以 `expand` 工作)。设置一个针对完整工具名匹配的 `fnmatch` glob 的逗号分隔列表:
+
+`TOKEN_OPTIMIZER_ARCHIVE_EXEMPT_TOOLS="mcp__context7__*,*github_repository_file"`
+
+默认为空,除非你 opt-in 一个工具,否则没有东西被豁免。
+
+## 会话连续性
+
+压缩很重要,但 Token Optimizer 做的最重要的事是自动让你的工作在会话和压缩之间存活。
+
+当你结束一个会话,Token Optimizer 把你的状态检查点到 SQLite:活动任务、关键决策、修改的文件、git 分支、最近读取。当你开始新会话,它针对你的提示给所有最近检查点评分,并浮现最相关的一个作为提示。你带着上下文恢复,而非从零开始。
+
+**自动发生什么:**
+
+- **跨会话提示**:相关性评分的检查点在你开始新会话时浮现。提示包括前一个会话的任务、决策、文件和分支。全部以 RECOVERED DATA 围栏,绝非指令。
+- **冷恢复精简**:无需支付完整转录成本重开一个陈旧会话。Token Optimizer 从其检查点重建精简上下文。无 LLM 调用,无完整转录冷恢复。从 SQLite 免 token 重建。
+- **提示跟随测量**:当连续性提示浮现文件路径而模型随后读取其中一个,Token Optimizer 记一笔避免的探索性搜索。计量的因果,不是猜测。
+
+```bash
+python3 measure.py resume-lean                    # 列出可重开的冷会话
+python3 measure.py resume-lean <#|session_id> --print  # 输出精简上下文块
+```
+
+压缩节省只有在你的会话在压缩中存活时才粘住。会话连续性使之发生。
+
+## 智能压缩
+
+当自动压缩触发,60-70% 的对话消失。决策、错误修复序列、代理状态,全部消失。
+
+Token Optimizer 在压缩前检查点你的会话,并通过 hook 自动恢复摘要丢掉的内容。它还注入一个**上下文情报摘要**:模型已处理的大型工具输出的启发式摘要(触及的文件路径、见到的错误、行数)。压缩后,模型知道它看过什么而无需重读一切。
+
+**活动模式检测**用最近 10 次工具调用实时分类你的会话(代码、调试、审查、基础设施、通用)。该模式进入压缩指导,使 PRESERVE/DROP 优先级适配你现在正在做的事,而非通用启发式。
+
+**决策提取**在决策语句从工具输出发生时捕捉并存入会话 DB。压缩时,这些作为 CRITICAL DECISIONS 注入,摘要必须逐字保留。每会话上限 10 条。
+
+压缩节省只有在你的会话在压缩中存活时才粘住。在 `git status` 上节省 token,如果下一次自动压缩抹掉让你运行它的决策,就毫无帮助。
+
+<p align="center">
+  <img src="skills/token-optimizer/assets/quality-nudges-loops.svg" alt="运行中的质量提示和循环检测" width="800">
+</p>
+
+<details>
+<summary><b>智能压缩如何工作</b></summary>
+
+### 渐进检查点
+
+在多个阈值捕捉会话状态:20%、35%、50%、65%、80% 上下文填充,加上质量跌破 80、70、50 和 40。还在代理扇出前和大编辑批次后快照。恢复时,选择最丰富的合格检查点。
+
+### 上下文情报摘要
+
+压缩后,Token Optimizer 注入会话最大工具输出的摘要:触及的文件路径、检测到的错误、行数。在 <30ms 内启发式生成,无 LLM 调用。模型无需重读一切即可重新定位。
+
+```bash
+python3 measure.py setup-smart-compact    # 检查点 + 恢复 hook
+```
+
+</details>
+
+## 输出 token:精简 vs 冗长
+
+输出 token 是你会话中最昂贵的部分。在 Opus 上它们比输入 token 贵 5 倍,按生成计费而非按缓存读取。对简单问题的冗长回答烧掉你从不需要花的美元。
+
+Token Optimizer 用**精简输出提示**自动处理这个。当你的上下文填过 25%,一段简短提示告诉模型深度推理但保持可见输出精简。填充是唯一触发;上下文质量不是条件。减少**估算为 10-15% 且非反事实计量**,所以在估算层级报告,与计量节省分开。
+
+**如何工作:**
+
+- 提示作为 `additionalContext` 注入,从不修改现有前缀,所以你的缓存保持完整
+- 只在上下文填满时触发,而非你有大量空间时
+- 模型仍然思考问题;它只是产生更精简的可见答案
+- 今天没有开关;用 `TOKEN_OPTIMIZER_VERBOSITY_MIN_FILL`(默认 `25`)调整触发点
+
+这是 9 项主动压缩功能之一,也是节省输出侧的那项,token 在那里最贵。
+
+## 质量评分
+
+质量评分追踪两件事:**资源健康**(你离退化悬崖多近)和**会话效率**(你的 token 是否在做有用的工作)。从 S 到 F 的字母等级让分诊即时。
+
+随着上下文填充,质量下降。MRCR 在 256K 和 1M 上下文之间从 93% 降到 76%。你的 AI 随窗口填充可测量地变笨。质量评分向你展示那何时发生。
+
+![真实会话质量分解](skills/token-optimizer/assets/quality-example.svg)
+
+状态栏随质量退化变色:绿、黄、橙、红。当质量跌破 75,会话时长作为警告出现。运行的子代理显示其模型和经过时间。
+
+![状态栏退化](skills/token-optimizer/assets/status-bar.svg)
+
+```bash
+python3 measure.py setup-quality-bar      # 一次性安装
+```
+
+[阅读评分如何工作 →](https://alexgreensh.github.io/token-optimizer/features/quality-signals/)
+
+<details>
+<summary><b>质量评分详情</b></summary>
+
+| 评分 | 信号 | 含义 |
+|--------|--------|----------------|
+| **资源健康** | 上下文填充、压缩深度、绝对浪费 token | 你离退化悬崖多近 |
+| **会话效率** | 陈旧读取、臃肿结果、决策密度、代理效率 | 会话现在是否在好好使用 token |
+
+| 等级 | 范围 | 含义 |
+|-------|-------|---------|
+| **S** | 90-100 | 峰值效率 |
+| **A** | 80-89 | 健康,可小幅优化 |
+| **B** | 70-79 | 退化开始 |
+| **C** | 55-69 | 显著浪费 |
+| **D** | 40-54 | 严重问题 |
+| **F** | 0-39 | 上下文正在腐烂,需要立即行动 |
+
+**质量栏消失了?** 运行 Claude Code 的 `/statusline` 会覆盖 Token Optimizer 的条目。SessionStart 自动恢复。只要开始一个新会话它就回来。
+
+**想永久关掉?**
+```bash
+python3 measure.py setup-quality-bar --uninstall
+```
+
+</details>
+
+## Coach 模式
+
+```
+> /token-coach
+```
+
+告诉它你的目标。拿回具体的、带优先级的修复,附精确 token 节省。它读取你 30 天的会话数据并浮现单个会话无法展示的:质量向下漂移、会话变长、缓存命中率下降、每会话成本攀升。
+
+每个洞察都基于你的真实数字。"你的短会话得分 68 对长会话 60"比"考虑更短的会话"更扎心。Coach 模式还识别项目级优化机会(你从不使用的 skill、急切加载的 MCP 服务器、破坏你缓存的 CLAUDE.md 模式)并教你如何修复,使未来会话从更精简开始。
+
+[阅读 Coach 模式 →](https://alexgreensh.github.io/token-optimizer/features/token-coach/)
+
+<details>
+<summary><b>Coach 模式详情</b></summary>
+
+### 检测到的历史模式
+
+| 模式 | 检测什么 |
+|---|---|
+| 质量漂移 | 平均质量逐周下降 |
+| 会话时长爬升 | 会话变长,更快填满上下文 |
+| 缓存退化 | 缓存命中率下降(以及模型切换是否导致) |
+| 等级分布 | 太多 D 级会话堆积 |
+| 成本意识 | 每会话成本攀升,附路由建议 |
+| 时长-质量相关 | 短会话得分更高,建议你拆分长的 |
+| 压缩差距 | 仅 shadow 的节省远超主动压缩 |
+| 模型切换 | 频繁的会话中途模型切换使提示缓存失效 |
+
+### 浪费检测器
+
+11 个自动化检测器分析你的会话模式:
+
+| 检测器 | 捕捉什么 |
+|---|---|
+| PDF/二进制摄取 | 消耗上下文的大文件 |
+| Web 搜索开销 | 太多 web 结果倾倒进上下文 |
+| 重试搅动 | 同一工具带错误重试 3+ 次 |
+| 工具级联 | 3+ 连续工具错误 |
+| 循环 | 重复的相似消息 |
+| 过强模型 | 简单编辑用 Opus |
+| 过弱模型 | 复杂任务用 Haiku |
+| 糟糕分解 | 单体 500+ 字提示 |
+| 浪费思考 | 小编辑的扩展思考 >2x 输出 |
+| 输出浪费 | 对简单操作的冗长响应 |
+| 缓存不稳定 | 破坏提示缓存的 CLAUDE.md 模式 |
+
+### Keep-Warm
+
+API 计费会话的 opt-in 功能。在你的提示缓存条目即将过期前发出一个微小的缓存读取 ping,刷新其 TTL。成本约为前缀的 ~0.1x,对比恢复时你要付的 1.25-2x 重写。如果 ping 不再自付成本,绊线自动关闭。
+
+```bash
+python3 measure.py keepwarm-enable          # opt-in(仅 API 计费)
+python3 measure.py keepwarm-report            # 净节省、支出、绊线状态
+python3 measure.py keepwarm-disable           # 随时 opt-out
+```
+
+### 舰队审计器
+
+跨 Claude Code、Codex 和自定义转录设置扫描,以发现空闲烧钱、模型误路由和配置臃肿,每项发现附美元节省。
+
+### CLAUDE.md 路由注入
+
+从你的实际使用数据生成模型路由指令并注入 CLAUDE.md。48 小时陈旧守卫自动移除过时建议。
+
+```bash
+python3 measure.py inject-routing --dry-run   # 预览
+python3 measure.py inject-routing              # 注入
+```
+
+</details>
+
+## FAQ
+
+<details>
+<summary><b>🔒 它会降低我的上下文质量吗?</b></summary>
+
+不会。结构优化只移除真正未使用的组件。主动压缩控制可用单个命令或环境变量禁用。质量评分系统实时追踪退化。
+
+</details>
+
+<details>
+<summary><b>💾 它会破坏提示缓存吗?</b></summary>
+
+不会。Token Optimizer 从不触碰已在你的上下文中的内容。它作用于进入你窗口的新内容和压缩边界。你的缓存前缀保持完整,这意味着它两次省钱:每轮更少输入,以及之后每轮更便宜的缓存读取。
+
+</details>
+
+<details>
+<summary><b>📡 它会把任何数据发到任何地方吗?</b></summary>
+
+无分析,无遥测端点,无产品数据离开你的机器。测量事件是你拥有的本地 SQLite 行。零网络调用。
+
+</details>
+
+<details>
+<summary><b>⚠️ 它会伤害我的会话吗?</b></summary>
+
+不会。所有 hook 都是非阻塞的失败开放设计。如果某个 Token Optimizer 脚本出错,你的命令正常运行。
+
+</details>
+
+<details>
+<summary><b>📦 有任何运行时依赖吗?</b></summary>
+
+没有。在 Claude Code 和 Codex 上是纯 Python 标准库。在 OpenCode 和 OpenClaw 上是零运行时依赖的 TypeScript。
+
+</details>
+
+<details>
+<summary><b>🔐 install.sh 如何验证文件完整性?</b></summary>
+
+解析最新的 GitHub Release 标签,检出该标签,从同一发布获取 CHECKSUMS.sha256,并验证每个脚本文件。带外验证意味着一个被攻破的提交无法同时替换代码和校验和。
+
+</details>
+
+## 所有命令
+
+<details>
+<summary><b>显示所有命令</b></summary>
+
+| 命令 | 做什么 | 文档 |
+|---|---|---|
+| `/token-optimizer` | 6 个并行代理的完整审计,引导修复 | [→](https://alexgreensh.github.io/token-optimizer/start/quickstart/) |
+| `/token-coach` | 30 天趋势分析,带优先级修复 | [→](https://alexgreensh.github.io/token-optimizer/features/token-coach/) |
+| `quick` | 10 秒健康检查 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `doctor` | 安装检查,10 分制评分 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `dashboard` | 打开 HTML 仪表盘 | [→](https://alexgreensh.github.io/token-optimizer/features/dashboard/) |
+| `savings` | 美元节省报告 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `report` | 按组件的 token 分解 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `quality` | 实时会话的上下文质量分析 | [→](https://alexgreensh.github.io/token-optimizer/features/quality-signals/) |
+| `trends` | skill 采纳、模型混合、随时间的开销 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `compression-stats` | 主动压缩的计量节省 | [→](https://alexgreensh.github.io/token-optimizer/features/active-compression/) |
+| `memory-review` | MEMORY.md 结构审计 | [→](https://alexgreensh.github.io/token-optimizer/features/memory-health/) |
+| `git-context` | 为你当前 diff 建议文件 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `drift` | 与你上次快照的并排对比 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `conversation` | 按消息的 token 和成本分解 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `pricing-tier` | 查看或切换定价层级 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `expand` | 检索归档的工具结果(渐进式披露) | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+| `resume-lean` | 用免 token 重建重开冷会话 | [→](https://alexgreensh.github.io/token-optimizer/reference/cli/) |
+
+[完整 CLI 参考 →](https://alexgreensh.github.io/token-optimizer/reference/cli/)
+
+</details>
+
+## 许可证
+
+**PolyForm Noncommercial 1.0.0**。源码可见。个人、研究、教育和非商业使用无需购买许可证。
+
+### 个人 / 爱好 / 研究 / 教育?
+放手去做。完整源码,本地运行,无需购买许可证。
+
+### 小团队(5 人以下或月收入 $20k 以下)?
+小团队自动获得免费商业许可证。尽管用。
+
+### 从个人开始,现在要变成生意了?
+你过去的使用完全没问题。许可证内置任何书面通知后 32 天的宽限期。准备好时联系获取商业许可证。
+
+### 更大的公司 / 商业使用?
+联系 [Alex Greenshpun](https://linkedin.com/in/alexgreensh) 或 me@alexgreenshpun.com。
+
+---
+
+由 [Alex Greenshpun](https://linkedin.com/in/alexgreensh) 创建。


### PR DESCRIPTION
Adds a visible language-navigation row (native-script labels, current language bold-unlinked) to `README.md` plus three full translations: `README.ko.md` (한국어), `README.zh-CN.md` (简体中文), `README.ja.md` (日本語).

Filenames + nav pattern follow the dominant high-star-repo convention (ant-design, immich, dify): flat dot-locale files at repo root, native-script labels, no flag emoji. Code blocks, CLI/slash commands, `TOKEN_OPTIMIZER_*` env vars, file paths, and product names stay verbatim English; only prose/headings/table descriptions are translated.

Drafted via GLM and reviewed: nav rows correct in all 4 files, code-fence parity (18 blocks each), install commands / env vars / slash commands preserved identically, comparison tables intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)