### PR TITLE
fix(hooks): budget the compact-restore SessionStart hook (first-prompt stall)

### DIFF
--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -39315,19 +39315,32 @@ if __name__ == "__main__":
             else:
                 compact_restore(session_id=sid, is_compact=is_compact)
 
-        # Codex requires SessionStart stdout to be empty or valid JSON. Under the
-        # Codex marketplace plugin the shared hooks.json calls this directly (not
-        # via codex_hook_bridge), so capture the raw text and wrap it (issue #81).
-        # Claude keeps the raw-text stream unchanged.
-        if detect_runtime() == "codex":
-            import io as _io
-            from contextlib import redirect_stdout as _redirect_stdout
-            _buf = _io.StringIO()
-            with _redirect_stdout(_buf):
+        # Cap this SessionStart hook's wall-clock like every other hook. It was the
+        # ONLY synchronous first-prompt hook with no internal budget -- just the
+        # harness 20s timeout -- so under disk/CPU contention (many parallel sessions
+        # on one project dir) it was the dominant contributor to a ~36s first-prompt
+        # stall. Its output is a best-effort re-orientation hint, so a budget-exit
+        # (no hint) degrades gracefully. Env-overridable.
+        _tok_hook_deadline = _install_hook_budget(
+            _int_env("TOKEN_OPTIMIZER_COMPACT_RESTORE_BUDGET", 8))
+        try:
+            # Codex requires SessionStart stdout to be empty or valid JSON. Under the
+            # Codex marketplace plugin the shared hooks.json calls this directly (not
+            # via codex_hook_bridge), so capture the raw text and wrap it (issue #81).
+            # Claude keeps the raw-text stream unchanged.
+            if detect_runtime() == "codex":
+                import io as _io
+                from contextlib import redirect_stdout as _redirect_stdout
+                _buf = _io.StringIO()
+                with _redirect_stdout(_buf):
+                    _run_compact_restore()
+                _emit_codex_session_start(_buf.getvalue())
+            else:
                 _run_compact_restore()
-            _emit_codex_session_start(_buf.getvalue())
-        else:
-            _run_compact_restore()
+        except _HookTimeout:
+            pass
+        finally:
+            _clear_hook_budget(_tok_hook_deadline)
     elif args[0] in ("continue-last", "codex-continue-last"):
         topic = ""
         for i, a in enumerate(args):

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -39315,19 +39315,32 @@ if __name__ == "__main__":
             else:
                 compact_restore(session_id=sid, is_compact=is_compact)
 
-        # Codex requires SessionStart stdout to be empty or valid JSON. Under the
-        # Codex marketplace plugin the shared hooks.json calls this directly (not
-        # via codex_hook_bridge), so capture the raw text and wrap it (issue #81).
-        # Claude keeps the raw-text stream unchanged.
-        if detect_runtime() == "codex":
-            import io as _io
-            from contextlib import redirect_stdout as _redirect_stdout
-            _buf = _io.StringIO()
-            with _redirect_stdout(_buf):
+        # Cap this SessionStart hook's wall-clock like every other hook. It was the
+        # ONLY synchronous first-prompt hook with no internal budget -- just the
+        # harness 20s timeout -- so under disk/CPU contention (many parallel sessions
+        # on one project dir) it was the dominant contributor to a ~36s first-prompt
+        # stall. Its output is a best-effort re-orientation hint, so a budget-exit
+        # (no hint) degrades gracefully. Env-overridable.
+        _tok_hook_deadline = _install_hook_budget(
+            _int_env("TOKEN_OPTIMIZER_COMPACT_RESTORE_BUDGET", 8))
+        try:
+            # Codex requires SessionStart stdout to be empty or valid JSON. Under the
+            # Codex marketplace plugin the shared hooks.json calls this directly (not
+            # via codex_hook_bridge), so capture the raw text and wrap it (issue #81).
+            # Claude keeps the raw-text stream unchanged.
+            if detect_runtime() == "codex":
+                import io as _io
+                from contextlib import redirect_stdout as _redirect_stdout
+                _buf = _io.StringIO()
+                with _redirect_stdout(_buf):
+                    _run_compact_restore()
+                _emit_codex_session_start(_buf.getvalue())
+            else:
                 _run_compact_restore()
-            _emit_codex_session_start(_buf.getvalue())
-        else:
-            _run_compact_restore()
+        except _HookTimeout:
+            pass
+        finally:
+            _clear_hook_budget(_tok_hook_deadline)
     elif args[0] in ("continue-last", "codex-continue-last"):
         topic = ""
         for i, a in enumerate(args):

