### PR TITLE
fix(runway,codex): Cowork meter path + Codex SessionEnd clamp — 5.11.106

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "token-optimizer",
       "source": "./",
       "description": "Audit, fix, and monitor Claude Code context window usage. Find the ghost tokens.",
-      "version": "5.11.105",
+      "version": "5.11.106",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"
@@ -55,7 +55,7 @@
       "name": "token-optimizer-cowork",
       "source": "./cowork/token-optimizer",
       "description": "Token Optimizer for Claude Cowork \u2014 full skills + Cowork-native hooks (beta). Install THIS in Cowork; the standard token-optimizer entry is for desktop Claude Code.",
-      "version": "5.11.105",
+      "version": "5.11.106",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.105",
+  "version": "5.11.106",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.105",
+  "version": "5.11.106",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/cowork/token-optimizer/.claude-plugin/plugin.json
+++ b/cowork/token-optimizer/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.105",
+  "version": "5.11.106",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -15213,10 +15213,40 @@ def _keepwarm_rate_limits_path():
 
     Written by statusline.js from Claude Code's own usage data: five_hour /
     seven_day used_percentage + resets_at. THE meter source for the subscription
-    quota model. Lives beside live-fill.json in QUALITY_CACHE_DIR (resolved at
-    call time so a test override of QUALITY_CACHE_DIR is honoured).
+    quota model.
+
+    Base is RUNTIME_DIR, NOT QUALITY_CACHE_DIR. The meter is ACCOUNT-global, not
+    per-session state, so it must not ride the is_cowork() -> plugin-data
+    _STATE_BASE divergence that QUALITY_CACHE_DIR uses for run-once markers and
+    the quality cache. RUNTIME_DIR resolves to <claude home>/token-optimizer on
+    desktop AND inside Cowork (is_cowork() only shifts _STATE_BASE, never
+    RUNTIME_DIR). Reading via QUALITY_CACHE_DIR pointed a Cowork or synced-plugin
+    session at <plugin-data>/token-optimizer/rate-limits.json -- a path the
+    statusline never writes -- so the meter read empty, runway_snapshot returned
+    zero windows, and the "your live 5h/7d view reappears next session" placeholder
+    got baked into the SHARED dashboard that every session (desktop included) then
+    displayed, even with a fresh live meter. Pinning to RUNTIME_DIR removes that
+    divergence: RUNTIME_DIR (= claude_home() for the Claude runtime) is stable
+    across Cowork, matching where the statusline writes in the common case.
+
+    KNOWN GAP (pre-existing, not introduced here, tracked separately): RUNTIME_DIR
+    resolves through claude_home(), which HONORS CLAUDE_CONFIG_DIR, but statusline.js
+    (and the VS Code extension) hardcode os.homedir()/.claude and IGNORE
+    CLAUDE_CONFIG_DIR. So a user who relocates their Claude config via
+    CLAUDE_CONFIG_DIR reads the meter from claude_home() while the statusline writes
+    it under os.homedir()/.claude -- they diverge and the runway card empties, the
+    same symptom by a different trigger. The old QUALITY_CACHE_DIR base had the
+    identical divergence on desktop, so this is unchanged by the fix. The complete
+    cure is to make the JS/TS writers honor CLAUDE_CONFIG_DIR too (hot-path change,
+    separate follow-up). With CLAUDE_CONFIG_DIR unset (the common case) all three
+    resolve to ~/.claude/token-optimizer and agree.
+
+    Foreign runtimes (codex/copilot/hermes) have no meter writer, so their
+    runtime-scoped RUNTIME_DIR path stays empty. runway_snapshot then returns a card
+    with no windows whenever the savings ledger alone has a story, and the template
+    shows the "live view refreshes while you work" note (NOT literally nothing).
     """
-    return QUALITY_CACHE_DIR / "rate-limits.json"
+    return RUNTIME_DIR / "token-optimizer" / "rate-limits.json"
 
 
 def _keepwarm_read_meters(rate_limits_path=None, now=None):

--- a/plugins/token-optimizer/.codex-plugin/plugin.json
+++ b/plugins/token-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.105",
+  "version": "5.11.106",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/token-optimizer/hooks/hooks.json
+++ b/plugins/token-optimizer/hooks/hooks.json
@@ -142,7 +142,7 @@
           {
             "type": "command",
             "command": "for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do command -v \"$b\" >/dev/null 2>&1 && exec \"$b\" \"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh\" \"${CLAUDE_PLUGIN_ROOT}/hooks/run.py\" skills/token-optimizer/scripts/measure.py session-end-flush --trigger end --defer; done; exit 0",
-            "timeout": 60
+            "timeout": 3
           }
         ]
       }

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -15213,10 +15213,40 @@ def _keepwarm_rate_limits_path():
 
     Written by statusline.js from Claude Code's own usage data: five_hour /
     seven_day used_percentage + resets_at. THE meter source for the subscription
-    quota model. Lives beside live-fill.json in QUALITY_CACHE_DIR (resolved at
-    call time so a test override of QUALITY_CACHE_DIR is honoured).
+    quota model.
+
+    Base is RUNTIME_DIR, NOT QUALITY_CACHE_DIR. The meter is ACCOUNT-global, not
+    per-session state, so it must not ride the is_cowork() -> plugin-data
+    _STATE_BASE divergence that QUALITY_CACHE_DIR uses for run-once markers and
+    the quality cache. RUNTIME_DIR resolves to <claude home>/token-optimizer on
+    desktop AND inside Cowork (is_cowork() only shifts _STATE_BASE, never
+    RUNTIME_DIR). Reading via QUALITY_CACHE_DIR pointed a Cowork or synced-plugin
+    session at <plugin-data>/token-optimizer/rate-limits.json -- a path the
+    statusline never writes -- so the meter read empty, runway_snapshot returned
+    zero windows, and the "your live 5h/7d view reappears next session" placeholder
+    got baked into the SHARED dashboard that every session (desktop included) then
+    displayed, even with a fresh live meter. Pinning to RUNTIME_DIR removes that
+    divergence: RUNTIME_DIR (= claude_home() for the Claude runtime) is stable
+    across Cowork, matching where the statusline writes in the common case.
+
+    KNOWN GAP (pre-existing, not introduced here, tracked separately): RUNTIME_DIR
+    resolves through claude_home(), which HONORS CLAUDE_CONFIG_DIR, but statusline.js
+    (and the VS Code extension) hardcode os.homedir()/.claude and IGNORE
+    CLAUDE_CONFIG_DIR. So a user who relocates their Claude config via
+    CLAUDE_CONFIG_DIR reads the meter from claude_home() while the statusline writes
+    it under os.homedir()/.claude -- they diverge and the runway card empties, the
+    same symptom by a different trigger. The old QUALITY_CACHE_DIR base had the
+    identical divergence on desktop, so this is unchanged by the fix. The complete
+    cure is to make the JS/TS writers honor CLAUDE_CONFIG_DIR too (hot-path change,
+    separate follow-up). With CLAUDE_CONFIG_DIR unset (the common case) all three
+    resolve to ~/.claude/token-optimizer and agree.
+
+    Foreign runtimes (codex/copilot/hermes) have no meter writer, so their
+    runtime-scoped RUNTIME_DIR path stays empty. runway_snapshot then returns a card
+    with no windows whenever the savings ledger alone has a story, and the template
+    shows the "live view refreshes while you work" note (NOT literally nothing).
     """
