### PR TITLE
fix(compact-restore): derive envelope event from stdin hook_event_name (SessionStart:compact rejection on local CLI)

### DIFF
--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -40572,14 +40572,22 @@ if __name__ == "__main__":
                 _buf = _io.StringIO()
                 with _redirect_stdout(_buf):
                     _run_compact_restore()
-                # Fable #1 follow-up (future-proof, no live impact today): the emitted
-                # event is chosen statically because Cowork fires this only from the
-                # UserPromptSubmit-registered entry and desktop/codex only from
-                # SessionStart. If #40495 is ever fixed and SessionStart starts firing in
-                # Cowork, derive the event from stdin hook_event_name instead so the
-                # envelope hookEventName always matches the firing hook.
+                # Derive the envelope event from the firing hook's stdin payload so
+                # the emitted hookEventName always matches the hook that actually
+                # fired. Previously this was hardcoded from is_cowork()
+                # ("UserPromptSubmit" if cowork else "SessionStart"), which assumed
+                # is_cowork() is accurate on every host. It is not: on the local CLI,
+                # hook subprocesses inherit the harness AI_AGENT marker
+                # (claude-code_*_harness), so is_cowork() false-positives and the
+                # SessionStart:compact hook emits a UserPromptSubmit envelope, which
+                # Claude Code rejects ("expected SessionStart but got
+                # UserPromptSubmit"), discarding the post-compaction recovery context.
+                # Reading hook_event_name from stdin removes the dependency on runtime
+                # detection being right. Falls back to SessionStart if the field is
+                # absent (older harnesses).
                 _emit_additional_context(
-                    _buf.getvalue(), event="UserPromptSubmit" if _cw else "SessionStart")
+                    _buf.getvalue(),
+                    event=str(hook_input.get("hook_event_name") or "SessionStart"))
             else:
                 _run_compact_restore()
         except _HookTimeout:

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -40572,14 +40572,22 @@ if __name__ == "__main__":
                 _buf = _io.StringIO()
                 with _redirect_stdout(_buf):
                     _run_compact_restore()
-                # Fable #1 follow-up (future-proof, no live impact today): the emitted
-                # event is chosen statically because Cowork fires this only from the
-                # UserPromptSubmit-registered entry and desktop/codex only from
-                # SessionStart. If #40495 is ever fixed and SessionStart starts firing in
-                # Cowork, derive the event from stdin hook_event_name instead so the
-                # envelope hookEventName always matches the firing hook.
+                # Derive the envelope event from the firing hook's stdin payload so
+                # the emitted hookEventName always matches the hook that actually
+                # fired. Previously this was hardcoded from is_cowork()
+                # ("UserPromptSubmit" if cowork else "SessionStart"), which assumed
+                # is_cowork() is accurate on every host. It is not: on the local CLI,
+                # hook subprocesses inherit the harness AI_AGENT marker
+                # (claude-code_*_harness), so is_cowork() false-positives and the
+                # SessionStart:compact hook emits a UserPromptSubmit envelope, which
+                # Claude Code rejects ("expected SessionStart but got
+                # UserPromptSubmit"), discarding the post-compaction recovery context.
+                # Reading hook_event_name from stdin removes the dependency on runtime
+                # detection being right. Falls back to SessionStart if the field is
+                # absent (older harnesses).
                 _emit_additional_context(
-                    _buf.getvalue(), event="UserPromptSubmit" if _cw else "SessionStart")
+                    _buf.getvalue(),
+                    event=str(hook_input.get("hook_event_name") or "SessionStart"))
             else:
                 _run_compact_restore()
         except _HookTimeout:

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -40572,14 +40572,22 @@ if __name__ == "__main__":
                 _buf = _io.StringIO()
                 with _redirect_stdout(_buf):
                     _run_compact_restore()
-                # Fable #1 follow-up (future-proof, no live impact today): the emitted
-                # event is chosen statically because Cowork fires this only from the
-                # UserPromptSubmit-registered entry and desktop/codex only from
-                # SessionStart. If #40495 is ever fixed and SessionStart starts firing in
-                # Cowork, derive the event from stdin hook_event_name instead so the
-                # envelope hookEventName always matches the firing hook.
+                # Derive the envelope event from the firing hook's stdin payload so
+                # the emitted hookEventName always matches the hook that actually
+                # fired. Previously this was hardcoded from is_cowork()
+                # ("UserPromptSubmit" if cowork else "SessionStart"), which assumed
+                # is_cowork() is accurate on every host. It is not: on the local CLI,
+                # hook subprocesses inherit the harness AI_AGENT marker
+                # (claude-code_*_harness), so is_cowork() false-positives and the
+                # SessionStart:compact hook emits a UserPromptSubmit envelope, which
+                # Claude Code rejects ("expected SessionStart but got
+                # UserPromptSubmit"), discarding the post-compaction recovery context.
+                # Reading hook_event_name from stdin removes the dependency on runtime
+                # detection being right. Falls back to SessionStart if the field is
+                # absent (older harnesses).
                 _emit_additional_context(
-                    _buf.getvalue(), event="UserPromptSubmit" if _cw else "SessionStart")
+                    _buf.getvalue(),
+                    event=str(hook_input.get("hook_event_name") or "SessionStart"))
             else:
                 _run_compact_restore()
         except _HookTimeout:


