### PR TITLE
fix(dashboard): live-refresh the 5h/7d window card (auto-regen)

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -6255,6 +6255,13 @@ var DB = (function() {
     if (payload.cache_health && typeof payload.cache_health === 'object') {
       data.cache_health = payload.cache_health;
     }
+    // Live window/runway card: pick up a fresher 5h/7d reading the instant the
+    // statusline writes one, so an open dashboard auto-updates instead of needing
+    // a manual Regenerate. safeRender('Savings') below repaints runwayCardHtml, and
+    // its "as of / N ago" label recomputes live from the new meter_ts.
+    if (payload.runway && typeof payload.runway === 'object') {
+      data.runway = payload.runway;
+    }
     safeRender('Savings', 'savings', renderSavings);
     safeRender('Overview', 'overview', renderOverview);
     var stamp = document.getElementById('to-live-stamp');
@@ -6651,6 +6658,18 @@ document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('visibilitychange', function() {
       if (document.visibilityState === 'visible') refreshSavingsLive();
     });
+  }
+
+  // Auto-refresh the live tiles (incl. the 5h/7d window card) every ~60s while the
+  // tab is open, so a new rate-limit reading surfaces on its own instead of needing
+  // a manual Regenerate. refreshSavingsLive is a no-op unless __TOKEN_API_LIVE, and
+  // is a small JSON GET (never a full-page regen); skip while the tab is hidden.
+  if (typeof setInterval === 'function') {
+    setInterval(function() {
+      if (typeof document === 'undefined' || document.visibilityState !== 'hidden') {
+        refreshSavingsLive();
+      }
+    }, 60000);
   }
 
   // Probe for our custom API server before init.

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -36603,10 +36603,19 @@ def _live_savings_payload(days=30):
             cache_health["keepwarm"] = keepwarm_cache_health_block(days=days)
     except Exception:
         pass
+    # Window/runway card (5h/7d): include it in the LIVE payload so an open dashboard
+    # picks up a fresh rate-limit reading the instant the statusline writes one (the
+    # figure is only ever fresh while Claude is actively running). Same builder the
+    # full regen uses; fail-open to None so a slow/failed read never breaks /api/savings.
+    try:
+        runway = runway_snapshot(days=days)
+    except Exception:
+        runway = None
     return {
         "ok": True,
         "savings": savings_data,
         "cache_health": cache_health,
+        "runway": runway,
         "generated_at": datetime.now().isoformat(),
     }
 

--- a/skills/token-optimizer/assets/dashboard.html
+++ b/skills/token-optimizer/assets/dashboard.html
@@ -6255,6 +6255,13 @@ var DB = (function() {
     if (payload.cache_health && typeof payload.cache_health === 'object') {
       data.cache_health = payload.cache_health;
     }
+    // Live window/runway card: pick up a fresher 5h/7d reading the instant the
+    // statusline writes one, so an open dashboard auto-updates instead of needing
+    // a manual Regenerate. safeRender('Savings') below repaints runwayCardHtml, and
+    // its "as of / N ago" label recomputes live from the new meter_ts.
+    if (payload.runway && typeof payload.runway === 'object') {
+      data.runway = payload.runway;
+    }
     safeRender('Savings', 'savings', renderSavings);
     safeRender('Overview', 'overview', renderOverview);
     var stamp = document.getElementById('to-live-stamp');
@@ -6651,6 +6658,18 @@ document.addEventListener('DOMContentLoaded', function() {
     document.addEventListener('visibilitychange', function() {
       if (document.visibilityState === 'visible') refreshSavingsLive();
     });
+  }
+
+  // Auto-refresh the live tiles (incl. the 5h/7d window card) every ~60s while the
+  // tab is open, so a new rate-limit reading surfaces on its own instead of needing
+  // a manual Regenerate. refreshSavingsLive is a no-op unless __TOKEN_API_LIVE, and
+  // is a small JSON GET (never a full-page regen); skip while the tab is hidden.
+  if (typeof setInterval === 'function') {
+    setInterval(function() {
+      if (typeof document === 'undefined' || document.visibilityState !== 'hidden') {
+        refreshSavingsLive();
+      }
+    }, 60000);
   }
 
   // Probe for our custom API server before init.

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -36603,10 +36603,19 @@ def _live_savings_payload(days=30):
             cache_health["keepwarm"] = keepwarm_cache_health_block(days=days)
     except Exception:
         pass
+    # Window/runway card (5h/7d): include it in the LIVE payload so an open dashboard
+    # picks up a fresh rate-limit reading the instant the statusline writes one (the
+    # figure is only ever fresh while Claude is actively running). Same builder the
+    # full regen uses; fail-open to None so a slow/failed read never breaks /api/savings.
+    try:
+        runway = runway_snapshot(days=days)
+    except Exception:
+        runway = None
     return {
         "ok": True,
         "savings": savings_data,
         "cache_health": cache_health,
+        "runway": runway,
         "generated_at": datetime.now().isoformat(),
     }
 

--- a/tests/test_dashboard_live_runway.py
+++ b/tests/test_dashboard_live_runway.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Live window/runway card on the dashboard.
+
+The 5h/7d "window reading" is only ever fresh while the statusline is writing it
+(active turns). The dashboard already has a live path (`GET /api/savings` ->
+`_live_savings_payload` -> client `refreshSavings`) that patched only the savings
+and cache-health tiles, so the ONE number that can jump the instant a new reading
+lands (the window card) was the one number nothing live-updated, forcing a manual
+Regenerate that provably cannot refresh it.
+
+This adds `runway` to the live payload, patches it client-side, and polls every
+~60s, so an open dashboard reflects a new reading on its own.
+
+Guarantees under test:
+- `_live_savings_payload` carries `runway`, equal to the shared `runway_snapshot`
+  builder (single source of truth; a live-patched card can't diverge from a regen)
+- fail-open: a raising `runway_snapshot` degrades to `runway: None`, never raises
+- the payload reflects whatever reading exists now (live-reflect)
+- client wiring is present in BOTH the canonical and plugin-mirror dashboard.html
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+ASSET = REPO / "skills" / "token-optimizer" / "assets" / "dashboard.html"
+ASSET_MIRROR = (
+    REPO / "plugins" / "token-optimizer" / "skills" / "token-optimizer"
+    / "assets" / "dashboard.html"
+)
+
+
+@pytest.fixture()
+def measure(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "TOKEN_OPTIMIZER_SNAPSHOT_DIR",
+        str(tmp_path / "base" / "token-optimizer-a" / "data"),
+    )
+    monkeypatch.syspath_prepend(str(SCRIPTS))
+    sys.modules.pop("measure", None)
+    spec = importlib.util.spec_from_file_location("measure", SCRIPTS / "measure.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["measure"] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    sys.modules.pop("measure", None)
+
+
+# ---- payload ----
+
+def test_payload_carries_runway(measure):
+    """The live payload includes the window/runway card, equal to the shared
+    builder (mirrors test_matches_full_regen_source's single-source rule)."""
+    p = measure._live_savings_payload(days=30)
+    assert "runway" in p
+    assert p["runway"] == measure.runway_snapshot(days=30)
+
+
+def test_runway_fail_open(measure, monkeypatch):
+    """A raising runway builder must not break /api/savings: payload stays ok,
+    runway degrades to None (same fail-open shape as the savings/cache blocks)."""
+    def _boom(*a, **k):
+        raise RuntimeError("meter read blew up")
+    monkeypatch.setattr(measure, "runway_snapshot", _boom)
+    p = measure._live_savings_payload(days=30)
+    assert p["ok"] is True
+    assert p["runway"] is None
+
+
+def test_runway_reflects_current_reading(measure, monkeypatch):
+    """Live-reflect: the payload carries whatever reading exists NOW, so an open
+    dashboard shows a fresh 5h/7d figure the instant the statusline writes one."""
+    sentinel = {"meter_ts": 1234567890, "meter_stale": False, "windows": ["fresh"]}
+    monkeypatch.setattr(measure, "runway_snapshot", lambda *a, **k: sentinel)
+    p = measure._live_savings_payload(days=30)
+    assert p["runway"] == sentinel
+
+
+# ---- client wiring (edit-time string asserts, mirrored to the plugin tree) ----
+
+@pytest.mark.parametrize("asset", [ASSET, ASSET_MIRROR], ids=["canonical", "plugin-mirror"])
+def test_client_patches_runway(asset):
+    """refreshSavings must assign the live runway into data.runway so the repaint
+    picks up the fresher reading."""
+    html = asset.read_text(encoding="utf-8")
+    assert "data.runway = payload.runway" in html
+
+
+@pytest.mark.parametrize("asset", [ASSET, ASSET_MIRROR], ids=["canonical", "plugin-mirror"])
+def test_client_has_periodic_poll(asset):
+    """A periodic poll of the live endpoint must exist so the window auto-updates
+    without a manual Regenerate."""
+    html = asset.read_text(encoding="utf-8")
+    assert "setInterval(" in html
+    assert "refreshSavingsLive" in html
+    # the poll body calls the guarded live refresh (no-op unless __TOKEN_API_LIVE)
+    assert "refreshSavingsLive()" in html


### PR DESCRIPTION
**Problem:** the savings card's window figure went stale and the Regenerate button couldn't refresh it — the card even says so. The 5h/7d reading is only fresh while the statusline writes it (active turns), and the dashboard's existing live path (`GET /api/savings`) patched every tile *except* the window card.

**Fix:** add `runway` to the live `_live_savings_payload` (guarded, fail-open), patch it in `refreshSavings`, and poll every ~60s (skipped when the tab is hidden). An open dashboard now reflects a new reading on its own — no manual Regenerate.

**Honesty boundary (kept):** this doesn't invent a number while Claude is idle (the windows exist only in the statusline stdin); it surfaces the newest *real* reading automatically, and the "as of / N ago" label keeps counting truthfully.

**Ops:** the installed daemon (v5.11.85) predates `/api/savings`, so it needs a regenerate/restart for the live path to work on an existing machine (separate step, called out in the commit).

**Tests:** `tests/test_dashboard_live_runway.py` — runway in payload (== builder), fail-open, live-reflect, client wiring mirrored to plugin tree. Full suite 1184 passed.