### PR TITLE
fix: recognize mise shims in python-launcher.sh

### DIFF
--- a/hooks/python-launcher.sh
+++ b/hooks/python-launcher.sh
@@ -7,6 +7,8 @@
 #   - Windows Store Python (real installs proven alive via a flash-free
 #     GUI-twin proof-of-life probe, console --version probe as the fallback
 #     authority; non-functional AppExecutionAlias stubs skipped automatically)
+#   - mise (https://mise.jdx.dev) shims at their default per-platform data-dir
+#     location (Windows/macOS/Linux)
 # On Windows (Git Bash/MSYS), exec prefers the GUI-subsystem twin over the
 # console binary to avoid the per-hook console-window flash and orphaned
 # conhost.exe: python.exe/python3.exe swap to pythonw.exe, and py.exe (the
@@ -59,6 +61,19 @@ _is_safe_prefix() {
         # Exact filename keeps the anti-hijack intent (no wildcard in that dir).
         /[a-zA-Z]/Windows/py.exe)                                      return 0 ;;
         /[a-zA-Z]/Windows/pyw.exe)                                     return 0 ;;
+        # mise (https://mise.jdx.dev) shim directory, default Windows data dir.
+        # Hardcoded default location only -- never derived from MISE_DATA_DIR/
+        # MISE_SHIMS_DIR, which would reopen the PATH-hijack vector this
+        # allowlist exists to close.
+        /[a-zA-Z]/Users/*/AppData/Local/mise/shims/*)                  return 0 ;;
+    esac
+    # mise (https://mise.jdx.dev) shim directory, default macOS/Linux data dir
+    # (XDG: ~/.local/share/mise/shims). Needs its own case block (not
+    # _SAFE_PREFIXES) because it requires a per-user wildcard component.
+    # Hardcoded default location only, same rationale as the Windows entry above.
+    case "$binpath" in
+        /Users/*/.local/share/mise/shims/*)                            return 0 ;;
+        /home/*/.local/share/mise/shims/*)                             return 0 ;;
     esac
     # C8: case-insensitive WindowsApps allow for Windows-style drive-letter
     # paths. On a case-insensitive FS the dir can be any casing; the drive-


### PR DESCRIPTION
Fixes #145.

## Summary
`_is_safe_prefix()` had no case pattern for [mise](https://mise.jdx.dev)'s default shim directories, so a mise-managed `python3`/`python` on `$PATH` was found by `find_interpreter()` but rejected by the allowlist on every platform.

## Verified
Windows/Git Bash, mise 2026.8.8: `which python3` resolves to `AppData\Local\mise\shims\python3.exe` — a genuine PE executable (not a symlink or batch wrapper), executable and non-empty, passing every check except `_is_safe_prefix`. `mise which python3` resolves to the real interpreter at `AppData\Local\mise\installs\python\3.14.7\python3.exe`, which the script never consults directly (it only walks `$PATH`), so that path doesn't need allow-listing.

Tested against current `main` (5.11.99) after rebasing off it — the newer `TOKEN_OPTIMIZER_PYTHON` override and hook-safety `exit 0` degrade path (970fbc7) are untouched by this diff.

## Change
Adds hardcoded default-shim-directory patterns for Windows, macOS, and Linux, in the same per-user/wildcard-username style already used for `AppData/Local/Programs/Python`. Deliberately **not** read from `MISE_DATA_DIR`/`MISE_SHIMS_DIR`, to preserve the allowlist's documented "hardcoded, never PATH/env-derived" invariant.

## Scope
pyenv/asdf (POSIX, same shim shape) and pyenv-win (`.bat` shims, needs an extension-loop change too) are noted as follow-ups in #145, not included here.