### PR TITLE
feat(audit,docs): recommend skill name-only slimming, not just archive — 5.11.107

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "token-optimizer",
       "source": "./",
       "description": "Audit, fix, and monitor Claude Code context window usage. Find the ghost tokens.",
-      "version": "5.11.106",
+      "version": "5.11.107",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"
@@ -55,7 +55,7 @@
       "name": "token-optimizer-cowork",
       "source": "./cowork/token-optimizer",
       "description": "Token Optimizer for Claude Cowork \u2014 full skills + Cowork-native hooks (beta). Install THIS in Cowork; the standard token-optimizer entry is for desktop Claude Code.",
-      "version": "5.11.106",
+      "version": "5.11.107",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.106",
+  "version": "5.11.107",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.106",
+  "version": "5.11.107",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/cowork/token-optimizer/.claude-plugin/plugin.json
+++ b/cowork/token-optimizer/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.106",
+  "version": "5.11.107",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/cowork/token-optimizer/skills/token-dashboard/SKILL.md
+++ b/cowork/token-optimizer/skills/token-dashboard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: token-dashboard
 description: Open the Token Optimizer dashboard in your browser (context usage, quality, savings). Use to view the dashboard.
+disable-model-invocation: true
 ---
 
 # Token Optimizer Dashboard

--- a/cowork/token-optimizer/skills/token-optimizer/references/token-flow-architecture.md
+++ b/cowork/token-optimizer/skills/token-optimizer/references/token-flow-architecture.md
@@ -533,7 +533,24 @@ CLAUDE.md supports `@path/to/file.md` imports that pull external file content in
 
 ### `disable-model-invocation: true` in Skill Frontmatter
 
-Skills can set `disable-model-invocation: true` to prevent being invoked by the model (only user can invoke). This doesn't change token cost but is useful context: skills without this flag can be auto-invoked, which triggers full skill content loading.
+Skills inject `name` + `description` into always-on context every turn (progressive disclosure: the body loads only on invoke). Dropping a skill's description from that always-on context recovers its per-turn description cost — quantify it with the per-skill token cost `measure.py report` already computes, not a flat constant. Descriptions are also dropped after `/compact` and never re-injected, so the savings persist across compaction. Claude Code gives **two distinct levers** to do this, and they are NOT the same thing:
+
+**1. `skillOverrides` in settings (the true "name-only" middle mode).** `.claude/settings.local.json` `skillOverrides` maps a skill name to one of four visibility states (the `/skills` menu writes it for you — highlight a skill, press `Space` to cycle, `Enter` to save). Per the official docs (code.claude.com/docs/en/skills.md, "Override skill visibility from settings"):
+
+| Value | Listed to Claude | In `/` menu |
+| :-- | :-- | :-- |
+| `"on"` (default) | Name **and** description | Yes |
+| `"name-only"` | **Name only** (description hidden) | Yes |
+| `"user-invocable-only"` | Hidden from Claude | Yes |
+| `"off"` | Hidden | Hidden |
+
+`"name-only"` is the real name-visible/description-hidden middle mode: the model still sees the skill's **name** (so it can still invoke it by name) but not its description, so it stops auto-triggering on description match while you keep the token savings. This is the right choice for a skill you want to stay discoverable-by-name without paying for its description or letting it fire automatically.
+
+**2. `disable-model-invocation: true` in SKILL.md frontmatter (fully hidden from the model).** This **removes the skill from the model's context entirely** — not even the name is visible; only the USER can invoke it via `/name`. Official docs, verbatim: *"Description not in context, full skill loads when you invoke"* and *"They stay completely out of context until you invoke them with /name"* (context-window.md). Use it for skills only the user ever triggers explicitly (e.g. one that launches a browser tab, where auto-triggering on a guess is intrusive). It is a **binary** frontmatter flag (advertised, or fully hidden) — the graded middle states live in `skillOverrides` above, not in the flag. Equivalent settings values are `"user-invocable-only"` / `"off"`.
+
+Do NOT relabel `disable-model-invocation` as "name-only" — that term is Claude Code's `skillOverrides` state (name kept), and `disable-model-invocation` hides the name too. Keep skills whose value is proactive auto-triggering on the default `"on"`.
+
+**Cross-harness caveat**: both levers are **Claude-Code-specific**. Codex / OpenCode / Copilot skills keep `name` + `description` resident regardless; there is no per-skill "hide description" toggle there (the equivalent is a different primitive — a command / prompt-file — or a full disable via `[[skills.config]] enabled = false` on Codex). Other harnesses ignore the unknown frontmatter key (harmless, not an error).
 
 ### Compact Instructions Section in CLAUDE.md
 

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6675,8 +6675,10 @@ def _generate_codex_auto_recommendations(components, trends=None, days=30):
 # audit tool you never explicitly "invoke" is not the same as an unused skill.
 _OWN_TOOL_SKILLS = frozenset({
     "token-optimizer", "token-coach", "token-dashboard", "fleet-auditor",
+    "resume-checkpoint",
     "token-optimizer:token-optimizer", "token-optimizer:token-coach",
     "token-optimizer:token-dashboard", "token-optimizer:fleet-auditor",
+    "token-optimizer:resume-checkpoint",
     "token-optimizer:health", "token-optimizer:quick",
 })
 