-    return QUALITY_CACHE_DIR / "rate-limits.json"
+    return RUNTIME_DIR / "token-optimizer" / "rate-limits.json"
 
 
 def _keepwarm_read_meters(rate_limits_path=None, now=None):

--- a/scripts/sync-codex-marketplace-plugin.sh
+++ b/scripts/sync-codex-marketplace-plugin.sh
@@ -66,15 +66,28 @@ cp "${REPO_ROOT}/.codex-plugin/plugin.json" "${STAGE}/.codex-plugin/plugin.json"
 find "${STAGE}" \( -name '__pycache__' -o -name '.DS_Store' -o -name '*.pyc' -o -name '*.pyo' \) \
   -exec rm -rf {} + 2>/dev/null || true
 
-# --- Codex compatibility (issue #83): Codex warns and SKIPS any hook with
-#     "async": true ("async hooks are not supported yet"), so those hooks never
-#     run for Codex marketplace users. Strip the async flag from the mirrored
-#     hooks.json so Codex runs them synchronously. The root hooks/hooks.json keeps
-#     "async": true for Claude's non-blocking path — the mirror equals the root
-#     modulo the async keys (the parity test normalizes this the same way).
+# --- Codex compatibility. Two transforms applied to the mirrored hooks.json;
+#     the root hooks/hooks.json keeps its Claude-tuned values (the parity test
+#     normalizes both the same way):
+#
+#     (issue #83) Codex warns and SKIPS any hook with "async": true ("async hooks
+#       are not supported yet"), so those hooks never run for Codex marketplace
+#       users. Strip the async flag so Codex runs them synchronously. Claude keeps
+#       "async": true for its non-blocking path.
+#
+#     (SessionEnd clamp) Codex hard-caps SessionEnd hook timeouts at 3s and prints
+#       "clamping SessionEnd hook timeout to 3s in .../hooks.json" as a load-time
+#       ISSUE whenever a SessionEnd hook declares more. Our SessionEnd hook runs
+#       `session-end-flush --defer`, which only spawns a detached worker and
+#       returns in well under a second, so the 60s Claude value is pure headroom
+#       Codex can never honor. Pre-clamp SessionEnd timeouts to 3 in the mirror so
+#       Codex loads it clean (no user-facing warning) with identical behavior.
 if [ -f "${STAGE}/hooks/hooks.json" ]; then