### PR DESCRIPTION
## Summary

Fixes the `SessionStart:compact hook error — expected 'SessionStart' but got 'UserPromptSubmit'` rejection that fires on every `/compact` (manual or auto) on the local Claude Code CLI, causing the post-compaction recovery context to be silently discarded.

### Root cause

`measure.py` `compact-restore` stamped its `additionalContext` envelope with `hookEventName` inferred from `is_cowork()` (`"UserPromptSubmit" if cowork else "SessionStart"`) rather than from the hook that actually fired.

On the local CLI, hook subprocesses inherit the harness `AI_AGENT` marker (`claude-code_*_harness`), so `is_cowork()` signal 3 (`runtime_env.py:71`, markers `("claude-code", "harness")`) false-positives. The `SessionStart:compact` hook then emits a `UserPromptSubmit` envelope, Claude Code rejects the mismatch and throws the payload away — while the plugin logs a savings event for context that never reached the model.

The emit site is `skills/token-optimizer/scripts/measure.py` (the `SessionStart` / `matcher: "compact"` entry in `hooks/hooks.json`). The envelope only prints when `compact_restore()` produces non-empty text (a matching checkpoint exists), which is why only the `compact` matcher trips it and the other `SessionStart` entries stay silent.

### Fix

Read `hook_event_name` from the stdin hook payload instead — the fix the code's own comment already prescribed — falling back to `"SessionStart"` when the field is absent:

```python
_emit_additional_context(
    _buf.getvalue(),
    event=str(hook_input.get("hook_event_name") or "SessionStart"))
```

`hook_input` is already parsed at the top of the `compact-restore` branch. The envelope can no longer disagree with the firing hook, and correctness no longer depends on `is_cowork()` being accurate (the property that broke here).

Correct in all three environments:

| Environment | Hook wired to | `hook_event_name` on stdin | Emitted envelope |
| --- | --- | --- | --- |
| Local Claude Code CLI | `SessionStart` (matcher `compact`) | `SessionStart` | SessionStart, accepted |
| Claude Cowork | `UserPromptSubmit` | `UserPromptSubmit` | UserPromptSubmit, accepted |
| Codex | `SessionStart` | `SessionStart` | SessionStart, accepted |

### Scope

- One-line behavior change in `skills/token-optimizer/scripts/measure.py`, plus the now-stale "Fable #1 follow-up (no live impact today)" comment rewritten to describe the new behavior (the old comment's "no live impact today" assumption is what this bug disproved).
- The same byte-identical `measure.py` ships in three trees (root, `plugins/token-optimizer/` Codex marketplace mirror, `cowork/token-optimizer/` committed Cowork tree). Both mirrors regenerated via `scripts/sync-codex-marketplace-plugin.sh` and `cowork_install.py --emit-committed` to keep the anti-drift tests green.

### Out of scope (flagged for a separate, migration-aware change)

`is_cowork()` still false-positives on the local CLI and also gates the state-directory root (`_STATE_BASE`, `measure.py:369-376`): when it false-positives with a resolved `CLAUDE_PLUGIN_DATA`, checkpoints/quality-cache relocate to the plugin-data tree. **This is intentionally not changed here** — every hook process already evaluates `is_cowork()` as true on the local CLI, so all existing local state lives under the Cowork-mode path. Flipping the detector would silently orphan that history. It needs a migration step and should be a separate PR.

A second instance of the same `event="UserPromptSubmit" if _cw else "SessionStart"` pattern exists in `hooks/userpromptsubmit_runner.py:409-411` (`_sub_compact_restore`). It is **not** broken today because that path is wired onto `UserPromptSubmit`, so a false-positive `_cw` emits `UserPromptSubmit` on a `UserPromptSubmit` hook (accidentally correct). It carries the same latent dependency on `is_cowork()` and could get the same stdin-derived treatment for consistency, but is left untouched here to keep this PR to the reported bug.

## Reproduction

Deterministic, no live session needed (from the plugin script dir, with any session id that has a checkpoint):

```bash
cat > /tmp/payload.json <<EOF
{"session_id":"<sid>","transcript_path":"/dev/null","cwd":"$PWD",
 "hook_event_name":"SessionStart","source":"compact"}
EOF

AI_AGENT=claude-code_2-1-233_harness CLAUDE_PLUGIN_ROOT=<plugin> \
  python3 <plugin>/skills/token-optimizer/scripts/measure.py compact-restore --compact \
  < /tmp/payload.json | head -c 160
```

Before the fix: emits `{"continue": true, "hookSpecificOutput": {"hookEventName": "UserPromptSubmit", ...}}` → rejected by the `SessionStart` hook.
After the fix: emits `hookEventName: "SessionStart"` → accepted.

#### Test plan

- [x] `python3 -m pytest tests/test_cowork_committed_plugin.py tests/test_codex_marketplace_plugin.py -q` — 13 passed (byte-identity + rebuild-leaves-git-clean anti-drift)
- [x] `python3 -m pytest tests/ -q` — 1395 passed, 13 skipped (full suite)
- [x] Three `measure.py` copies byte-identical after regeneration (`diff` clean)
- [ ] Maintainer confirms against a live local CLI `/compact` (the empirical `AI_AGENT=..._harness`-in-hook-subprocess observation this fix is predicated on; reproducible via the snippet above)