@@ -6694,6 +6696,44 @@ def _is_own_tool_skill(name) -> bool:
         or base.startswith("token-coach")
         or base.startswith("token-dashboard")
         or base.startswith("fleet-auditor")
+        or base.startswith("resume-checkpoint")
+    )
+
+
+def _skill_slim_clause(avg_tokens, runtime):
+    """Softer-than-archive options for an unused skill, inserted ABOVE the archive
+    step. Keeps the skill installed while dropping its per-turn description cost.
+
+    Returns a block that STARTS and ends with a newline so it drops cleanly
+    between the skill list and the archive step (each call site therefore does
+    NOT add its own leading newline). Claude gets the two REAL, distinct Claude
+    Code levers -- do not conflate them:
+      - skillOverrides "name-only": NAME stays visible to the model (still
+        invocable by name), description dropped -> stops auto-triggering, saves
+        the description tokens. The true "name-only" middle mode.
+      - disable-model-invocation: true (frontmatter): removes the skill from the
+        model's context ENTIRELY (name too); only the user invokes it via /name.
+    Foreign runtimes have no per-skill toggle, so they get an honest note.
+    """
+    if runtime == "claude":
+        return (
+            f"\n  Softer than archiving -- two Claude Code levers keep the skill installed and recover "
+            f"~{avg_tokens} tokens/skill per turn (Claude may already have dropped some descriptions past "
+            f"its listing budget, so treat this as an upper bound):"
+            f"\n    - Name-only (keep it discoverable): in the `/skills` menu press Space to cycle a skill to "
+            f"`name-only` (writes `skillOverrides` in .claude/settings.local.json). The model still sees the "
+            f"NAME so it can invoke it, but the description drops from context and it stops auto-triggering. "
+            f"Best for skills you still want suggested by name."
+            f"\n    - Fully hidden (user-only): set `disable-model-invocation: true` in the SKILL.md frontmatter "
+            f"(or the `off` / `user-invocable-only` `skillOverrides` state). The model sees nothing; only you "
+            f"invoke it via `/name`. Best for skills you alone ever trigger."
+            f"\n  Both are Claude-Code-specific and survive `/compact`. Keep skills whose value is proactive "
+            f"auto-triggering on the default.\n"
+        )
+    return (
+        f"\n  Softer than archiving: this runtime ({runtime}) has no per-skill 'hide description' toggle. "
+        f"The equivalent is converting a skill you only trigger yourself into a command/prompt primitive, or "
+        f"fully disabling it. Keep skills you want auto-suggested as normal skills.\n"
     )
 
 
@@ -6796,6 +6836,11 @@ def generate_auto_recommendations(components, trends=None, days=30):
     # Use actual measured avg if available, else fallback to constant
     _si = components.get("skills", {})
     _actual_avg = _si.get("tokens", 0) // max(_si.get("count", 1), 1) if _si.get("count", 0) > 0 else TOKENS_PER_SKILL_APPROX
+    # Harness-aware "slim it, don't delete it" clause inserted ABOVE the archive
+    # step (see _skill_slim_clause). Codex is dispatched to
+    # _generate_codex_auto_recommendations and never reaches here, so this only
+    # shapes Claude / other-foreign-runtime advice.
+    _runtime = detect_runtime()
     if trends:
         # Never recommend cutting our own measurement skills (issue #111).
         never_used = [
@@ -6814,8 +6859,9 @@ def generate_auto_recommendations(components, trends=None, days=30):
                 f"  Start with these: {skill_list}"
                 + (f"\n  ({remaining} more will surface after you archive these and re-run.)" if remaining > 0 else "") +
                 f"\n  For each skill, ask: do I use this? Is it seasonal? Does anything depend on it? "
-                f"(`grep -r \"[skill-name]\" ~/.claude/CLAUDE.md ~/.claude/rules/ ~/.claude/skills/`)\n"
-                f"  Archive by moving to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
+                f"(`grep -r \"[skill-name]\" ~/.claude/CLAUDE.md ~/.claude/rules/ ~/.claude/skills/`)"
+                + _skill_slim_clause(_actual_avg, _runtime) +
+                f"  Archive (harder step, for truly-dead skills) by moving to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
                 f"Restore any skill by moving it back. "
                 f"~{overhead:,} tokens recoverable across all {len(never_used)}."
             )