-  python3 - "${STAGE}/hooks/hooks.json" <<'PYSTRIP' || { echo "ERROR: failed to strip async from mirrored hooks.json" >&2; exit 4; }
+  python3 - "${STAGE}/hooks/hooks.json" <<'PYSTRIP' || { echo "ERROR: failed to apply Codex hooks.json transforms" >&2; exit 4; }
 import json, sys
+# Codex's hard cap for SessionEnd hook timeouts (seconds). Anything above this is
+# clamped by Codex and surfaced as a load-time issue, so we pre-clamp to match.
+CODEX_SESSION_END_TIMEOUT_CAP = 3
 p = sys.argv[1]
 with open(p, encoding="utf-8") as f:
     data = json.load(f)
@@ -87,6 +100,13 @@ def strip_async(o):
         for v in o:
             strip_async(v)
 strip_async(data)
+# Clamp SessionEnd timeouts only (the event Codex caps at 3s). Other events keep
+# their declared timeouts; Codex does not warn on those.
+for group in data.get("hooks", {}).get("SessionEnd", []):
+    for hook in group.get("hooks", []):
+        t = hook.get("timeout")
+        if isinstance(t, (int, float)) and t > CODEX_SESSION_END_TIMEOUT_CAP:
+            hook["timeout"] = CODEX_SESSION_END_TIMEOUT_CAP
 with open(p, "w", encoding="utf-8") as f:
     json.dump(data, f, indent=2)
     f.write("\n")

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -15213,10 +15213,40 @@ def _keepwarm_rate_limits_path():
 
     Written by statusline.js from Claude Code's own usage data: five_hour /
     seven_day used_percentage + resets_at. THE meter source for the subscription
