### PR TITLE
fix(codex): harden telemetry hooks

### DIFF
--- a/cowork/token-optimizer/hooks/run.py
+++ b/cowork/token-optimizer/hooks/run.py
@@ -123,10 +123,14 @@ def _check_consent() -> bool:
                 return True  # Path outside home = skip (fail-open)
             config_path = pd / "config" / "config.json"
         else:
-            # Legacy / Codex fallback
-            codex_home = os.environ.get("CODEX_HOME", "")
-            if codex_home:
-                ch = Path(codex_home).resolve()
+            # Codex hooks set TOKEN_OPTIMIZER_RUNTIME=codex, but Codex does
+            # not guarantee CODEX_HOME is exported to every hook process.
+            # Honor the explicit runtime and fall back to ~/.codex so a valid
+            # Codex consent record is not silently skipped in favor of Claude's.
+            codex_home = os.environ.get("CODEX_HOME", "").strip()
+            runtime = os.environ.get("TOKEN_OPTIMIZER_RUNTIME", "").strip().lower()
+            if codex_home or runtime == "codex":
+                ch = Path(codex_home).expanduser().resolve() if codex_home else home / ".codex"
                 if not str(ch).startswith(str(home)):
                     return True
                 config_path = ch / "token-optimizer" / "config.json"

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/context_intel.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/context_intel.py
@@ -26,6 +26,7 @@ import re
 import time
 
 from hook_io import read_stdin_hook_input
+from credential_patterns import redact_credentials
 from session_store import SessionStore
 
 _OUTPUT_THRESHOLD = 8192  # Only summarize outputs >= 8K chars
@@ -196,6 +197,16 @@ _MAX_DECISIONS = 10
 _SENTENCE_SPLIT_RE = re.compile(r"[.!?\n]+")
 
 
+def _load_redacted_decisions(store: SessionStore) -> list:
+    """Load decisions and repair credential-bearing records from older versions."""
+    existing_raw = store.get_meta("session_decisions")
+    existing = json.loads(existing_raw) if existing_raw else []
+    redacted = [redact_credentials(d) if isinstance(d, str) else d for d in existing]
+    if redacted != existing:
+        store.set_meta("session_decisions", json.dumps(redacted, ensure_ascii=False))
+    return redacted
+
+
 def _extract_decisions(text: str, store: SessionStore) -> None:
     """Extract decision statements from tool output and store incrementally.
 
@@ -205,34 +216,34 @@ def _extract_decisions(text: str, store: SessionStore) -> None:
     to avoid conflicting with the implicit transaction from log_tool_use on
     the same shared connection.
     """
-    if len(text) < 50:
-        return
-    sample = text[:5000]
-    if not _DECISION_RE.search(sample):
-        return
-
-    sentences = [
-        s.strip() for s in _SENTENCE_SPLIT_RE.split(sample)
-        if 20 <= len(s.strip()) <= 200
-    ]
-    new_decisions = []
-    for sentence in sentences:
-        if _DECISION_RE.search(sentence):
-            new_decisions.append(sentence.strip()[:150])
-        if len(new_decisions) >= 3:
-            break
-
-    if not new_decisions:
-        return
-
     try:
-        existing_raw = store.get_meta("session_decisions")
-        existing = json.loads(existing_raw) if existing_raw else []
+        existing = _load_redacted_decisions(store)
+
+        if len(text) < 50:
+            return
+        sample = text[:5000]
+        if not _DECISION_RE.search(sample):
+            return
+
+        sentences = [
+            s.strip() for s in _SENTENCE_SPLIT_RE.split(sample)
+            if 20 <= len(s.strip()) <= 200
+        ]
+        new_decisions = []
+        for sentence in sentences:
+            if _DECISION_RE.search(sentence):
+                new_decisions.append(sentence.strip()[:150])
+            if len(new_decisions) >= 3:
+                break
+
+        if not new_decisions:
+            return
 
         if len(existing) >= _MAX_DECISIONS:
             return
 
         for d in new_decisions:
+            d = redact_credentials(d)
             if d not in existing:
                 existing.append(d)
                 if len(existing) >= _MAX_DECISIONS:

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -6,7 +6,7 @@ Status: supported
 
 *Find the ghost tokens. Survive compaction. Track the quality decay.*
 