@@ -6824,8 +6870,10 @@ def generate_auto_recommendations(components, trends=None, days=30):
             skill_list = ", ".join(sorted(never_used))
             medium.append(
                 f"**Review {len(never_used)} skills not invoked in {days} days**: "
-                f"No Skill call or slash command for these in {days} days: {skill_list}. "
-                f"Consider archiving to ~/.claude/skills/_archived/. ~{overhead:,} tokens recoverable."
+                f"No Skill call or slash command for these in {days} days: {skill_list}."
+                + _skill_slim_clause(_actual_avg, _runtime) +
+                f"  Or archive truly-dead skills to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
+                f"~{overhead:,} tokens recoverable."
             )
 
     # --- Rule 3a: Skills audit fallback (no trends data) ---
@@ -6841,8 +6889,9 @@ def generate_auto_recommendations(components, trends=None, days=30):
             f"You have {skill_count} skills but no session data to determine which are unused. "
             f"Each skill costs ~{avg_per_skill} tokens at startup whether you use it or not.\n"
             f"  Install the SessionEnd hook (`python3 measure.py setup-hook`) to enable usage-based "
-            f"recommendations. Meanwhile, manually review: do you use all {skill_count} regularly? "
-            f"Archiving {est_archive} would free ~{est_savings:,} tokens/session. "
+            f"recommendations. Meanwhile, manually review: do you use all {skill_count} regularly?"
+            + _skill_slim_clause(avg_per_skill, _runtime) +
+            f"  Archiving {est_archive} (harder step, truly-dead skills) would free ~{est_savings:,} tokens/session. "
             f"~{est_savings:,} tokens recoverable."
         )
 

--- a/plugins/token-optimizer/.codex-plugin/plugin.json
+++ b/plugins/token-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.106",
+  "version": "5.11.107",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/token-optimizer/skills/token-dashboard/SKILL.md
+++ b/plugins/token-optimizer/skills/token-dashboard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: token-dashboard
 description: Open the Token Optimizer dashboard in your browser (context usage, quality, savings). Use to view the dashboard.
+disable-model-invocation: true
 ---
 
 # Token Optimizer Dashboard

--- a/plugins/token-optimizer/skills/token-optimizer/references/token-flow-architecture.md
+++ b/plugins/token-optimizer/skills/token-optimizer/references/token-flow-architecture.md
@@ -533,7 +533,24 @@ CLAUDE.md supports `@path/to/file.md` imports that pull external file content in
 
 ### `disable-model-invocation: true` in Skill Frontmatter
 
-Skills can set `disable-model-invocation: true` to prevent being invoked by the model (only user can invoke). This doesn't change token cost but is useful context: skills without this flag can be auto-invoked, which triggers full skill content loading.
+Skills inject `name` + `description` into always-on context every turn (progressive disclosure: the body loads only on invoke). Dropping a skill's description from that always-on context recovers its per-turn description cost — quantify it with the per-skill token cost `measure.py report` already computes, not a flat constant. Descriptions are also dropped after `/compact` and never re-injected, so the savings persist across compaction. Claude Code gives **two distinct levers** to do this, and they are NOT the same thing:
+
+**1. `skillOverrides` in settings (the true "name-only" middle mode).** `.claude/settings.local.json` `skillOverrides` maps a skill name to one of four visibility states (the `/skills` menu writes it for you — highlight a skill, press `Space` to cycle, `Enter` to save). Per the official docs (code.claude.com/docs/en/skills.md, "Override skill visibility from settings"):
+
+| Value | Listed to Claude | In `/` menu |
+| :-- | :-- | :-- |
+| `"on"` (default) | Name **and** description | Yes |
+| `"name-only"` | **Name only** (description hidden) | Yes |
+| `"user-invocable-only"` | Hidden from Claude | Yes |
+| `"off"` | Hidden | Hidden |
+
+`"name-only"` is the real name-visible/description-hidden middle mode: the model still sees the skill's **name** (so it can still invoke it by name) but not its description, so it stops auto-triggering on description match while you keep the token savings. This is the right choice for a skill you want to stay discoverable-by-name without paying for its description or letting it fire automatically.
+
+**2. `disable-model-invocation: true` in SKILL.md frontmatter (fully hidden from the model).** This **removes the skill from the model's context entirely** — not even the name is visible; only the USER can invoke it via `/name`. Official docs, verbatim: *"Description not in context, full skill loads when you invoke"* and *"They stay completely out of context until you invoke them with /name"* (context-window.md). Use it for skills only the user ever triggers explicitly (e.g. one that launches a browser tab, where auto-triggering on a guess is intrusive). It is a **binary** frontmatter flag (advertised, or fully hidden) — the graded middle states live in `skillOverrides` above, not in the flag. Equivalent settings values are `"user-invocable-only"` / `"off"`.
+
+Do NOT relabel `disable-model-invocation` as "name-only" — that term is Claude Code's `skillOverrides` state (name kept), and `disable-model-invocation` hides the name too. Keep skills whose value is proactive auto-triggering on the default `"on"`.
+
+**Cross-harness caveat**: both levers are **Claude-Code-specific**. Codex / OpenCode / Copilot skills keep `name` + `description` resident regardless; there is no per-skill "hide description" toggle there (the equivalent is a different primitive — a command / prompt-file — or a full disable via `[[skills.config]] enabled = false` on Codex). Other harnesses ignore the unknown frontmatter key (harmless, not an error).
 
 ### Compact Instructions Section in CLAUDE.md
 

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6675,8 +6675,10 @@ def _generate_codex_auto_recommendations(components, trends=None, days=30):
 # audit tool you never explicitly "invoke" is not the same as an unused skill.
 _OWN_TOOL_SKILLS = frozenset({
     "token-optimizer", "token-coach", "token-dashboard", "fleet-auditor",
+    "resume-checkpoint",
     "token-optimizer:token-optimizer", "token-optimizer:token-coach",
     "token-optimizer:token-dashboard", "token-optimizer:fleet-auditor",
+    "token-optimizer:resume-checkpoint",
     "token-optimizer:health", "token-optimizer:quick",
 })
 