--- a/tests/test_stuck_session_compact_restore_budget.py
+++ b/tests/test_stuck_session_compact_restore_budget.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""SessionStart `compact-restore` must be wall-clock budgeted.
+
+Root cause of the ~36s first-prompt stall on a new session with many parallel
+sessions open: `compact-restore --new-session-only` was the ONLY synchronous
+first-prompt hook with no internal HookDeadline budget -- just the harness 20s
+timeout, 2.5x the 8s cap on every other hook -- so under disk/CPU contention it
+dominated the stall. This wraps it in the same `_install_hook_budget(...)` guard
+the other eight hooks already use (env-overridable via
+TOKEN_OPTIMIZER_COMPACT_RESTORE_BUDGET). Its output is a best-effort re-orientation
+hint, so a budget-exit degrades gracefully to no hint.
+
+We do NOT unit-test the budget actually firing: HookDeadline's backstop is
+`os._exit(0)`, which would terminate the pytest process itself. The firing
+mechanism is shared with eight already-shipped hooks. Here we prove the wrapper
+integrates cleanly (fast case + a tiny budget both exit 0, no traceback) and an
+edit-time guard keeps the budget from silently regressing in both source trees.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+MEASURE = REPO / "skills" / "token-optimizer" / "scripts" / "measure.py"
+MEASURE_MIRROR = (
+    REPO / "plugins" / "token-optimizer" / "skills" / "token-optimizer"
+    / "scripts" / "measure.py"
+)
+
+
+def _run_compact_restore(env_extra=None):
+    env = {"PATH": __import__("os").environ.get("PATH", "")}
+    env.update(env_extra or {})
+    return subprocess.run(
+        [sys.executable, str(MEASURE), "compact-restore", "--new-session-only"],
+        input='{"session_id":"budget-smoketest","source":"startup"}',
+        capture_output=True, text=True, env=env, timeout=25,
+    )
+
+
+def test_compact_restore_exits_clean_default_budget():
+    p = _run_compact_restore()
+    assert p.returncode == 0, p.stderr
+    assert "Traceback" not in p.stderr
+
+
+def test_compact_restore_exits_clean_tiny_budget():
+    # A 1s budget must not break the fast path (real op completes well under 1s).
+    p = _run_compact_restore({"TOKEN_OPTIMIZER_COMPACT_RESTORE_BUDGET": "1"})
+    assert p.returncode == 0, p.stderr
+    assert "Traceback" not in p.stderr
+
+
+@pytest.mark.parametrize(
+    "src", [MEASURE, MEASURE_MIRROR], ids=["canonical", "plugin-mirror"]
+)
+def test_compact_restore_dispatch_installs_a_budget(src):
+    """Guard: the compact-restore CLI branch must install a hook budget, in both
+    the canonical and the codex-mirror source trees."""
+    text = src.read_text(encoding="utf-8")
+    idx = text.find('args[0] == "compact-restore"')
+    assert idx != -1, "compact-restore dispatch not found"
+    # look within the dispatch branch (before the next elif arg handler)
+    branch = text[idx: idx + 3200]
+    assert "_install_hook_budget(" in branch, "compact-restore is not budgeted"
+    assert "TOKEN_OPTIMIZER_COMPACT_RESTORE_BUDGET" in branch
+    assert "_clear_hook_budget(" in branch


### PR DESCRIPTION
**Problem:** a brand-new session could hang ~36s on the first prompt when several Claude Code sessions were open on the same project dir.

**Root cause (measured):** not the continuity scan (that's checkpoint-bounded and 8s-budgeted). It's the synchronous first-prompt hook chain, dominated by `compact-restore --new-session-only` — the **only** hook with no internal budget, capped solely by the harness's 20s timeout (2.5x the 8s cap on every other hook). Under disk/CPU contention it dominated the stall.

**Fix:** wrap it in the same `_install_hook_budget(...)` guard the other eight hooks already use (env-overridable, default 8s). Its output is a best-effort re-orientation hint, so a budget-exit degrades to no hint instead of blocking.

**Deliberately deferred** (bigger/riskier): collapsing the 3 UserPromptSubmit hooks into one process, caching the O(all-jsonl) session-resolution fallback (a shared cross-process cache risks misattributing the current session in exactly the parallel-session case that triggers this), and globally lowering budgets. This PR caps the single dominant contributor with a low-risk, pattern-matched edit; the additive-chain worst case is a follow-up worth doing deliberately.

**Tests:** clean exit under default + tiny budget, edit-time budget guard (both source trees). Full suite 1181 passed.

Honest caveat: I could not reproduce the full 36s live (warm, every hook 0.35–0.70s) — it's the cold/contended tail these ceilings allowed. This removes the largest ceiling.