### PR TITLE
fix(dashboard): version-downgrade guard — older builds never overwrite a newer dashboard (5.11.108)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "token-optimizer",
       "source": "./",
       "description": "Audit, fix, and monitor Claude Code context window usage. Find the ghost tokens.",
-      "version": "5.11.107",
+      "version": "5.11.108",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"
@@ -55,7 +55,7 @@
       "name": "token-optimizer-cowork",
       "source": "./cowork/token-optimizer",
       "description": "Token Optimizer for Claude Cowork \u2014 full skills + Cowork-native hooks (beta). Install THIS in Cowork; the standard token-optimizer entry is for desktop Claude Code.",
-      "version": "5.11.107",
+      "version": "5.11.108",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.107",
+  "version": "5.11.108",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.107",
+  "version": "5.11.108",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/cowork/token-optimizer/.claude-plugin/plugin.json
+++ b/cowork/token-optimizer/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.11.107",
+  "version": "5.11.108",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -389,6 +389,107 @@ def _dashboard_meta_path(html_path):
     return Path(html_path).with_suffix(".meta.json")
 
 
+def _parse_semver(v):
+    """(major, minor, patch) ints for a version string, or None if unparseable.
+    Tolerant: strips a leading 'v' and any -pre / +build suffix, pads missing
+    components with 0. Used only for precedence comparison, never display."""
+    try:
+        core = str(v).strip().lstrip("vV").split("+", 1)[0].split("-", 1)[0]
+        parts = (core.split(".") + ["0", "0", "0"])[:3]
+        return tuple(int(x) for x in parts)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+# A dashboard HTML smaller than this is treated as absent/corrupt, so the version
+# guard will not honor a "newer" sidecar sitting next to a broken file (a real
+# dashboard is 4-5MB; the bundled template alone is tens of KB). This is the
+# anti-wedge floor: without it, a sidecar that names an impossibly-high version
+# next to an empty/truncated HTML would block EVERY future writer, including the
+# newest build, and never self-heal.
+_DASHBOARD_MIN_VALID_BYTES = 4096
+
+
+def _write_dashboard_meta(html_path):
+    """Write the (version, shape) sidecar next to a dashboard HTML we just wrote,
+    so the sidecar always names the build that produced the on-disk HTML. Every
+    writer of a shared dashboard MUST call this after writing, or the downgrade
+    guard reads a stale version and can be bypassed. Fail-soft; never raises."""
+    try:
+        _dashboard_meta_path(html_path).write_text(
+            json.dumps({"version": TOKEN_OPTIMIZER_VERSION, "shape": _DASHBOARD_SHAPE_MARKER}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def _dashboard_on_disk_is_newer(html_path):
+    """True iff a REAL dashboard already on disk was written by a STRICTLY NEWER
+    Token Optimizer version than this process.
+
+    An older build must never overwrite a newer dashboard. Without this guard a
+    stale long-lived daemon or a still-running pre-upgrade session regenerates
+    the shared dashboard with pre-fix code and clobbers a just-shipped fix -- the
+    "we fixed it but it's still broken" report, where the fix ships yet an old
+    in-memory process keeps overwriting the corrected file.
+
+    Fail-OPEN by design: a missing sidecar, an unparseable/dev version on either
+    side, or an absent/undersized (corrupt) HTML returns False (allow the write).
+    The HTML-integrity floor is the anti-wedge: the guard only protects a REAL
+    on-disk dashboard, so a lying/corrupt sidecar next to a broken HTML can never
+    permanently block regeneration -- the next writer repairs it and rewrites the
+    sidecar. Reads only the ~40-byte sidecar plus a cheap stat. Never raises.
+    Equal versions are NOT "newer", so same-version regen and legitimate upgrades
+    both proceed; only a strictly-older writer is blocked.
+
+    Residual (documented, not auto-recovered): a *valid* newer sidecar beside a
+    *valid* HTML always blocks older writers -- correct when a real newer build
+    wrote it; on the rare chance the version was corrupted upward next to intact
+    HTML, recovery is deleting the .meta.json sidecar."""
+    try:
+        mine = _parse_semver(TOKEN_OPTIMIZER_VERSION)
+        if mine is None:
+            return False
+        # Only guard a real, non-trivial dashboard. A missing/tiny HTML means
+        # there is nothing worth protecting -- allow the write so a broken file
+        # (even next to a lying sidecar) always self-heals.
+        try:
+            if Path(html_path).stat().st_size < _DASHBOARD_MIN_VALID_BYTES:
+                return False
+        except OSError:
+            return False
+        meta_path = _dashboard_meta_path(html_path)
+        if not meta_path.exists():
+            return False
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        if not isinstance(meta, dict):
+            return False
+        existing = _parse_semver(meta.get("version"))
+        if existing is None:
+            return False
+        return existing > mine
+    except Exception:
+        return False
+
+
+def _dashboard_meta_is_fresh(meta):
+    """Freshness decision for the SessionStart staleness check, factored out so it
+    is directly testable. `meta` is the parsed sidecar dict. Fresh (no regen) iff:
+      - the on-disk build is STRICTLY NEWER than ours (an older session must not
+        regenerate/clobber a newer dashboard -- leave it to the newer build), OR
+      - version AND shape marker match ours exactly.
+    Anything else (older on disk, or a shape change) is stale -> regenerate."""
+    if not isinstance(meta, dict):
+        return False
+    existing = _parse_semver(meta.get("version"))
+    mine = _parse_semver(TOKEN_OPTIMIZER_VERSION)
+    if existing is not None and mine is not None and existing > mine:
+        return True
+    return (meta.get("version") == TOKEN_OPTIMIZER_VERSION
+            and meta.get("shape") == _DASHBOARD_SHAPE_MARKER)
+
+
 def _use_codex_session_adapter(filepath=None):
     """True when session JSONL should be parsed with the Codex adapter."""
     return detect_runtime() == "codex" or (filepath is not None and codex_session.is_codex_session_path(filepath))
@@ -4712,16 +4813,29 @@ def generate_dashboard(coord_path):
     # was configured to use. Same dual-path pattern as v5.4.7 daemon script.
     legacy_dashboard = RUNTIME_DIR / "_backups" / "token-optimizer" / "dashboard.html"
     wrote_mirror = False
+    skipped_all = True
     for mirror_path in {DASHBOARD_PATH, legacy_dashboard}:
+        # Version-downgrade guard: an older build's audit must not clobber a
+        # shared dashboard a newer build already wrote. The per-run audit artifact
+        # (out_path) is still written above; only the SHARED served copies are
+        # guarded. Fail-open (see _dashboard_on_disk_is_newer).
+        if _dashboard_on_disk_is_newer(mirror_path):
+            continue
+        skipped_all = False
         try:
             mirror_path.parent.mkdir(parents=True, exist_ok=True)
             mirror_fd = os.open(str(mirror_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             with os.fdopen(mirror_fd, "w", encoding="utf-8") as f:
                 f.write(injected)
+            # The sidecar must name the build that wrote THIS HTML, or the guard
+            # reads a stale version and a middle build could clobber a newer file.
+            _write_dashboard_meta(mirror_path)
             wrote_mirror = True
         except OSError:
             pass
-    if not wrote_mirror:
+    # Only a real write FAILURE warrants the warning; an intentional guard skip
+    # (all shared copies are already newer) is not a failure.
+    if not wrote_mirror and not skipped_all:
         print("  [Warning] Could not mirror dashboard to daemon paths.")
 
     # Prefer the bookmarkable URL when the daemon is live; fall back to
@@ -5811,6 +5925,18 @@ def generate_standalone_dashboard(days=30, quiet=False, force=False):
                 return str(DASHBOARD_PATH)
         except OSError:
             pass
+
+    # Version-downgrade guard: never let an OLDER build overwrite a dashboard a
+    # NEWER build already wrote (the "fixed but still broken" regression -- a
+    # stale daemon or pre-upgrade session clobbering a just-shipped fix). Checked
+    # BEFORE the expensive data build so an older writer skips cheaply. force does
+    # NOT bypass this: force governs the 60s throttle, not version precedence.
+    # Newer/equal writers proceed (equal is not strictly newer). Fail-open.
+    if _dashboard_on_disk_is_newer(DASHBOARD_PATH):
+        if not quiet:
+            print(f"  [Token Optimizer] Skipping dashboard write: the on-disk dashboard "
+                  f"was written by a newer version than this build (v{TOKEN_OPTIMIZER_VERSION}).")
+        return str(DASHBOARD_PATH)
 
     script_dir = Path(__file__).resolve().parent
     template_path = script_dir.parent / "assets" / "dashboard.html"
@@ -38974,9 +39100,10 @@ def run_ensure_health():
             if _meta_path.exists():
                 try:
                     _meta = json.loads(_meta_path.read_text(encoding="utf-8"))
-                    _fresh = (isinstance(_meta, dict)
-                              and _meta.get("version") == TOKEN_OPTIMIZER_VERSION
-                              and _meta.get("shape") == _DASHBOARD_SHAPE_MARKER)
+                    # An older session must NOT regenerate (and thus clobber with
+                    # pre-fix code) a dashboard a NEWER build wrote; a strictly-newer
+                    # on-disk build reads as fresh. See _dashboard_meta_is_fresh.
+                    _fresh = _dashboard_meta_is_fresh(_meta)
                 except (OSError, json.JSONDecodeError, ValueError):
                     _fresh = False
             else:

--- a/plugins/token-optimizer/.codex-plugin/plugin.json
+++ b/plugins/token-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.11.107",
+  "version": "5.11.108",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -389,6 +389,107 @@ def _dashboard_meta_path(html_path):
     return Path(html_path).with_suffix(".meta.json")
 
 
+def _parse_semver(v):
+    """(major, minor, patch) ints for a version string, or None if unparseable.
+    Tolerant: strips a leading 'v' and any -pre / +build suffix, pads missing
+    components with 0. Used only for precedence comparison, never display."""
+    try:
+        core = str(v).strip().lstrip("vV").split("+", 1)[0].split("-", 1)[0]
+        parts = (core.split(".") + ["0", "0", "0"])[:3]
+        return tuple(int(x) for x in parts)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+# A dashboard HTML smaller than this is treated as absent/corrupt, so the version
+# guard will not honor a "newer" sidecar sitting next to a broken file (a real
+# dashboard is 4-5MB; the bundled template alone is tens of KB). This is the
+# anti-wedge floor: without it, a sidecar that names an impossibly-high version
+# next to an empty/truncated HTML would block EVERY future writer, including the
+# newest build, and never self-heal.
+_DASHBOARD_MIN_VALID_BYTES = 4096
+
+
+def _write_dashboard_meta(html_path):
+    """Write the (version, shape) sidecar next to a dashboard HTML we just wrote,
+    so the sidecar always names the build that produced the on-disk HTML. Every
+    writer of a shared dashboard MUST call this after writing, or the downgrade
+    guard reads a stale version and can be bypassed. Fail-soft; never raises."""
+    try:
+        _dashboard_meta_path(html_path).write_text(
+            json.dumps({"version": TOKEN_OPTIMIZER_VERSION, "shape": _DASHBOARD_SHAPE_MARKER}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def _dashboard_on_disk_is_newer(html_path):
+    """True iff a REAL dashboard already on disk was written by a STRICTLY NEWER
+    Token Optimizer version than this process.
+
+    An older build must never overwrite a newer dashboard. Without this guard a
+    stale long-lived daemon or a still-running pre-upgrade session regenerates
+    the shared dashboard with pre-fix code and clobbers a just-shipped fix -- the
+    "we fixed it but it's still broken" report, where the fix ships yet an old
+    in-memory process keeps overwriting the corrected file.
+
+    Fail-OPEN by design: a missing sidecar, an unparseable/dev version on either
+    side, or an absent/undersized (corrupt) HTML returns False (allow the write).
+    The HTML-integrity floor is the anti-wedge: the guard only protects a REAL
+    on-disk dashboard, so a lying/corrupt sidecar next to a broken HTML can never
+    permanently block regeneration -- the next writer repairs it and rewrites the
+    sidecar. Reads only the ~40-byte sidecar plus a cheap stat. Never raises.
+    Equal versions are NOT "newer", so same-version regen and legitimate upgrades
+    both proceed; only a strictly-older writer is blocked.
+
+    Residual (documented, not auto-recovered): a *valid* newer sidecar beside a
+    *valid* HTML always blocks older writers -- correct when a real newer build
+    wrote it; on the rare chance the version was corrupted upward next to intact
+    HTML, recovery is deleting the .meta.json sidecar."""
+    try:
+        mine = _parse_semver(TOKEN_OPTIMIZER_VERSION)
+        if mine is None:
+            return False
+        # Only guard a real, non-trivial dashboard. A missing/tiny HTML means
+        # there is nothing worth protecting -- allow the write so a broken file
+        # (even next to a lying sidecar) always self-heals.
+        try:
+            if Path(html_path).stat().st_size < _DASHBOARD_MIN_VALID_BYTES:
+                return False
+        except OSError:
+            return False
+        meta_path = _dashboard_meta_path(html_path)
+        if not meta_path.exists():
+            return False
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        if not isinstance(meta, dict):
+            return False
+        existing = _parse_semver(meta.get("version"))
+        if existing is None:
+            return False
+        return existing > mine
+    except Exception:
+        return False
+
+
+def _dashboard_meta_is_fresh(meta):
+    """Freshness decision for the SessionStart staleness check, factored out so it
+    is directly testable. `meta` is the parsed sidecar dict. Fresh (no regen) iff:
+      - the on-disk build is STRICTLY NEWER than ours (an older session must not
+        regenerate/clobber a newer dashboard -- leave it to the newer build), OR
+      - version AND shape marker match ours exactly.
+    Anything else (older on disk, or a shape change) is stale -> regenerate."""
+    if not isinstance(meta, dict):
+        return False
+    existing = _parse_semver(meta.get("version"))
+    mine = _parse_semver(TOKEN_OPTIMIZER_VERSION)
+    if existing is not None and mine is not None and existing > mine:
+        return True
+    return (meta.get("version") == TOKEN_OPTIMIZER_VERSION
+            and meta.get("shape") == _DASHBOARD_SHAPE_MARKER)
+
+
 def _use_codex_session_adapter(filepath=None):
     """True when session JSONL should be parsed with the Codex adapter."""
     return detect_runtime() == "codex" or (filepath is not None and codex_session.is_codex_session_path(filepath))
@@ -4712,16 +4813,29 @@ def generate_dashboard(coord_path):
     # was configured to use. Same dual-path pattern as v5.4.7 daemon script.
     legacy_dashboard = RUNTIME_DIR / "_backups" / "token-optimizer" / "dashboard.html"
     wrote_mirror = False
+    skipped_all = True
     for mirror_path in {DASHBOARD_PATH, legacy_dashboard}:
+        # Version-downgrade guard: an older build's audit must not clobber a
+        # shared dashboard a newer build already wrote. The per-run audit artifact
+        # (out_path) is still written above; only the SHARED served copies are
+        # guarded. Fail-open (see _dashboard_on_disk_is_newer).
+        if _dashboard_on_disk_is_newer(mirror_path):
+            continue
+        skipped_all = False
         try:
             mirror_path.parent.mkdir(parents=True, exist_ok=True)
             mirror_fd = os.open(str(mirror_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             with os.fdopen(mirror_fd, "w", encoding="utf-8") as f:
                 f.write(injected)
+            # The sidecar must name the build that wrote THIS HTML, or the guard
+            # reads a stale version and a middle build could clobber a newer file.
+            _write_dashboard_meta(mirror_path)
             wrote_mirror = True
         except OSError:
             pass
-    if not wrote_mirror:
+    # Only a real write FAILURE warrants the warning; an intentional guard skip
+    # (all shared copies are already newer) is not a failure.
+    if not wrote_mirror and not skipped_all:
         print("  [Warning] Could not mirror dashboard to daemon paths.")
 
     # Prefer the bookmarkable URL when the daemon is live; fall back to
@@ -5811,6 +5925,18 @@ def generate_standalone_dashboard(days=30, quiet=False, force=False):
                 return str(DASHBOARD_PATH)
         except OSError:
             pass
+
+    # Version-downgrade guard: never let an OLDER build overwrite a dashboard a
+    # NEWER build already wrote (the "fixed but still broken" regression -- a
+    # stale daemon or pre-upgrade session clobbering a just-shipped fix). Checked
+    # BEFORE the expensive data build so an older writer skips cheaply. force does
+    # NOT bypass this: force governs the 60s throttle, not version precedence.
+    # Newer/equal writers proceed (equal is not strictly newer). Fail-open.
+    if _dashboard_on_disk_is_newer(DASHBOARD_PATH):
+        if not quiet:
+            print(f"  [Token Optimizer] Skipping dashboard write: the on-disk dashboard "
+                  f"was written by a newer version than this build (v{TOKEN_OPTIMIZER_VERSION}).")
+        return str(DASHBOARD_PATH)
 
     script_dir = Path(__file__).resolve().parent
     template_path = script_dir.parent / "assets" / "dashboard.html"
@@ -38974,9 +39100,10 @@ def run_ensure_health():
             if _meta_path.exists():
                 try:
                     _meta = json.loads(_meta_path.read_text(encoding="utf-8"))
-                    _fresh = (isinstance(_meta, dict)
-                              and _meta.get("version") == TOKEN_OPTIMIZER_VERSION
-                              and _meta.get("shape") == _DASHBOARD_SHAPE_MARKER)
+                    # An older session must NOT regenerate (and thus clobber with
+                    # pre-fix code) a dashboard a NEWER build wrote; a strictly-newer
+                    # on-disk build reads as fresh. See _dashboard_meta_is_fresh.
+                    _fresh = _dashboard_meta_is_fresh(_meta)
                 except (OSError, json.JSONDecodeError, ValueError):
                     _fresh = False
             else:

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -389,6 +389,107 @@ def _dashboard_meta_path(html_path):
     return Path(html_path).with_suffix(".meta.json")
 
 
+def _parse_semver(v):
+    """(major, minor, patch) ints for a version string, or None if unparseable.
+    Tolerant: strips a leading 'v' and any -pre / +build suffix, pads missing
+    components with 0. Used only for precedence comparison, never display."""
+    try:
+        core = str(v).strip().lstrip("vV").split("+", 1)[0].split("-", 1)[0]
+        parts = (core.split(".") + ["0", "0", "0"])[:3]
+        return tuple(int(x) for x in parts)
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+# A dashboard HTML smaller than this is treated as absent/corrupt, so the version
+# guard will not honor a "newer" sidecar sitting next to a broken file (a real
+# dashboard is 4-5MB; the bundled template alone is tens of KB). This is the
+# anti-wedge floor: without it, a sidecar that names an impossibly-high version
+# next to an empty/truncated HTML would block EVERY future writer, including the
+# newest build, and never self-heal.
+_DASHBOARD_MIN_VALID_BYTES = 4096
+
+
+def _write_dashboard_meta(html_path):
+    """Write the (version, shape) sidecar next to a dashboard HTML we just wrote,
+    so the sidecar always names the build that produced the on-disk HTML. Every
+    writer of a shared dashboard MUST call this after writing, or the downgrade
+    guard reads a stale version and can be bypassed. Fail-soft; never raises."""
+    try:
+        _dashboard_meta_path(html_path).write_text(
+            json.dumps({"version": TOKEN_OPTIMIZER_VERSION, "shape": _DASHBOARD_SHAPE_MARKER}),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
+def _dashboard_on_disk_is_newer(html_path):
+    """True iff a REAL dashboard already on disk was written by a STRICTLY NEWER
+    Token Optimizer version than this process.
+
+    An older build must never overwrite a newer dashboard. Without this guard a
+    stale long-lived daemon or a still-running pre-upgrade session regenerates
+    the shared dashboard with pre-fix code and clobbers a just-shipped fix -- the
+    "we fixed it but it's still broken" report, where the fix ships yet an old
+    in-memory process keeps overwriting the corrected file.
+
+    Fail-OPEN by design: a missing sidecar, an unparseable/dev version on either
+    side, or an absent/undersized (corrupt) HTML returns False (allow the write).
+    The HTML-integrity floor is the anti-wedge: the guard only protects a REAL
+    on-disk dashboard, so a lying/corrupt sidecar next to a broken HTML can never
+    permanently block regeneration -- the next writer repairs it and rewrites the
+    sidecar. Reads only the ~40-byte sidecar plus a cheap stat. Never raises.
+    Equal versions are NOT "newer", so same-version regen and legitimate upgrades
+    both proceed; only a strictly-older writer is blocked.
+
+    Residual (documented, not auto-recovered): a *valid* newer sidecar beside a
+    *valid* HTML always blocks older writers -- correct when a real newer build
+    wrote it; on the rare chance the version was corrupted upward next to intact
+    HTML, recovery is deleting the .meta.json sidecar."""
+    try:
+        mine = _parse_semver(TOKEN_OPTIMIZER_VERSION)
+        if mine is None:
+            return False
+        # Only guard a real, non-trivial dashboard. A missing/tiny HTML means
+        # there is nothing worth protecting -- allow the write so a broken file
+        # (even next to a lying sidecar) always self-heals.
+        try:
+            if Path(html_path).stat().st_size < _DASHBOARD_MIN_VALID_BYTES:
+                return False
+        except OSError:
+            return False
+        meta_path = _dashboard_meta_path(html_path)
+        if not meta_path.exists():
+            return False
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        if not isinstance(meta, dict):
+            return False
+        existing = _parse_semver(meta.get("version"))
+        if existing is None:
+            return False
+        return existing > mine
+    except Exception:
+        return False
+
+
+def _dashboard_meta_is_fresh(meta):
+    """Freshness decision for the SessionStart staleness check, factored out so it
+    is directly testable. `meta` is the parsed sidecar dict. Fresh (no regen) iff:
+      - the on-disk build is STRICTLY NEWER than ours (an older session must not
+        regenerate/clobber a newer dashboard -- leave it to the newer build), OR
+      - version AND shape marker match ours exactly.
+    Anything else (older on disk, or a shape change) is stale -> regenerate."""
+    if not isinstance(meta, dict):
+        return False
+    existing = _parse_semver(meta.get("version"))
+    mine = _parse_semver(TOKEN_OPTIMIZER_VERSION)
+    if existing is not None and mine is not None and existing > mine:
+        return True
+    return (meta.get("version") == TOKEN_OPTIMIZER_VERSION
+            and meta.get("shape") == _DASHBOARD_SHAPE_MARKER)
+
+
 def _use_codex_session_adapter(filepath=None):
     """True when session JSONL should be parsed with the Codex adapter."""
     return detect_runtime() == "codex" or (filepath is not None and codex_session.is_codex_session_path(filepath))
@@ -4712,16 +4813,29 @@ def generate_dashboard(coord_path):
     # was configured to use. Same dual-path pattern as v5.4.7 daemon script.
     legacy_dashboard = RUNTIME_DIR / "_backups" / "token-optimizer" / "dashboard.html"
     wrote_mirror = False
+    skipped_all = True
     for mirror_path in {DASHBOARD_PATH, legacy_dashboard}:
+        # Version-downgrade guard: an older build's audit must not clobber a
+        # shared dashboard a newer build already wrote. The per-run audit artifact
+        # (out_path) is still written above; only the SHARED served copies are
+        # guarded. Fail-open (see _dashboard_on_disk_is_newer).
+        if _dashboard_on_disk_is_newer(mirror_path):
+            continue
+        skipped_all = False
         try:
             mirror_path.parent.mkdir(parents=True, exist_ok=True)
             mirror_fd = os.open(str(mirror_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             with os.fdopen(mirror_fd, "w", encoding="utf-8") as f:
                 f.write(injected)
+            # The sidecar must name the build that wrote THIS HTML, or the guard
+            # reads a stale version and a middle build could clobber a newer file.
+            _write_dashboard_meta(mirror_path)
             wrote_mirror = True
         except OSError:
             pass
-    if not wrote_mirror:
+    # Only a real write FAILURE warrants the warning; an intentional guard skip
+    # (all shared copies are already newer) is not a failure.
+    if not wrote_mirror and not skipped_all:
         print("  [Warning] Could not mirror dashboard to daemon paths.")
 
     # Prefer the bookmarkable URL when the daemon is live; fall back to
@@ -5811,6 +5925,18 @@ def generate_standalone_dashboard(days=30, quiet=False, force=False):
                 return str(DASHBOARD_PATH)
         except OSError:
             pass
+
+    # Version-downgrade guard: never let an OLDER build overwrite a dashboard a
+    # NEWER build already wrote (the "fixed but still broken" regression -- a
+    # stale daemon or pre-upgrade session clobbering a just-shipped fix). Checked
+    # BEFORE the expensive data build so an older writer skips cheaply. force does
+    # NOT bypass this: force governs the 60s throttle, not version precedence.
+    # Newer/equal writers proceed (equal is not strictly newer). Fail-open.
+    if _dashboard_on_disk_is_newer(DASHBOARD_PATH):
+        if not quiet:
+            print(f"  [Token Optimizer] Skipping dashboard write: the on-disk dashboard "
+                  f"was written by a newer version than this build (v{TOKEN_OPTIMIZER_VERSION}).")
+        return str(DASHBOARD_PATH)
 
     script_dir = Path(__file__).resolve().parent
     template_path = script_dir.parent / "assets" / "dashboard.html"
@@ -38974,9 +39100,10 @@ def run_ensure_health():
             if _meta_path.exists():
                 try:
                     _meta = json.loads(_meta_path.read_text(encoding="utf-8"))
-                    _fresh = (isinstance(_meta, dict)
-                              and _meta.get("version") == TOKEN_OPTIMIZER_VERSION
-                              and _meta.get("shape") == _DASHBOARD_SHAPE_MARKER)
+                    # An older session must NOT regenerate (and thus clobber with
+                    # pre-fix code) a dashboard a NEWER build wrote; a strictly-newer
+                    # on-disk build reads as fresh. See _dashboard_meta_is_fresh.
+                    _fresh = _dashboard_meta_is_fresh(_meta)
                 except (OSError, json.JSONDecodeError, ValueError):
                     _fresh = False
             else:

--- a/tests/test_dashboard_version_guard.py
+++ b/tests/test_dashboard_version_guard.py
@@ -1,0 +1,186 @@
+"""Version-downgrade guard: an OLDER Token Optimizer build must never overwrite a
+dashboard a NEWER build already wrote.
+
+Regression this prevents: a fix ships, but a stale long-lived daemon or a still-
+running pre-upgrade session keeps regenerating the shared dashboard with pre-fix
+code, clobbering the corrected file -- "we fixed it but it's still broken".
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import measure  # noqa: E402
+
+
+# --- _parse_semver ---------------------------------------------------------- #
+
+def test_parse_semver_basic():
+    assert measure._parse_semver("5.11.108") == (5, 11, 108)
+    assert measure._parse_semver("v5.11.108") == (5, 11, 108)      # leading v
+    assert measure._parse_semver("5.11") == (5, 11, 0)             # padded
+    assert measure._parse_semver("5") == (5, 0, 0)
+    assert measure._parse_semver("5.11.108-rc1") == (5, 11, 108)   # pre-release stripped
+    assert measure._parse_semver("5.11.108+build") == (5, 11, 108) # build metadata stripped
+
+
+def test_parse_semver_unparseable_is_none():
+    # Real inputs are always strings (JSON meta / VERSION constant). These cannot
+    # yield a numeric (major, minor, patch), so they must fail closed to None.
+    for bad in ("", None, "dev", "abc.def", "x.y.z", "latest"):
+        assert measure._parse_semver(bad) is None, bad
+
+
+def test_semver_ordering():
+    assert measure._parse_semver("5.11.104") < measure._parse_semver("5.11.106")
+    assert measure._parse_semver("5.11.106") < measure._parse_semver("5.12.0")
+    assert measure._parse_semver("5.11.106") == measure._parse_semver("5.11.106")
+
+
+# --- _dashboard_on_disk_is_newer -------------------------------------------- #
+
+# A real dashboard is 4-5MB; the guard ignores anything under the integrity floor.
+# Tests that want the version logic exercised must write a >floor HTML.
+_BIG_HTML = "<html>" + ("x" * (measure._DASHBOARD_MIN_VALID_BYTES + 100)) + "</html>"
+
+
+def _write_meta(html_path, version):
+    meta = measure._dashboard_meta_path(html_path)
+    meta.write_text(json.dumps({"version": version, "shape": measure._DASHBOARD_SHAPE_MARKER}))
+
+
+def test_on_disk_newer_blocks(tmp_path, monkeypatch):
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    _write_meta(html, "5.11.108")           # on disk is NEWER than me
+    assert measure._dashboard_on_disk_is_newer(html) is True
+
+
+def test_on_disk_older_allows(tmp_path, monkeypatch):
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.108")
+    _write_meta(html, "5.11.104")           # on disk is OLDER
+    assert measure._dashboard_on_disk_is_newer(html) is False
+
+
+def test_on_disk_equal_allows(tmp_path, monkeypatch):
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.108")
+    _write_meta(html, "5.11.108")           # equal is NOT newer -> allow
+    assert measure._dashboard_on_disk_is_newer(html) is False
+
+
+def test_fail_open_no_meta(tmp_path, monkeypatch):
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    # no sidecar written -> fail open (allow)
+    assert measure._dashboard_on_disk_is_newer(html) is False
+
+
+def test_fail_open_malformed_meta(tmp_path, monkeypatch):
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    measure._dashboard_meta_path(html).write_text("{not json")
+    assert measure._dashboard_on_disk_is_newer(html) is False
+
+
+def test_fail_open_unparseable_versions(tmp_path, monkeypatch):
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    # dev version on our side -> cannot compare -> allow
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "dev")
+    _write_meta(html, "5.11.108")
+    assert measure._dashboard_on_disk_is_newer(html) is False
+    # unparseable version in the sidecar -> allow
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    _write_meta(html, "garbage")
+    assert measure._dashboard_on_disk_is_newer(html) is False
+
+
+# --- generate_standalone_dashboard early-skip ------------------------------- #
+
+def test_generate_skips_write_when_on_disk_is_newer(tmp_path, monkeypatch):
+    """The chokepoint: an older build calling generate_standalone_dashboard must
+    return early WITHOUT overwriting a newer on-disk dashboard."""
+    html = tmp_path / "dashboard.html"
+    sentinel = "<html>NEWER-DASHBOARD-DO-NOT-CLOBBER" + ("x" * (measure._DASHBOARD_MIN_VALID_BYTES + 100)) + "</html>"
+    html.write_text(sentinel)
+    monkeypatch.setattr(measure, "DASHBOARD_PATH", html)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    _write_meta(html, "5.11.108")           # on disk written by a NEWER build
+
+    result = measure.generate_standalone_dashboard(quiet=True, force=True)
+
+    # returned the existing path and left the newer content untouched
+    assert result == str(html)
+    assert html.read_text() == sentinel
+
+
+# --- HTML integrity floor (anti-wedge) -------------------------------------- #
+
+def test_tiny_or_missing_html_fails_open_even_with_newer_sidecar(tmp_path, monkeypatch):
+    """Anti-wedge: a newer sidecar next to a MISSING or tiny/corrupt HTML must NOT
+    block writes -- otherwise a lying/corrupt sidecar wedges regeneration forever."""
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    html = tmp_path / "dashboard.html"
+    _write_meta(html, "999.999.999")            # lying, impossibly-high version
+    # (a) HTML missing entirely
+    assert measure._dashboard_on_disk_is_newer(html) is False
+    # (b) HTML present but below the integrity floor
+    html.write_text("<html>truncated</html>")
+    assert measure._dashboard_on_disk_is_newer(html) is False
+    # (c) once the HTML is a real size, the newer sidecar is honored again
+    html.write_text(_BIG_HTML)
+    assert measure._dashboard_on_disk_is_newer(html) is True
+
+
+# --- _dashboard_meta_is_fresh (SessionStart staleness decision) ------------- #
+
+def test_meta_is_fresh_newer_on_disk_is_left_alone(monkeypatch):
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    # strictly-newer on disk -> fresh (older session must not regenerate it)
+    assert measure._dashboard_meta_is_fresh(
+        {"version": "5.11.108", "shape": measure._DASHBOARD_SHAPE_MARKER}) is True
+    # even if the shape marker differs, a newer build owns it
+    assert measure._dashboard_meta_is_fresh(
+        {"version": "5.11.108", "shape": "OLD_SHAPE"}) is True
+
+
+def test_meta_is_fresh_upgrade_and_shape_change_regenerate(monkeypatch):
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.108")
+    # older on disk -> stale (I'm an upgrade; regenerate)
+    assert measure._dashboard_meta_is_fresh(
+        {"version": "5.11.104", "shape": measure._DASHBOARD_SHAPE_MARKER}) is False
+    # same version, changed shape -> stale (regenerate)
+    assert measure._dashboard_meta_is_fresh(
+        {"version": "5.11.108", "shape": "OLD_SHAPE"}) is False
+    # exact match -> fresh
+    assert measure._dashboard_meta_is_fresh(
+        {"version": "5.11.108", "shape": measure._DASHBOARD_SHAPE_MARKER}) is True
+    # junk -> stale
+    assert measure._dashboard_meta_is_fresh("nope") is False
+    assert measure._dashboard_meta_is_fresh({}) is False
+
+
+# --- _write_dashboard_meta -------------------------------------------------- #
+
+def test_write_dashboard_meta_names_this_build(tmp_path, monkeypatch):
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.108")
+    html = tmp_path / "dashboard.html"
+    html.write_text(_BIG_HTML)
+    measure._write_dashboard_meta(html)
+    meta = json.loads(measure._dashboard_meta_path(html).read_text())
+    assert meta["version"] == "5.11.108"
+    assert meta["shape"] == measure._DASHBOARD_SHAPE_MARKER
+    # and now an older build sees it as newer (guard would hold)
+    monkeypatch.setattr(measure, "TOKEN_OPTIMIZER_VERSION", "5.11.106")
+    assert measure._dashboard_on_disk_is_newer(html) is True


### PR DESCRIPTION
## What
Stops the **"we shipped the fix but it's still broken"** class: a stale long-lived daemon or a still-running pre-upgrade session regenerates the *shared* dashboard with pre-fix code and clobbers a just-shipped fix. (Hit live this session — a 3-day-old daemon kept re-rendering the runway card's "reappears next session" placeholder even after the 5.11.106 meter fix shipped.)

**Principle: an older build must never overwrite a dashboard a newer build wrote.**

## Changes
- `_parse_semver` + `_dashboard_on_disk_is_newer`: an older build refuses to overwrite a strictly-newer dashboard. **Fail-open** (missing/dev/unparseable version) plus an **HTML-integrity floor** so a corrupt/lying sidecar can never wedge regeneration — the guard only protects a real, non-trivial on-disk dashboard.
- Guards **both** shared-dashboard writers: `generate_standalone_dashboard` early-skip + the audit mirror loop (which now also writes the sidecar, so the version ledger can't be understated). `force` does not bypass (force governs the 60s throttle, not version precedence).
- SessionStart staleness check factored into `_dashboard_meta_is_fresh`: an older session treats a strictly-newer dashboard as fresh instead of regenerating it (was exact-match — the root of the clobber).
- 15 tests: semver, newer/older/equal, fail-open incl. the corrupt-HTML anti-wedge, freshness helper, sidecar writer, standalone chokepoint.

## Verification
4-lane GLM torture room + **Kimi K3 judge in Droid**. Reviews found a real defect (audit writer didn't update the sidecar) and a HIGH anti-wedge gap (lying sidecar could self-reinforce); both fixed and re-judged **VERDICT: SHIP**. Mirrors byte-identical.

**Forward-only by nature:** protects once the *writer* runs the guarded build (5.11.108+); the newest-code daemon re-heals any current pre-guard sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