-Token Optimizer for Codex audits local Codex context usage, tracks real session token/cost data from Codex JSONL logs, and installs a balanced hook profile for quality tracking and session continuity. Pure Python stdlib, zero dependencies, zero telemetry.
+Token Optimizer for Codex audits local Codex context usage, tracks real session token/cost data from Codex JSONL logs, and installs a selectable hook profile for quality tracking and session continuity. Pure Python stdlib, zero dependencies, zero telemetry.
 
 ## Status
 
@@ -32,21 +32,21 @@ TOKEN_OPTIMIZER_RUNTIME=codex python3 skills/token-optimizer/scripts/measure.py 
 
 This installs hooks to `~/.codex/hooks.json`, which Codex loads for all projects regardless of trust level. For per-project overrides, use `--project "$PWD"` instead.
 
-The default profile is `balanced`. It installs:
-
-- `SessionStart` for session recovery context.
-- `UserPromptSubmit` for prompt-quality and loop nudges.
-- `Stop` for throttled dashboard refresh and continuity checkpointing.
-- Codex compact prompt guidance in `~/.codex/config.toml`.
+The default profile is `aggressive`. It installs the balanced hooks plus
+PostToolUse telemetry. All profiles install Codex compact prompt guidance in
+`~/.codex/config.toml` unless you pass `--skip-compact-prompt`.
 
 ### Hook profiles
 
 | Profile | What it installs | Noise level |
 |---------|-----------------|-------------|
-| `balanced` (default) | SessionStart + UserPromptSubmit + Stop + compact prompt | Low, 3 hook events |
+| `balanced` | SessionStart + UserPromptSubmit + SubagentStart + SubagentStop + Stop | Low, session continuity and subagent tracking |
 | `quiet` | Stop only | Minimal, 1 hook event |