@@ -6694,6 +6696,44 @@ def _is_own_tool_skill(name) -> bool:
         or base.startswith("token-coach")
         or base.startswith("token-dashboard")
         or base.startswith("fleet-auditor")
+        or base.startswith("resume-checkpoint")
+    )
+
+
+def _skill_slim_clause(avg_tokens, runtime):
+    """Softer-than-archive options for an unused skill, inserted ABOVE the archive
+    step. Keeps the skill installed while dropping its per-turn description cost.
+
+    Returns a block that STARTS and ends with a newline so it drops cleanly
+    between the skill list and the archive step (each call site therefore does
+    NOT add its own leading newline). Claude gets the two REAL, distinct Claude
+    Code levers -- do not conflate them:
+      - skillOverrides "name-only": NAME stays visible to the model (still
+        invocable by name), description dropped -> stops auto-triggering, saves
+        the description tokens. The true "name-only" middle mode.
+      - disable-model-invocation: true (frontmatter): removes the skill from the
+        model's context ENTIRELY (name too); only the user invokes it via /name.
+    Foreign runtimes have no per-skill toggle, so they get an honest note.
+    """
+    if runtime == "claude":
+        return (
+            f"\n  Softer than archiving -- two Claude Code levers keep the skill installed and recover "
+            f"~{avg_tokens} tokens/skill per turn (Claude may already have dropped some descriptions past "
+            f"its listing budget, so treat this as an upper bound):"
+            f"\n    - Name-only (keep it discoverable): in the `/skills` menu press Space to cycle a skill to "
+            f"`name-only` (writes `skillOverrides` in .claude/settings.local.json). The model still sees the "
+            f"NAME so it can invoke it, but the description drops from context and it stops auto-triggering. "
+            f"Best for skills you still want suggested by name."
+            f"\n    - Fully hidden (user-only): set `disable-model-invocation: true` in the SKILL.md frontmatter "
+            f"(or the `off` / `user-invocable-only` `skillOverrides` state). The model sees nothing; only you "
+            f"invoke it via `/name`. Best for skills you alone ever trigger."
+            f"\n  Both are Claude-Code-specific and survive `/compact`. Keep skills whose value is proactive "
+            f"auto-triggering on the default.\n"
+        )
+    return (
+        f"\n  Softer than archiving: this runtime ({runtime}) has no per-skill 'hide description' toggle. "
+        f"The equivalent is converting a skill you only trigger yourself into a command/prompt primitive, or "
+        f"fully disabling it. Keep skills you want auto-suggested as normal skills.\n"
     )
 
 
@@ -6796,6 +6836,11 @@ def generate_auto_recommendations(components, trends=None, days=30):
     # Use actual measured avg if available, else fallback to constant
     _si = components.get("skills", {})
     _actual_avg = _si.get("tokens", 0) // max(_si.get("count", 1), 1) if _si.get("count", 0) > 0 else TOKENS_PER_SKILL_APPROX
+    # Harness-aware "slim it, don't delete it" clause inserted ABOVE the archive
+    # step (see _skill_slim_clause). Codex is dispatched to
+    # _generate_codex_auto_recommendations and never reaches here, so this only
+    # shapes Claude / other-foreign-runtime advice.
+    _runtime = detect_runtime()
     if trends:
         # Never recommend cutting our own measurement skills (issue #111).
         never_used = [
@@ -6814,8 +6859,9 @@ def generate_auto_recommendations(components, trends=None, days=30):
                 f"  Start with these: {skill_list}"
                 + (f"\n  ({remaining} more will surface after you archive these and re-run.)" if remaining > 0 else "") +
                 f"\n  For each skill, ask: do I use this? Is it seasonal? Does anything depend on it? "
-                f"(`grep -r \"[skill-name]\" ~/.claude/CLAUDE.md ~/.claude/rules/ ~/.claude/skills/`)\n"
-                f"  Archive by moving to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
+                f"(`grep -r \"[skill-name]\" ~/.claude/CLAUDE.md ~/.claude/rules/ ~/.claude/skills/`)"
+                + _skill_slim_clause(_actual_avg, _runtime) +
+                f"  Archive (harder step, for truly-dead skills) by moving to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
                 f"Restore any skill by moving it back. "
                 f"~{overhead:,} tokens recoverable across all {len(never_used)}."
             )