-    quota model. Lives beside live-fill.json in QUALITY_CACHE_DIR (resolved at
-    call time so a test override of QUALITY_CACHE_DIR is honoured).
+    quota model.
+
+    Base is RUNTIME_DIR, NOT QUALITY_CACHE_DIR. The meter is ACCOUNT-global, not
+    per-session state, so it must not ride the is_cowork() -> plugin-data
+    _STATE_BASE divergence that QUALITY_CACHE_DIR uses for run-once markers and
+    the quality cache. RUNTIME_DIR resolves to <claude home>/token-optimizer on
+    desktop AND inside Cowork (is_cowork() only shifts _STATE_BASE, never
+    RUNTIME_DIR). Reading via QUALITY_CACHE_DIR pointed a Cowork or synced-plugin
+    session at <plugin-data>/token-optimizer/rate-limits.json -- a path the
+    statusline never writes -- so the meter read empty, runway_snapshot returned
+    zero windows, and the "your live 5h/7d view reappears next session" placeholder
+    got baked into the SHARED dashboard that every session (desktop included) then
+    displayed, even with a fresh live meter. Pinning to RUNTIME_DIR removes that
+    divergence: RUNTIME_DIR (= claude_home() for the Claude runtime) is stable
+    across Cowork, matching where the statusline writes in the common case.
+
+    KNOWN GAP (pre-existing, not introduced here, tracked separately): RUNTIME_DIR
+    resolves through claude_home(), which HONORS CLAUDE_CONFIG_DIR, but statusline.js
+    (and the VS Code extension) hardcode os.homedir()/.claude and IGNORE
+    CLAUDE_CONFIG_DIR. So a user who relocates their Claude config via
+    CLAUDE_CONFIG_DIR reads the meter from claude_home() while the statusline writes
+    it under os.homedir()/.claude -- they diverge and the runway card empties, the
+    same symptom by a different trigger. The old QUALITY_CACHE_DIR base had the
+    identical divergence on desktop, so this is unchanged by the fix. The complete
+    cure is to make the JS/TS writers honor CLAUDE_CONFIG_DIR too (hot-path change,
+    separate follow-up). With CLAUDE_CONFIG_DIR unset (the common case) all three
+    resolve to ~/.claude/token-optimizer and agree.
+
+    Foreign runtimes (codex/copilot/hermes) have no meter writer, so their
+    runtime-scoped RUNTIME_DIR path stays empty. runway_snapshot then returns a card
+    with no windows whenever the savings ledger alone has a story, and the template
+    shows the "live view refreshes while you work" note (NOT literally nothing).
     """
-    return QUALITY_CACHE_DIR / "rate-limits.json"
+    return RUNTIME_DIR / "token-optimizer" / "rate-limits.json"
 
 
 def _keepwarm_read_meters(rate_limits_path=None, now=None):

--- a/tests/test_codex_marketplace_plugin.py
+++ b/tests/test_codex_marketplace_plugin.py
@@ -162,11 +162,15 @@ def test_codex_mirror_hooks_byte_identical_to_root():
 
 
 def test_codex_mirror_hooks_json_is_async_stipped_root():
-    """hooks.json in the mirror must equal the root hooks.json with every
-    ``async`` key recursively removed (the sync script's Codex compatibility
-    transform, issue #83). Guards that the mirror's hooks.json did not drift
-    in any OTHER respect."""
+    """hooks.json in the mirror must equal the root hooks.json under the sync
+    script's two Codex compatibility transforms: every ``async`` key recursively
+    removed (issue #83) AND SessionEnd hook timeouts clamped to Codex's 3s cap.
+    Guards that the mirror's hooks.json did not drift in any OTHER respect."""
     import json
+
+    # Must match CODEX_SESSION_END_TIMEOUT_CAP in
+    # scripts/sync-codex-marketplace-plugin.sh.
+    CODEX_SESSION_END_TIMEOUT_CAP = 3
 
     root_hj = ROOT_HOOKS / "hooks.json"
     mirror_hj = MIRROR_HOOKS / "hooks.json"
@@ -179,10 +183,20 @@ def test_codex_mirror_hooks_json_is_async_stipped_root():
             return [_strip_async(v) for v in o]
         return o
 
-    expected = _strip_async(json.loads(root_hj.read_text(encoding="utf-8")))
+    def _clamp_session_end(doc):
+        for group in doc.get("hooks", {}).get("SessionEnd", []):
+            for hook in group.get("hooks", []):
+                t = hook.get("timeout")
+                if isinstance(t, (int, float)) and t > CODEX_SESSION_END_TIMEOUT_CAP:
+                    hook["timeout"] = CODEX_SESSION_END_TIMEOUT_CAP
+        return doc
+
+    expected = _clamp_session_end(
+        _strip_async(json.loads(root_hj.read_text(encoding="utf-8")))
+    )
     actual = json.loads(mirror_hj.read_text(encoding="utf-8"))
     assert actual == expected, (
         "plugins/token-optimizer/hooks/hooks.json drifted from the root "
-        "hooks.json modulo the async keys; rerun "
-        "scripts/sync-codex-marketplace-plugin.sh."
+        "hooks.json modulo the async keys and the SessionEnd timeout clamp; "
+        "rerun scripts/sync-codex-marketplace-plugin.sh."
     )

--- a/tests/test_hook_timeout_bounds.py
+++ b/tests/test_hook_timeout_bounds.py
@@ -39,6 +39,23 @@ LIFECYCLE_CEILING = 60
 # mid-run and the feature would silently stop working.
 FLOOR = 5
 
+# Codex hard-caps SessionEnd hook timeouts at 3s (below FLOOR) and prints a
+# load-time issue when a SessionEnd hook declares more, so the Codex mirror
+# pre-clamps SessionEnd to this value (see scripts/sync-codex-marketplace-plugin.sh).
+# Safe below the floor: that hook runs `session-end-flush --defer`, which only
+# spawns a detached worker and returns in well under a second. The root tree keeps
+# its Claude-tuned 60s. Exactly this (codex-mirror, SessionEnd, ==cap) entry is
+# exempt from the floor and from root/mirror timeout parity.
+CODEX_SESSION_END_TIMEOUT_CAP = 3
+
+
+def _is_codex_clamped_session_end(tree, event, value):
+    return (
+        tree == "codex-mirror"
+        and event == "SessionEnd"
+        and value == CODEX_SESSION_END_TIMEOUT_CAP
+    )
+
 
 def _flatten(path):
     """Yield (event, matcher, command, hook_dict) for every hook command entry."""
@@ -115,13 +132,16 @@ def test_timeouts_leave_room_for_a_healthy_run():
     for tree, path in _both_trees():
         for event, matcher, command, hook in _flatten(path):
             value = hook.get("timeout")
+            if _is_codex_clamped_session_end(tree, event, value):
+                continue  # Codex forces 3s here; --defer returns instantly.
             if isinstance(value, int) and value < FLOOR:
                 tight.append(f"{tree}: {_label(event, matcher, command)} -> {value}s")
     assert not tight, f"timeouts below the {FLOOR}s floor:\n  " + "\n  ".join(tight)
 
 
 def test_mirror_timeouts_match_the_root():
-    """The Codex mirror strips async, never timeouts. Any drift is a bug."""
+    """The Codex mirror strips async and clamps SessionEnd to Codex's 3s cap;
+    every OTHER timeout must equal the root. Any other drift is a bug."""
     root = {
         (e, m, c): h.get("timeout") for e, m, c, h in _flatten(HOOKS_JSON)
     }
@@ -129,9 +149,18 @@ def test_mirror_timeouts_match_the_root():
         (e, m, c): h.get("timeout") for e, m, c, h in _flatten(MIRROR_HOOKS_JSON)
     }
     assert root.keys() == mirror.keys(), "hook sets differ between root and mirror"
-    drifted = [
-        f"{_label(*key)}: root={root[key]}s mirror={mirror[key]}s"
-        for key in root
-        if root[key] != mirror[key]
-    ]
+    drifted = []
+    for key in root:
+        event = key[0]
+        if root[key] == mirror[key]:
+            continue
+        # The one sanctioned divergence: SessionEnd clamped down to Codex's cap.
+        if (
+            event == "SessionEnd"
+            and mirror[key] == CODEX_SESSION_END_TIMEOUT_CAP
+            and isinstance(root[key], int)
+            and root[key] > CODEX_SESSION_END_TIMEOUT_CAP
+        ):
+            continue
+        drifted.append(f"{_label(*key)}: root={root[key]}s mirror={mirror[key]}s")
     assert not drifted, "timeout drift:\n  " + "\n  ".join(drifted)


### PR DESCRIPTION
## Two user-reported bugs

### 1. Dashboard limit card stuck on the "reappears next session" placeholder
The account-global rate-limit meter was read via `QUALITY_CACHE_DIR`, whose `_STATE_BASE` flips to the plugin-data dir under `is_cowork()`/synced-plugin sessions — a path the statusline never writes. A Cowork-context regen read an empty meter → **zero runway windows** → the placeholder baked into the **single shared dashboard** every session displays, even with a fresh live meter.

**Fix:** pin the meter read to `RUNTIME_DIR` (stable across Cowork, matches the statusline writer in the common case). Foreign runtimes stay runtime-scoped and silent.

Reproduced (Cowork context → 0 windows + headline) and verified fixed (→ 2 windows); codex stays `None`.

### 2. Codex "1 issue loading hooks"
SessionEnd declared `timeout: 60`, but Codex hard-caps SessionEnd at **3s** (strict `>`) and warns. The hook runs `session-end-flush --defer` (spawns a detached worker, returns instantly), so 3s is safe.

**Fix:** clamp SessionEnd timeouts to 3s in the Codex mirror via the sync transform; the Claude root keeps 60. Verified against Codex source (`SESSION_END_MAX_TIMEOUT_SEC = 3`).

## Verification
- Adversarial 5-lane GLM torture-room pass: regression / clamp-correctness / test-integrity / symptom-coverage all clean.
- Tests updated to encode the new mirror contract (async-strip + SessionEnd clamp) and **proven to still catch real drift** (injected 3 drift cases, all fail).
- Codex + Cowork mirrors regenerated (byte-identical, idempotent); reproducibility gates green.
- Version aligned to **5.11.106** across all primary surfaces.

## Known follow-up (pre-existing, not introduced here)
`CLAUDE_CONFIG_DIR`: `statusline.js` / the VS Code extension hardcode `os.homedir()/.claude` and ignore it, while the meter reader resolves via `claude_home()` (honors it). A relocated-config user diverges — same symptom, different trigger. The old base had the identical gap. Documented in the code; complete cure (make the JS/TS writers honor `CLAUDE_CONFIG_DIR`) is a separate hot-path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)