-| `telemetry` | Balanced + PostToolUse | Medium, visible rows in Desktop |
-| `aggressive` | All hooks including experimental Bash PreToolUse | High, full coverage |
+| `telemetry` | Stop + PostToolUse | Medium, local tool-output telemetry |
+| `aggressive` (default) | Balanced + PostToolUse | High, full non-experimental coverage |
+
+Experimental Bash command compression is separate from every profile and
+requires `--enable-bash-compression`; Codex cannot rewrite tool input yet.
 
 ```bash
 TOKEN_OPTIMIZER_RUNTIME=codex python3 skills/token-optimizer/scripts/measure.py codex-install --profile quiet
@@ -163,9 +163,9 @@ Codex and Claude Code have different hook surfaces, so some features work differ
 | Config file | `CLAUDE.md` | `AGENTS.md` | Different platforms |
 | Memory system | `MEMORY.md` + project memory dirs | `~/.codex/memories/**/*.md` | Different storage |
 | Model routing advice | Opus/Sonnet/Haiku per-agent routing | Intelligence levels (Low/Medium/High/Extra High) + model selection (GPT-5.6 Sol/Terra/Luna, GPT-5.5, 5.4, 5.4-Mini, 5.3-Codex, 5.2) | Different model families |
-| Hook install | Auto via plugin, 8 hook events | `codex-install` command (global by default), 4 profiles, 3-5 hook events | Codex hooks are newer, fewer events |
+| Hook install | Auto via plugin, 8 hook events | `codex-install` command (global by default), 4 profiles, 1-6 hook event types | Codex hooks are newer, fewer events |
 | Compact lifecycle | PreCompact + PostCompact hooks capture/restore | Compact prompt guidance + Stop checkpoints | Codex lacks PreCompact/PostCompact |
-| Tool result archive | PostToolUse archives immediately per tool call | Stop-time backfill from JSONL (balanced), or PostToolUse (telemetry profile) | Different timing |
+| Tool result archive | PostToolUse archives immediately per tool call | Stop-time backfill from JSONL (quiet/balanced), or immediate PostToolUse (telemetry/aggressive) | Different timing |
 | Dashboard refresh | SessionEnd hook + daemon at `localhost:24842` | Stop hook + daemon at `localhost:24843` | Both support bookmarkable URL via `setup-daemon` |
 | Plugin install | `/plugin marketplace add alexgreensh/token-optimizer` | `codex plugin marketplace add alexgreensh/token-optimizer` | Same concept, different CLI |
 | Auto-update | Claude Code marketplace auto-update | Codex marketplace `git ls-remote` on startup | Both work |

--- a/hooks/run.py
+++ b/hooks/run.py
@@ -123,10 +123,14 @@ def _check_consent() -> bool:
                 return True  # Path outside home = skip (fail-open)
             config_path = pd / "config" / "config.json"
         else:
-            # Legacy / Codex fallback
-            codex_home = os.environ.get("CODEX_HOME", "")
-            if codex_home:
-                ch = Path(codex_home).resolve()
+            # Codex hooks set TOKEN_OPTIMIZER_RUNTIME=codex, but Codex does
+            # not guarantee CODEX_HOME is exported to every hook process.
+            # Honor the explicit runtime and fall back to ~/.codex so a valid
+            # Codex consent record is not silently skipped in favor of Claude's.
+            codex_home = os.environ.get("CODEX_HOME", "").strip()
+            runtime = os.environ.get("TOKEN_OPTIMIZER_RUNTIME", "").strip().lower()
+            if codex_home or runtime == "codex":
+                ch = Path(codex_home).expanduser().resolve() if codex_home else home / ".codex"
                 if not str(ch).startswith(str(home)):
                     return True
                 config_path = ch / "token-optimizer" / "config.json"

--- a/plugins/token-optimizer/hooks/hooks.json
+++ b/plugins/token-optimizer/hooks/hooks.json
@@ -142,7 +142,7 @@
           {
             "type": "command",
             "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py session-end-flush --trigger end --defer; done; exit 0",
-            "timeout": 60
+            "timeout": 3
           }
         ]
       }

--- a/plugins/token-optimizer/hooks/run.py
+++ b/plugins/token-optimizer/hooks/run.py
@@ -123,10 +123,14 @@ def _check_consent() -> bool:
                 return True  # Path outside home = skip (fail-open)
             config_path = pd / "config" / "config.json"
         else:
-            # Legacy / Codex fallback
-            codex_home = os.environ.get("CODEX_HOME", "")
-            if codex_home:
-                ch = Path(codex_home).resolve()
+            # Codex hooks set TOKEN_OPTIMIZER_RUNTIME=codex, but Codex does
+            # not guarantee CODEX_HOME is exported to every hook process.
+            # Honor the explicit runtime and fall back to ~/.codex so a valid
+            # Codex consent record is not silently skipped in favor of Claude's.
+            codex_home = os.environ.get("CODEX_HOME", "").strip()
+            runtime = os.environ.get("TOKEN_OPTIMIZER_RUNTIME", "").strip().lower()
+            if codex_home or runtime == "codex":
+                ch = Path(codex_home).expanduser().resolve() if codex_home else home / ".codex"
                 if not str(ch).startswith(str(home)):
                     return True
                 config_path = ch / "token-optimizer" / "config.json"

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/context_intel.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/context_intel.py
@@ -26,6 +26,7 @@ import re
 import time
 
 from hook_io import read_stdin_hook_input
+from credential_patterns import redact_credentials
 from session_store import SessionStore
 
 _OUTPUT_THRESHOLD = 8192  # Only summarize outputs >= 8K chars
@@ -196,6 +197,16 @@ _MAX_DECISIONS = 10
 _SENTENCE_SPLIT_RE = re.compile(r"[.!?\n]+")
 
 
+def _load_redacted_decisions(store: SessionStore) -> list:
+    """Load decisions and repair credential-bearing records from older versions."""
+    existing_raw = store.get_meta("session_decisions")
+    existing = json.loads(existing_raw) if existing_raw else []
+    redacted = [redact_credentials(d) if isinstance(d, str) else d for d in existing]
+    if redacted != existing:
+        store.set_meta("session_decisions", json.dumps(redacted, ensure_ascii=False))
+    return redacted
+
+
 def _extract_decisions(text: str, store: SessionStore) -> None:
     """Extract decision statements from tool output and store incrementally.
 
@@ -205,34 +216,34 @@ def _extract_decisions(text: str, store: SessionStore) -> None:
     to avoid conflicting with the implicit transaction from log_tool_use on
     the same shared connection.
     """
-    if len(text) < 50:
-        return
-    sample = text[:5000]
-    if not _DECISION_RE.search(sample):
-        return
-
-    sentences = [
-        s.strip() for s in _SENTENCE_SPLIT_RE.split(sample)
-        if 20 <= len(s.strip()) <= 200
-    ]
-    new_decisions = []
-    for sentence in sentences:
-        if _DECISION_RE.search(sentence):
-            new_decisions.append(sentence.strip()[:150])
-        if len(new_decisions) >= 3:
-            break
-
-    if not new_decisions:
-        return
-
     try:
-        existing_raw = store.get_meta("session_decisions")
-        existing = json.loads(existing_raw) if existing_raw else []
+        existing = _load_redacted_decisions(store)
+
+        if len(text) < 50:
+            return
+        sample = text[:5000]
+        if not _DECISION_RE.search(sample):
+            return
+
+        sentences = [
+            s.strip() for s in _SENTENCE_SPLIT_RE.split(sample)
+            if 20 <= len(s.strip()) <= 200
+        ]
+        new_decisions = []
+        for sentence in sentences:
+            if _DECISION_RE.search(sentence):
+                new_decisions.append(sentence.strip()[:150])
+            if len(new_decisions) >= 3:
+                break
+
+        if not new_decisions:
+            return
 
         if len(existing) >= _MAX_DECISIONS:
             return
 
         for d in new_decisions:
+            d = redact_credentials(d)
             if d not in existing:
                 existing.append(d)
                 if len(existing) >= _MAX_DECISIONS:

--- a/scripts/sync-codex-marketplace-plugin.sh
+++ b/scripts/sync-codex-marketplace-plugin.sh
@@ -86,7 +86,19 @@ def strip_async(o):
     elif isinstance(o, list):
         for v in o:
             strip_async(v)
+
+def clamp_codex_session_end(o):
+    if isinstance(o, dict):
+        command = o.get("command")
+        if isinstance(command, str) and "session-end-flush --trigger end --defer" in command:
+            o["timeout"] = 3
+        for v in o.values():
+            clamp_codex_session_end(v)
+    elif isinstance(o, list):
+        for v in o:
+            clamp_codex_session_end(v)
 strip_async(data)
+clamp_codex_session_end(data)
 with open(p, "w", encoding="utf-8") as f:
     json.dump(data, f, indent=2)
     f.write("\n")

--- a/skills/token-optimizer/scripts/context_intel.py
+++ b/skills/token-optimizer/scripts/context_intel.py
@@ -26,6 +26,7 @@ import re
 import time
 
 from hook_io import read_stdin_hook_input
+from credential_patterns import redact_credentials
 from session_store import SessionStore
 
 _OUTPUT_THRESHOLD = 8192  # Only summarize outputs >= 8K chars
@@ -196,6 +197,16 @@ _MAX_DECISIONS = 10
 _SENTENCE_SPLIT_RE = re.compile(r"[.!?\n]+")
 
 
+def _load_redacted_decisions(store: SessionStore) -> list:
+    """Load decisions and repair credential-bearing records from older versions."""
+    existing_raw = store.get_meta("session_decisions")
+    existing = json.loads(existing_raw) if existing_raw else []
+    redacted = [redact_credentials(d) if isinstance(d, str) else d for d in existing]
+    if redacted != existing:
+        store.set_meta("session_decisions", json.dumps(redacted, ensure_ascii=False))
+    return redacted
+
+
 def _extract_decisions(text: str, store: SessionStore) -> None:
     """Extract decision statements from tool output and store incrementally.
 
@@ -205,34 +216,34 @@ def _extract_decisions(text: str, store: SessionStore) -> None:
     to avoid conflicting with the implicit transaction from log_tool_use on
     the same shared connection.
     """
-    if len(text) < 50:
-        return
-    sample = text[:5000]
-    if not _DECISION_RE.search(sample):
-        return
-
-    sentences = [
-        s.strip() for s in _SENTENCE_SPLIT_RE.split(sample)
-        if 20 <= len(s.strip()) <= 200
-    ]
-    new_decisions = []
-    for sentence in sentences:
-        if _DECISION_RE.search(sentence):
-            new_decisions.append(sentence.strip()[:150])
-        if len(new_decisions) >= 3:
-            break
-
-    if not new_decisions:
-        return
-
     try:
-        existing_raw = store.get_meta("session_decisions")
-        existing = json.loads(existing_raw) if existing_raw else []
+        existing = _load_redacted_decisions(store)
+
+        if len(text) < 50:
+            return
+        sample = text[:5000]
+        if not _DECISION_RE.search(sample):
+            return
+
+        sentences = [
+            s.strip() for s in _SENTENCE_SPLIT_RE.split(sample)
+            if 20 <= len(s.strip()) <= 200
+        ]
+        new_decisions = []
+        for sentence in sentences:
+            if _DECISION_RE.search(sentence):
+                new_decisions.append(sentence.strip()[:150])
+            if len(new_decisions) >= 3:
+                break
+
+        if not new_decisions:
+            return
 
         if len(existing) >= _MAX_DECISIONS:
             return
 
         for d in new_decisions:
+            d = redact_credentials(d)
             if d not in existing:
                 existing.append(d)
                 if len(existing) >= _MAX_DECISIONS:

--- a/tests/test_codex_hook_consent.py
+++ b/tests/test_codex_hook_consent.py
@@ -1,0 +1,52 @@
+"""Regression coverage for Codex hook consent resolution."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+RUN_PY = REPO / "hooks" / "run.py"
+
+
+def _load_run_py():
+    spec = importlib.util.spec_from_file_location("run_py_consent_test", RUN_PY)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_config(home: Path, runtime_dir: str, payload: dict) -> None:
+    config_dir = home / runtime_dir / "token-optimizer"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_explicit_codex_runtime_uses_default_codex_home_without_codex_home_env(monkeypatch, tmp_path):
+    """Codex hooks must not consult Claude consent when CODEX_HOME is unset."""
+    module = _load_run_py()
+    _write_config(tmp_path, ".codex", {})
+    _write_config(tmp_path, ".claude", {"enterprise_consent_shown": True})
+
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("TOKEN_OPTIMIZER_RUNTIME", "codex")
+
+    assert module._check_consent() is False
+
+
+def test_explicit_codex_runtime_reads_consent_from_default_codex_home(monkeypatch, tmp_path):
+    module = _load_run_py()
+    _write_config(tmp_path, ".codex", {"enterprise_consent_shown": True})
+
+    monkeypatch.setattr(module.Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("CLAUDE_PLUGIN_DATA", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setenv("TOKEN_OPTIMIZER_RUNTIME", "codex")
+
+    assert module._check_consent() is True

--- a/tests/test_codex_profile_docs.py
+++ b/tests/test_codex_profile_docs.py
@@ -1,0 +1,30 @@
+"""Keep Codex profile documentation aligned with the installer."""
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_codex_docs_name_the_installer_default_profile():
+    """A profile-default change must update the public Codex installation guide."""
+    docs = (ROOT / "docs" / "codex.md").read_text(encoding="utf-8")
+    installer = ast.parse(
+        (ROOT / "skills" / "token-optimizer" / "scripts" / "codex_install.py").read_text(encoding="utf-8")
+    )
+    profile_default = next(
+        keyword.value.value
+        for node in ast.walk(installer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add_argument"
+        and any(isinstance(arg, ast.Constant) and arg.value == "--profile" for arg in node.args)
+        for keyword in node.keywords
+        if keyword.arg == "default" and isinstance(keyword.value, ast.Constant)
+    )
+
+    assert f"The default profile is `{profile_default}`." in docs
+    assert "quiet/balanced" in docs
+    assert "telemetry/aggressive" in docs
+    assert "1-6 hook event types" in docs

--- a/tests/test_context_intel_decision_redaction.py
+++ b/tests/test_context_intel_decision_redaction.py
@@ -1,0 +1,62 @@
+"""Decision extraction must not persist credentials from tool output."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from context_intel import _MAX_DECISIONS, _extract_decisions  # noqa: E402
+
+
+class _Store:
+    def __init__(self):
+        self.values: dict[str, str] = {}
+
+    def get_meta(self, key: str):
+        return self.values.get(key)
+
+    def set_meta(self, key: str, value: str):
+        self.values[key] = value
+
+
+def test_decision_extraction_redacts_credential_before_persisting():
+    store = _Store()
+    raw_key = "AKIA" + "A" * 16
+
+    _extract_decisions(f"We decided to rotate {raw_key} tomorrow.", store)
+
+    stored = store.values["session_decisions"]
+    assert raw_key not in stored
+    assert "[CREDENTIAL REDACTED: AWS access key]" in stored
+
+
+def test_decision_extraction_repairs_legacy_credentials_at_the_decision_cap():
+    store = _Store()
+    raw_key = "AKIA" + "B" * 16
+    store.values["session_decisions"] = json.dumps([raw_key] * _MAX_DECISIONS)
+
+    _extract_decisions(
+        "We decided to keep the current release plan while coordinating the full regression suite.", store
+    )
+
+    stored = store.values["session_decisions"]
+    assert raw_key not in stored
+    assert "[CREDENTIAL REDACTED: AWS access key]" in stored
+
+
+def test_decision_extraction_repairs_legacy_credentials_without_a_decision():
+    store = _Store()
+    raw_key = "AKIA" + "C" * 16
+    store.values["session_decisions"] = json.dumps([raw_key])
+
+    _extract_decisions("no decision here", store)
+
+    stored = store.values["session_decisions"]
+    assert raw_key not in stored
+    assert "[CREDENTIAL REDACTED: AWS access key]" in stored

--- a/tests/test_hook_timeout_bounds.py
+++ b/tests/test_hook_timeout_bounds.py
@@ -39,6 +39,18 @@ LIFECYCLE_CEILING = 60
 # mid-run and the feature would silently stop working.
 FLOOR = 5
 
+# Codex executes SessionEnd synchronously and clamps it to three seconds even
+# when the source hook is async. The Codex mirror must honor that host limit.
+CODEX_SESSION_END_MAX = 3
+
+
+def _is_codex_session_end(tree, event, command):
+    return (
+        tree == "codex-mirror"
+        and event == "SessionEnd"
+        and "session-end-flush" in command
+    )
+
 
 def _flatten(path):
     """Yield (event, matcher, command, hook_dict) for every hook command entry."""
@@ -115,13 +127,17 @@ def test_timeouts_leave_room_for_a_healthy_run():
     for tree, path in _both_trees():
         for event, matcher, command, hook in _flatten(path):
             value = hook.get("timeout")
-            if isinstance(value, int) and value < FLOOR:
+            if (
+                isinstance(value, int)
+                and value < FLOOR
+                and not _is_codex_session_end(tree, event, command)
+            ):
                 tight.append(f"{tree}: {_label(event, matcher, command)} -> {value}s")
     assert not tight, f"timeouts below the {FLOOR}s floor:\n  " + "\n  ".join(tight)
 
 
 def test_mirror_timeouts_match_the_root():
-    """The Codex mirror strips async, never timeouts. Any drift is a bug."""
+    """The Codex mirror preserves timeouts except for Codex host limits."""
     root = {
         (e, m, c): h.get("timeout") for e, m, c, h in _flatten(HOOKS_JSON)
     }
@@ -133,5 +149,10 @@ def test_mirror_timeouts_match_the_root():
         f"{_label(*key)}: root={root[key]}s mirror={mirror[key]}s"
         for key in root
         if root[key] != mirror[key]
+        and not (
+            key[0] == "SessionEnd"
+            and "session-end-flush" in key[2]
+            and mirror[key] == CODEX_SESSION_END_MAX
+        )
     ]
     assert not drifted, "timeout drift:\n  " + "\n  ".join(drifted)


### PR DESCRIPTION
This retains the Codex SessionEnd 3-second bound while making the generated Codex mirror reproduce that host-specific limit.

It also fixes two Codex telemetry regressions: hook processes now resolve Codex consent even when CODEX_HOME is not inherited, and decision extraction redacts credentials before persistence (including records written by earlier releases). The Codex guide now matches the installed profile behavior, and the generated Codex and Cowork distributions are synchronized with the canonical runtime.

Verification: mirror-sync passes; the complete upstream test suite passes with 1,354 passed and 13 skipped.