@@ -6824,8 +6870,10 @@ def generate_auto_recommendations(components, trends=None, days=30):
             skill_list = ", ".join(sorted(never_used))
             medium.append(
                 f"**Review {len(never_used)} skills not invoked in {days} days**: "
-                f"No Skill call or slash command for these in {days} days: {skill_list}. "
-                f"Consider archiving to ~/.claude/skills/_archived/. ~{overhead:,} tokens recoverable."
+                f"No Skill call or slash command for these in {days} days: {skill_list}."
+                + _skill_slim_clause(_actual_avg, _runtime) +
+                f"  Or archive truly-dead skills to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
+                f"~{overhead:,} tokens recoverable."
             )
 
     # --- Rule 3a: Skills audit fallback (no trends data) ---
@@ -6841,8 +6889,9 @@ def generate_auto_recommendations(components, trends=None, days=30):
             f"You have {skill_count} skills but no session data to determine which are unused. "
             f"Each skill costs ~{avg_per_skill} tokens at startup whether you use it or not.\n"
             f"  Install the SessionEnd hook (`python3 measure.py setup-hook`) to enable usage-based "
-            f"recommendations. Meanwhile, manually review: do you use all {skill_count} regularly? "
-            f"Archiving {est_archive} would free ~{est_savings:,} tokens/session. "
+            f"recommendations. Meanwhile, manually review: do you use all {skill_count} regularly?"
+            + _skill_slim_clause(avg_per_skill, _runtime) +
+            f"  Archiving {est_archive} (harder step, truly-dead skills) would free ~{est_savings:,} tokens/session. "
             f"~{est_savings:,} tokens recoverable."
         )
 

--- a/skills/token-dashboard/SKILL.md
+++ b/skills/token-dashboard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: token-dashboard
 description: Open the Token Optimizer dashboard in your browser (context usage, quality, savings). Use to view the dashboard.
+disable-model-invocation: true
 ---
 
 # Token Optimizer Dashboard

--- a/skills/token-optimizer/references/token-flow-architecture.md
+++ b/skills/token-optimizer/references/token-flow-architecture.md
@@ -533,7 +533,24 @@ CLAUDE.md supports `@path/to/file.md` imports that pull external file content in
 
 ### `disable-model-invocation: true` in Skill Frontmatter
 
-Skills can set `disable-model-invocation: true` to prevent being invoked by the model (only user can invoke). This doesn't change token cost but is useful context: skills without this flag can be auto-invoked, which triggers full skill content loading.
+Skills inject `name` + `description` into always-on context every turn (progressive disclosure: the body loads only on invoke). Dropping a skill's description from that always-on context recovers its per-turn description cost — quantify it with the per-skill token cost `measure.py report` already computes, not a flat constant. Descriptions are also dropped after `/compact` and never re-injected, so the savings persist across compaction. Claude Code gives **two distinct levers** to do this, and they are NOT the same thing:
+
+**1. `skillOverrides` in settings (the true "name-only" middle mode).** `.claude/settings.local.json` `skillOverrides` maps a skill name to one of four visibility states (the `/skills` menu writes it for you — highlight a skill, press `Space` to cycle, `Enter` to save). Per the official docs (code.claude.com/docs/en/skills.md, "Override skill visibility from settings"):
+
+| Value | Listed to Claude | In `/` menu |
+| :-- | :-- | :-- |
+| `"on"` (default) | Name **and** description | Yes |
+| `"name-only"` | **Name only** (description hidden) | Yes |
+| `"user-invocable-only"` | Hidden from Claude | Yes |
+| `"off"` | Hidden | Hidden |
+
+`"name-only"` is the real name-visible/description-hidden middle mode: the model still sees the skill's **name** (so it can still invoke it by name) but not its description, so it stops auto-triggering on description match while you keep the token savings. This is the right choice for a skill you want to stay discoverable-by-name without paying for its description or letting it fire automatically.
+
+**2. `disable-model-invocation: true` in SKILL.md frontmatter (fully hidden from the model).** This **removes the skill from the model's context entirely** — not even the name is visible; only the USER can invoke it via `/name`. Official docs, verbatim: *"Description not in context, full skill loads when you invoke"* and *"They stay completely out of context until you invoke them with /name"* (context-window.md). Use it for skills only the user ever triggers explicitly (e.g. one that launches a browser tab, where auto-triggering on a guess is intrusive). It is a **binary** frontmatter flag (advertised, or fully hidden) — the graded middle states live in `skillOverrides` above, not in the flag. Equivalent settings values are `"user-invocable-only"` / `"off"`.
+
+Do NOT relabel `disable-model-invocation` as "name-only" — that term is Claude Code's `skillOverrides` state (name kept), and `disable-model-invocation` hides the name too. Keep skills whose value is proactive auto-triggering on the default `"on"`.
+
+**Cross-harness caveat**: both levers are **Claude-Code-specific**. Codex / OpenCode / Copilot skills keep `name` + `description` resident regardless; there is no per-skill "hide description" toggle there (the equivalent is a different primitive — a command / prompt-file — or a full disable via `[[skills.config]] enabled = false` on Codex). Other harnesses ignore the unknown frontmatter key (harmless, not an error).
 
 ### Compact Instructions Section in CLAUDE.md
 

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -6675,8 +6675,10 @@ def _generate_codex_auto_recommendations(components, trends=None, days=30):
 # audit tool you never explicitly "invoke" is not the same as an unused skill.
 _OWN_TOOL_SKILLS = frozenset({
     "token-optimizer", "token-coach", "token-dashboard", "fleet-auditor",
+    "resume-checkpoint",
     "token-optimizer:token-optimizer", "token-optimizer:token-coach",
     "token-optimizer:token-dashboard", "token-optimizer:fleet-auditor",
+    "token-optimizer:resume-checkpoint",
     "token-optimizer:health", "token-optimizer:quick",
 })
 
@@ -6694,6 +6696,44 @@ def _is_own_tool_skill(name) -> bool:
         or base.startswith("token-coach")
         or base.startswith("token-dashboard")
         or base.startswith("fleet-auditor")
+        or base.startswith("resume-checkpoint")
+    )
+
+
+def _skill_slim_clause(avg_tokens, runtime):
+    """Softer-than-archive options for an unused skill, inserted ABOVE the archive
+    step. Keeps the skill installed while dropping its per-turn description cost.
+
+    Returns a block that STARTS and ends with a newline so it drops cleanly
+    between the skill list and the archive step (each call site therefore does
+    NOT add its own leading newline). Claude gets the two REAL, distinct Claude
+    Code levers -- do not conflate them:
+      - skillOverrides "name-only": NAME stays visible to the model (still
+        invocable by name), description dropped -> stops auto-triggering, saves
+        the description tokens. The true "name-only" middle mode.
+      - disable-model-invocation: true (frontmatter): removes the skill from the
+        model's context ENTIRELY (name too); only the user invokes it via /name.
+    Foreign runtimes have no per-skill toggle, so they get an honest note.
+    """
+    if runtime == "claude":
+        return (
+            f"\n  Softer than archiving -- two Claude Code levers keep the skill installed and recover "
+            f"~{avg_tokens} tokens/skill per turn (Claude may already have dropped some descriptions past "
+            f"its listing budget, so treat this as an upper bound):"
+            f"\n    - Name-only (keep it discoverable): in the `/skills` menu press Space to cycle a skill to "
+            f"`name-only` (writes `skillOverrides` in .claude/settings.local.json). The model still sees the "
+            f"NAME so it can invoke it, but the description drops from context and it stops auto-triggering. "
+            f"Best for skills you still want suggested by name."
+            f"\n    - Fully hidden (user-only): set `disable-model-invocation: true` in the SKILL.md frontmatter "
+            f"(or the `off` / `user-invocable-only` `skillOverrides` state). The model sees nothing; only you "
+            f"invoke it via `/name`. Best for skills you alone ever trigger."
+            f"\n  Both are Claude-Code-specific and survive `/compact`. Keep skills whose value is proactive "
+            f"auto-triggering on the default.\n"
+        )
+    return (
+        f"\n  Softer than archiving: this runtime ({runtime}) has no per-skill 'hide description' toggle. "
+        f"The equivalent is converting a skill you only trigger yourself into a command/prompt primitive, or "
+        f"fully disabling it. Keep skills you want auto-suggested as normal skills.\n"
     )
 
 
@@ -6796,6 +6836,11 @@ def generate_auto_recommendations(components, trends=None, days=30):
     # Use actual measured avg if available, else fallback to constant
     _si = components.get("skills", {})
     _actual_avg = _si.get("tokens", 0) // max(_si.get("count", 1), 1) if _si.get("count", 0) > 0 else TOKENS_PER_SKILL_APPROX
+    # Harness-aware "slim it, don't delete it" clause inserted ABOVE the archive
+    # step (see _skill_slim_clause). Codex is dispatched to
+    # _generate_codex_auto_recommendations and never reaches here, so this only
+    # shapes Claude / other-foreign-runtime advice.
+    _runtime = detect_runtime()
     if trends:
         # Never recommend cutting our own measurement skills (issue #111).
         never_used = [
@@ -6814,8 +6859,9 @@ def generate_auto_recommendations(components, trends=None, days=30):
                 f"  Start with these: {skill_list}"
                 + (f"\n  ({remaining} more will surface after you archive these and re-run.)" if remaining > 0 else "") +
                 f"\n  For each skill, ask: do I use this? Is it seasonal? Does anything depend on it? "
-                f"(`grep -r \"[skill-name]\" ~/.claude/CLAUDE.md ~/.claude/rules/ ~/.claude/skills/`)\n"
-                f"  Archive by moving to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
+                f"(`grep -r \"[skill-name]\" ~/.claude/CLAUDE.md ~/.claude/rules/ ~/.claude/skills/`)"
+                + _skill_slim_clause(_actual_avg, _runtime) +
+                f"  Archive (harder step, for truly-dead skills) by moving to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
                 f"Restore any skill by moving it back. "
                 f"~{overhead:,} tokens recoverable across all {len(never_used)}."
             )
@@ -6824,8 +6870,10 @@ def generate_auto_recommendations(components, trends=None, days=30):
             skill_list = ", ".join(sorted(never_used))
             medium.append(
                 f"**Review {len(never_used)} skills not invoked in {days} days**: "
-                f"No Skill call or slash command for these in {days} days: {skill_list}. "
-                f"Consider archiving to ~/.claude/skills/_archived/. ~{overhead:,} tokens recoverable."
+                f"No Skill call or slash command for these in {days} days: {skill_list}."
+                + _skill_slim_clause(_actual_avg, _runtime) +
+                f"  Or archive truly-dead skills to ~/.claude/_backups/skills-archived-$(date +%Y%m%d)/ (NOT inside skills/). "
+                f"~{overhead:,} tokens recoverable."
             )
 
     # --- Rule 3a: Skills audit fallback (no trends data) ---
@@ -6841,8 +6889,9 @@ def generate_auto_recommendations(components, trends=None, days=30):
             f"You have {skill_count} skills but no session data to determine which are unused. "
             f"Each skill costs ~{avg_per_skill} tokens at startup whether you use it or not.\n"
             f"  Install the SessionEnd hook (`python3 measure.py setup-hook`) to enable usage-based "
-            f"recommendations. Meanwhile, manually review: do you use all {skill_count} regularly? "
-            f"Archiving {est_archive} would free ~{est_savings:,} tokens/session. "
+            f"recommendations. Meanwhile, manually review: do you use all {skill_count} regularly?"
+            + _skill_slim_clause(avg_per_skill, _runtime) +
+            f"  Archiving {est_archive} (harder step, truly-dead skills) would free ~{est_savings:,} tokens/session. "
             f"~{est_savings:,} tokens recoverable."
         )
 

--- a/tests/test_111_never_cut_own_skills.py
+++ b/tests/test_111_never_cut_own_skills.py
@@ -47,3 +47,132 @@ def test_recommendations_never_list_own_skills_for_archiving():
         assert own not in plan, f"recommendation plan must not suggest cutting own skill {own}"
     # third-party unused skills should still be surfaced
     assert "linkedin" in plan or "deep-research" in plan
+
+
+def test_name_only_recommendation_for_claude_runtime(monkeypatch):
+    """Rule 3 must offer the harness-aware slim-it tier (skillOverrides name-only +
+    disable-model-invocation, which are distinct levers) ABOVE the archive step for
+    the Claude runtime, and never target our own skills."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+    trends = {
+        "skills": {
+            "never_used": [
+                "token-coach", "token-dashboard",  # own skills -> must be filtered out
+                "linkedin", "my-notes", "deep-research", "old-thing", "extra-a", "extra-b",
+            ],
+            "installed_count": 40,
+        }
+    }
+    components = {"skills": {"count": 40, "tokens": 8000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=trends, days=30)
+
+    # name-only tier is present and references the Claude-Code-specific key
+    assert "disable-model-invocation: true" in plan
+    assert "name-only" in plan
+    # name-only clause sits ABOVE the archive step
+    assert plan.index("disable-model-invocation: true") < plan.index("Archive (harder step")
+    # own skills still never named
+    for own in ("token-coach", "token-dashboard"):
+        assert own not in plan
+
+
+def test_name_only_recommendation_for_claude_runtime_few_unused(monkeypatch):
+    """The medium-effort branch (2-4 unused) also surfaces the name-only tier."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+    trends = {
+        "skills": {
+            "never_used": ["linkedin", "my-notes"],
+            "installed_count": 40,
+        }
+    }
+    components = {"skills": {"count": 40, "tokens": 8000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=trends, days=30)
+    assert "disable-model-invocation: true" in plan
+    assert "name-only" in plan
+
+
+def test_name_only_recommendation_no_trends_fallback_for_claude(monkeypatch):
+    """Rule 3a (no trends data) must also surface the name-only tier for Claude."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+    components = {"skills": {"count": 20, "tokens": 4000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=None, days=30)
+    assert "disable-model-invocation: true" in plan
+    assert "name-only" in plan
+
+
+def test_codex_runtime_never_claims_name_only(monkeypatch):
+    """Codex has no per-skill name-only primitive. Its recommendations must NOT
+    claim a `disable-model-invocation` name-only option exists."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "codex")
+    trends = {
+        "skills": {
+            "never_used": ["linkedin", "my-notes", "deep-research", "old-thing", "extra-a"],
+            "installed_count": 40,
+        }
+    }
+    components = {"skills": {"count": 40, "tokens": 8000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=trends, days=30)
+    assert "disable-model-invocation" not in plan
+    assert "name-only" not in plan
+
+
+def test_other_foreign_runtime_is_qualitative_no_false_claim(monkeypatch):
+    """Non-Claude, non-Codex runtimes get a qualitative 'slim it' note and must
+    NOT falsely claim the Claude-only levers (name-only / disable-model-invocation)
+    work there. 'name-only' and 'disable-model-invocation' are Claude-specific."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "opencode")
+    trends = {
+        "skills": {
+            "never_used": ["linkedin", "my-notes", "deep-research", "old-thing", "extra-a"],
+            "installed_count": 40,
+        }
+    }
+    components = {"skills": {"count": 40, "tokens": 8000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=trends, days=30)
+    # qualitative softer-than-archive note present, naming the runtime
+    assert "Softer than archiving" in plan
+    assert "opencode" in plan
+    # but NO false claim that the Claude-only levers work here
+    assert "disable-model-invocation" not in plan
+    assert "skillOverrides" not in plan
+
+
+def test_resume_checkpoint_is_protected_own_skill(monkeypatch):
+    """resume-checkpoint is one of our own skills and must never be surfaced for
+    trimming/archiving (regression: it was missing from _OWN_TOOL_SKILLS)."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+    assert measure._is_own_tool_skill("resume-checkpoint")
+    assert measure._is_own_tool_skill("token-optimizer:resume-checkpoint")
+    trends = {
+        "skills": {
+            "never_used": ["resume-checkpoint", "linkedin", "my-notes",
+                           "deep-research", "old-thing", "extra-a"],
+            "installed_count": 40,
+        }
+    }
+    components = {"skills": {"count": 40, "tokens": 8000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=trends, days=30)
+    assert "resume-checkpoint" not in plan
+
+
+def test_claude_offers_both_levers_name_only_before_hidden(monkeypatch):
+    """The Claude clause must offer BOTH correct levers with the right labels:
+    skillOverrides 'name-only' (name kept) AND disable-model-invocation (fully
+    hidden), and must NOT mislabel disable-model-invocation as 'name-only'.
+    The discoverable name-only option is presented before the fully-hidden one."""
+    monkeypatch.setattr(measure, "detect_runtime", lambda: "claude")
+    trends = {
+        "skills": {
+            "never_used": ["linkedin", "my-notes", "deep-research", "old-thing", "extra-a", "extra-b"],
+            "installed_count": 40,
+        }
+    }
+    components = {"skills": {"count": 40, "tokens": 8000}}
+    plan, _count = measure.generate_auto_recommendations(components, trends=trends, days=30)
+    assert "skillOverrides" in plan
+    assert "name-only" in plan
+    assert "disable-model-invocation: true" in plan
+    # name-only (discoverable) is offered before the fully-hidden lever
+    assert plan.index("Name-only") < plan.index("Fully hidden")
+    # and both come before the archive step
+    assert plan.index("disable-model-invocation: true") < plan.index("Archive (harder step")


### PR DESCRIPTION
## What
Skills inject name+description into always-on context every turn. Two Claude Code levers drop that description cost while keeping a skill installed — the audit now recommends them as a **softer step before archiving** (removes the "delete my skills" fear):

- **skillOverrides "name-only"** (settings, via the /skills menu, Space-to-cycle): the NAME stays visible so the model can still invoke it by name; the description drops from context and it stops auto-firing.
- **disable-model-invocation: true** (frontmatter): removes the skill from context entirely; only the user invokes it via /name.

## Changes
- **Doc fix (token-flow-architecture.md):** it wrongly claimed disable-model-invocation "doesn't change token cost" (it removes the description from always-on context) and denied a middle mode (skillOverrides "name-only" is exactly that). Now documents both levers + the full 4-state skillOverrides table, cited.
- **Audit tier (measure.py):** harness-aware _skill_slim_clause inserted ABOVE the archive step in Rule 3 (both branches) + Rule 3a. Claude → both levers; Codex routes to its own generator (untouched); other runtimes → honest qualitative note. **Also fixed a pre-existing bug: resume-checkpoint was missing from the own-skill protection filter.**
- **Dogfood (token-dashboard/SKILL.md):** disable-model-invocation: true (browser-launching, user-only skill; verified nothing invokes it programmatically).
- **Tests:** 7 new/updated (both levers + labels + ordering, resume-checkpoint protection, Codex-never-claims, foreign-runtime-qualitative).

## Verification
Best-of-2 implementers (GLM vs swe on Devin) → 4-lane GLM torture room + **Kimi K3 as judge in Droid**. Both reviews flagged that we'd mislabeled disable-model-invocation as "name-only" and missed the real skillOverrides middle mode; all findings fixed and re-judged **VERDICT: SHIP**. Mirrors byte-identical; all tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
