### PR TITLE
fix(hooks): ensure-health no longer re-adds legacy quality-cache hook (#155)

### DIFF
--- a/cowork/token-optimizer/README.md
+++ b/cowork/token-optimizer/README.md
@@ -210,8 +210,7 @@ These ten rows are the ones where Token Optimizer is the only 🟢 in the row: w
 
 |  | Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
 |---|---|---|---|---|---|---|
-| Compaction survival | 🟢 Progressive checkpoints, restore, tool output digest | 🔴 | 🔴 | — | 🟡 Session guide only | 🔴 |
-| Session continuity | 🟢 Cross-session hints, cold-resume, checkpoint scoring | 🔴 | 🔴 | — | 🟡 Session guide | 🔴 |
+| Session continuity | 🟢 Progressive checkpoints before compaction + restore after, cross-session hints, cold-resume, tool-output digest; measured ~3.9M tokens / ~$19 recovered in a 30-day snapshot (checkpoint restores + lean resumes) | 🔴 | 🔴 | — | 🟡 Session guide only | 🔴 |
 | Structural waste audit | 🟢 Deep per-component (CLAUDE.md, skills, MCP, memory) | 🔴 | 🔴 | 🔴 | 🔴 | 🟡 Summary only |
 | CLAUDE.md and MEMORY.md health | 🟢 8 auditors + attention-curve scoring | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 |
 | Model routing and behavioral coaching | 🟢 12 detectors, subagent cost breakdown, anti-patterns | 🔴 | 🔴 | — | 🔴 | 🟡 Basic suggestions |
@@ -237,11 +236,11 @@ These ten rows are the ones where Token Optimizer is the only 🟢 in the row: w
 | Multi-platform | 🟢 Claude Code, VS Code, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15 integrations | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17 integrations | 🔴 Claude Code only |
 | Per-task model and effort advice | 🟢 `route` sizes the task before you spend | — | — | — | — | — |
 | Keep-Warm (cache TTL refresh) | 🟢 Opt-in ping before cache expiry, tripwire auto-off | 🔴 | 🔴 | — | 🔴 | 🔴 |
-| End-to-end task-outcome benchmark | 🔴 Output-token A/B only | — | — | 🟢 Vendor reports Terminal-Bench 2.0 with the same pass rate and ~12% lower cost | — | N/A |
+| End-to-end task-outcome benchmark | 🟡 Controlled A/B on 7 real tasks (output tokens) + measured real-session with/without savings; pass-rate study not yet run | — | — | 🟢 Vendor reports Terminal-Bench 2.0 with the same pass rate and ~12% lower cost | — | N/A |
 | Signed and checksum-verified install | 🟢 `CHECKSUMS.sha256` per release, verified at install, CI-enforced | — | — | 🔴 Installer verifies neither a checksum nor a signature | — | N/A |
 
 </details>
-An em dash means the capability was not verified from first-party material in the 2026-07-26 source audit; it is not a claim that the capability is absent. Boost's "pre-shell" and "shell-level" cells are sourced from its documented wrapper form (`boost <command>`); the mechanism `boost init` uses to wire an agent is not described in its first-party material. Token Optimizer's compression claims are tested against real sessions and an 87-fixture suite you can run yourself. **[Full benchmark methodology and results →](BENCHMARK.md)**
+An em dash means the capability was not verified from first-party material in the 2026-07-26 source audit (Boost's first-party material re-verified 2026-08-26); it is not a claim that the capability is absent. This page scores command-output compression only; JFrog Boost's separately-shipped BoostGraph, a local code-map its agent queries on request, is a different capability and out of scope here. Boost's "pre-shell" and "shell-level" cells are sourced from its documented wrapper form (`boost <command>`); the mechanism `boost init` uses to wire an agent is not described in its first-party material. Token Optimizer's compression claims are tested against real sessions and an 87-fixture suite you can run yourself. **[Full benchmark methodology and results →](BENCHMARK.md)**
 
 <p align="center">
   <a href="https://alexgreensh.github.io/token-optimizer/reference/comparison/"><img src="https://img.shields.io/badge/Read%20the%20official%20full%20comparison-in%20our%20docs-0b7285?style=for-the-badge" alt="Read the official full comparison page in our documentation"></a>

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -34260,6 +34260,43 @@ def _is_malformed_to_hook(cmd):
     return has_subshell or has_double_home
 
 
+# Marker substrings that prove a UserPromptSubmit hook already drives the
+# quality-cache update. Two shapes exist in the wild and BOTH must count as
+# "installed", or ensure-health appends a duplicate legacy hook every session
+# (GitHub #155):
+#   * legacy standalone hook  -> `python3 '<mp>' quality-cache --quiet`
+#     (pre-5.11.93 script installs; the literal "quality-cache" is present).
+#   * #139 consolidated dispatcher (a299bf7, v5.11.93+) ->
+#     `... hooks/userpromptsubmit_runner.py ...`, which runs quality-cache
+#     *inside* the runner, so "quality-cache" NEVER appears in the command.
+# Matching only the first shape made every detection site treat the shipped
+# consolidated dispatcher as "hook missing", regressing #139.
+_QUALITY_CACHE_HOOK_MARKERS = ("quality-cache", "userpromptsubmit_runner.py")
+
+
+def _command_drives_quality_cache(command):
+    """True if a hook *command string* already runs the quality-cache update.
+
+    Recognizes both the legacy standalone hook and the #139 consolidated
+    in-process dispatcher (see `_QUALITY_CACHE_HOOK_MARKERS`).
+    """
+    blob = command or ""
+    return any(marker in blob for marker in _QUALITY_CACHE_HOOK_MARKERS)
+
+
+def _quality_cache_hook_present(groups):
+    """True if any UserPromptSubmit hook *group* already drives quality-cache.
+
+    `groups` is a settings.json / hooks.json ``UserPromptSubmit`` list. This is
+    the two-marker generalization of the old ``any("quality-cache" in str(h)
+    for h in groups)`` scan: it stringifies each group so it stays robust to the
+    canonical ``{"hooks": [{"command": ...}]}`` shape and any bare/legacy entry,
+    while recognizing the consolidated dispatcher that carries no literal
+    "quality-cache" substring (GitHub #155).
+    """
+    return any(_command_drives_quality_cache(str(group)) for group in (groups or []))
+
+
 def _is_quality_bar_installed(settings=None):
     """Check which quality bar components are installed.
 
@@ -34276,11 +34313,12 @@ def _is_quality_bar_installed(settings=None):
     if "statusline.js" in cmd and "token-optimizer" in cmd:
         result["statusline"] = True
 
-    # Check UserPromptSubmit hook (settings.json)
+    # Check UserPromptSubmit hook (settings.json). Recognizes both the legacy
+    # standalone hook and the #139 consolidated dispatcher (GitHub #155).
     hooks = (settings.get("hooks") or {})
     for group in (hooks.get("UserPromptSubmit") or []):
         for hook in (group.get("hooks") or []):
-            if "quality-cache" in (hook.get("command") or ""):
+            if _command_drives_quality_cache(hook.get("command") or ""):
                 result["hook"] = True
                 break
 
@@ -34295,7 +34333,7 @@ def _is_quality_bar_installed(settings=None):
                         plugin_hooks = json.load(f).get("hooks", {})
                     for group in (plugin_hooks.get("UserPromptSubmit") or []):
                         for hook in (group.get("hooks") or []):
-                            if "quality-cache" in (hook.get("command") or ""):
+                            if _command_drives_quality_cache(hook.get("command") or ""):
                                 result["hook"] = True
                                 break
                 except (json.JSONDecodeError, PermissionError, OSError):
@@ -39565,7 +39603,10 @@ def run_ensure_health():
                         statusline_cmd = (settings.get("statusLine") or {}).get("command", "") or ""
                         statusline_is_ours = "statusline.js" in statusline_cmd and "token-optimizer" in statusline_cmd
                         hooks = settings.get("hooks", {}).get("UserPromptSubmit", [])
-                        has_cache_hook = any("quality-cache" in str(h) for h in hooks)
+                        # Recognize the #139 consolidated dispatcher as well as
+                        # the legacy standalone hook, else this re-adds the
+                        # legacy hook every SessionStart (GitHub #155).
+                        has_cache_hook = _quality_cache_hook_present(hooks)
                         if has_statusline and not statusline_is_ours and has_cache_hook:
                             print(
                                 "  [Token Optimizer] Statusline was replaced (e.g., by /statusline). "
@@ -41601,7 +41642,10 @@ if __name__ == "__main__":
                 if not _is_plugin and not _qb_disabled and SETTINGS_PATH.exists():
                     _sh_settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
                     _sh_hooks = _sh_settings.get("hooks", {}).get("UserPromptSubmit", [])
-                    if not any("quality-cache" in str(h) for h in _sh_hooks):
+                    # Recognize the #139 consolidated dispatcher too, so a script
+                    # install whose canonical hook is already present is not
+                    # "healed" by appending a duplicate legacy hook (GitHub #155).
+                    if not _quality_cache_hook_present(_sh_hooks):
                         setup_quality_bar(quiet=True)
             except Exception:
                 pass

--- a/decisions.md
+++ b/decisions.md
@@ -1,37 +1,69 @@
-# Cowork Full-Parity — Decisions (cowork-full-parity branch)
+# Issue #155 — ensure-health re-adds legacy quality-cache hook (partly undoing #139)
+
+## Root cause (confirmed)
+Since a299bf7 (#139, v5.11.93) the shipped `UserPromptSubmit` hook is a single
+in-process dispatcher whose command references `hooks/userpromptsubmit_runner.py`
+and runs `quality-cache` *inside* the runner. The literal substring
+`quality-cache` no longer appears in the hook command.
+
+Three predicates in `skills/token-optimizer/scripts/measure.py` detect the
+quality-cache hook purely by the substring `"quality-cache"`:
+- `measure.py:41604` — UserPromptSubmit self-heal probe (`ensure-health` path).
+- `measure.py:39568` — SessionStart auto-restore probe (`has_cache_hook`).
+- `measure.py:34283` / `:34298` — `_is_quality_bar_installed` idempotence check
+  (settings.json + plugin-cache hooks.json fallback), used by `setup_quality_bar`.
+
+All three return `False` against the consolidated dispatcher, so ensure-health
+concludes "hook missing" and `setup_quality_bar` appends a fresh legacy
+`python3 '<mp>' quality-cache --quiet` group at `measure.py:35073`. Every
+subsequent prompt then runs quality-cache twice (dispatcher + legacy), and the
+duplicate is un-removable because the next SessionStart re-adds it.
 
 ## Design Decisions
-- **In-place parity, not a second plugin.** The main `token-optimizer` plugin becomes
-  Cowork-native by adding the 3 run-once SessionStart features (ensure-health,
-  quality-cache --force, compact-restore --new-session-only) into the MASTER
-  `hooks/hooks.json` **UserPromptSubmit** group, each wrapped in a once-per-session guard.
-  Rationale: SessionStart does not fire in Cowork; UserPromptSubmit does. The guard makes
-  the UserPromptSubmit copies no-op in regular Claude Code (SessionStart already ran them
-  and set the marker), so zero behavior change for existing users and no duplicated skills/
-  tree. "Install the normal plugin in Cowork" = full parity.
-- **Proven firing events (cloud Cowork, CC 2.1.231):** UserPromptSubmit, PreToolUse,
-  PostToolUse, Stop, SubagentStop. `COWORK_EVENTS` corrected to the 4 that carry features
-  (SubagentStop has no master hooks to ride — not fabricated).
-- **build_cowork_hooks() stays a pure trim** (org-console ZIP path). Because master
-  UserPromptSubmit already carries the run-once commands, no special remap/injection is
-  needed in the packager.
-- **Once-per-session guard** keyed on sanitized session_id, stored in the engine's existing
-  per-session state dir (no new top-level location). Protects every existing CC user from
-  double-fire — this is the one correctness-critical piece.
+- Add two module-level helpers next to `_is_quality_bar_installed`:
+  - `_command_drives_quality_cache(command)` — True if a hook *command string*
+    matches either the legacy shape (`quality-cache`) OR the #139 consolidated
+    dispatcher (`userpromptsubmit_runner.py`).
+  - `_quality_cache_hook_present(groups)` — True if any UserPromptSubmit *group*
+    already drives quality-cache (faithful two-marker generalization of the old
+    `any("quality-cache" in str(h) ...)` scan).
+- Route all three detection sites through the helpers so the consolidated
+  dispatcher is recognized as "quality-cache already installed" and ensure-health
+  no longer appends the legacy hook. This respects the #139 state on script AND
+  plugin installs (the plugin-cache fallback now recognizes the shipped hook too).
+- Marker `userpromptsubmit_runner.py` chosen as the dispatcher signature: it is
+  the stable, distinctive filename the consolidated command always execs, present
+  in both settings.json (script install) and hooks.json (plugin install).
 
 ## Deviations
-- COWORK_BUILD_PLAN.md item 1-2 described editing cowork_install.py to remap events. The
-  remap moved UP into master hooks.json instead (cleaner, fixes both distribution paths at
-  once). Packager change reduced to the COWORK_EVENTS constant.
+- Left the `--uninstall` path (`measure.py:35016`) matching only `quality-cache`
+  on purpose: uninstall must strip the *legacy standalone* hook, never the
+  consolidated dispatcher (which is the legitimate #139 hook, not a quality-bar
+  add-on). Removing the dispatcher on `setup-quality-bar --uninstall` would break
+  every other UserPromptSubmit subcommand.
 
 ## Tradeoffs
-- Adding guarded commands to master UserPromptSubmit = 3 extra marker-check subprocess
-  spawns on the first prompt of every regular Claude Code session. Negligible, fail-open.
-  Accepted in exchange for a single source of truth and no repo bloat.
+- Substring/marker detection is inherently heuristic. `userpromptsubmit_runner.py`
+  is a strong, stable signal; a hand-rolled hook that runs the runner under a
+  different filename would not be recognized, but that is not a shipped shape.
+
+## Mirrors
+- Canonical file is `skills/token-optimizer/scripts/measure.py`. The
+  `plugins/token-optimizer/` and `cowork/token-optimizer/` copies are generated
+  mirrors enforced byte-identical by `scripts/check-mirror-sync.sh` and
+  `tests/test_cowork_committed_plugin.py`. Regenerated after the edit.
+
+## Picked-up pre-existing drift (not part of the #155 logic fix)
+- Regenerating the cowork mirror with `cowork_install.py --emit-committed` (the
+  only supported regen path, required by `test_cowork_committed_plugin.py`) also
+  refreshed `cowork/token-optimizer/README.md`. That README was already stale on
+  origin/main: #156 updated the root README (BoostGraph scoping) without
+  regenerating the cowork mirror, so `test_rebuild_emit_committed_leaves_git_clean`
+  already fails on a clean origin/main checkout. Verified: root README mentions
+  "BoostGraph" 1x, committed cowork README 0x, before any of my edits. The refresh
+  is committed because the mirror must be byte-reproducible from the generator; it
+  is unrelated to the hook logic.
 
 ## Open Questions
-- compaction-restore on native trigger stays degraded in Cowork (PreCompact/PostCompact/
-  SessionStart:compact all dead). compact-capture on Stop still saves state; fresh-session
-  compact-restore reads it back. Documented, not solved.
-- Version bump + alignment (plugin.json / marketplace.json / README badge / tag) at package
-  step; not pushed to main until torture-room green + review.
+- None blocking. The fix is behavior-preserving for already-correct installs
+  (no-op) and stops the duplicate on consolidated-dispatcher installs.

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -34260,6 +34260,43 @@ def _is_malformed_to_hook(cmd):
     return has_subshell or has_double_home
 
 
+# Marker substrings that prove a UserPromptSubmit hook already drives the
+# quality-cache update. Two shapes exist in the wild and BOTH must count as
+# "installed", or ensure-health appends a duplicate legacy hook every session
+# (GitHub #155):
+#   * legacy standalone hook  -> `python3 '<mp>' quality-cache --quiet`
+#     (pre-5.11.93 script installs; the literal "quality-cache" is present).
+#   * #139 consolidated dispatcher (a299bf7, v5.11.93+) ->
+#     `... hooks/userpromptsubmit_runner.py ...`, which runs quality-cache
+#     *inside* the runner, so "quality-cache" NEVER appears in the command.
+# Matching only the first shape made every detection site treat the shipped
+# consolidated dispatcher as "hook missing", regressing #139.
+_QUALITY_CACHE_HOOK_MARKERS = ("quality-cache", "userpromptsubmit_runner.py")
+
+
+def _command_drives_quality_cache(command):
+    """True if a hook *command string* already runs the quality-cache update.
+
+    Recognizes both the legacy standalone hook and the #139 consolidated
+    in-process dispatcher (see `_QUALITY_CACHE_HOOK_MARKERS`).
+    """
+    blob = command or ""
+    return any(marker in blob for marker in _QUALITY_CACHE_HOOK_MARKERS)
+
+
+def _quality_cache_hook_present(groups):
+    """True if any UserPromptSubmit hook *group* already drives quality-cache.
+
+    `groups` is a settings.json / hooks.json ``UserPromptSubmit`` list. This is
+    the two-marker generalization of the old ``any("quality-cache" in str(h)
+    for h in groups)`` scan: it stringifies each group so it stays robust to the
+    canonical ``{"hooks": [{"command": ...}]}`` shape and any bare/legacy entry,
+    while recognizing the consolidated dispatcher that carries no literal
+    "quality-cache" substring (GitHub #155).
+    """
+    return any(_command_drives_quality_cache(str(group)) for group in (groups or []))
+
+
 def _is_quality_bar_installed(settings=None):
     """Check which quality bar components are installed.
 
@@ -34276,11 +34313,12 @@ def _is_quality_bar_installed(settings=None):
     if "statusline.js" in cmd and "token-optimizer" in cmd:
         result["statusline"] = True
 
-    # Check UserPromptSubmit hook (settings.json)
+    # Check UserPromptSubmit hook (settings.json). Recognizes both the legacy
+    # standalone hook and the #139 consolidated dispatcher (GitHub #155).
     hooks = (settings.get("hooks") or {})
     for group in (hooks.get("UserPromptSubmit") or []):
         for hook in (group.get("hooks") or []):
-            if "quality-cache" in (hook.get("command") or ""):
+            if _command_drives_quality_cache(hook.get("command") or ""):
                 result["hook"] = True
                 break
 
@@ -34295,7 +34333,7 @@ def _is_quality_bar_installed(settings=None):
                         plugin_hooks = json.load(f).get("hooks", {})
                     for group in (plugin_hooks.get("UserPromptSubmit") or []):
                         for hook in (group.get("hooks") or []):
-                            if "quality-cache" in (hook.get("command") or ""):
+                            if _command_drives_quality_cache(hook.get("command") or ""):
                                 result["hook"] = True
                                 break
                 except (json.JSONDecodeError, PermissionError, OSError):
@@ -39565,7 +39603,10 @@ def run_ensure_health():
                         statusline_cmd = (settings.get("statusLine") or {}).get("command", "") or ""
                         statusline_is_ours = "statusline.js" in statusline_cmd and "token-optimizer" in statusline_cmd
                         hooks = settings.get("hooks", {}).get("UserPromptSubmit", [])
-                        has_cache_hook = any("quality-cache" in str(h) for h in hooks)
+                        # Recognize the #139 consolidated dispatcher as well as
+                        # the legacy standalone hook, else this re-adds the
+                        # legacy hook every SessionStart (GitHub #155).
+                        has_cache_hook = _quality_cache_hook_present(hooks)
                         if has_statusline and not statusline_is_ours and has_cache_hook:
                             print(
                                 "  [Token Optimizer] Statusline was replaced (e.g., by /statusline). "
@@ -41601,7 +41642,10 @@ if __name__ == "__main__":
                 if not _is_plugin and not _qb_disabled and SETTINGS_PATH.exists():
                     _sh_settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
                     _sh_hooks = _sh_settings.get("hooks", {}).get("UserPromptSubmit", [])
-                    if not any("quality-cache" in str(h) for h in _sh_hooks):
+                    # Recognize the #139 consolidated dispatcher too, so a script
+                    # install whose canonical hook is already present is not
+                    # "healed" by appending a duplicate legacy hook (GitHub #155).
+                    if not _quality_cache_hook_present(_sh_hooks):
                         setup_quality_bar(quiet=True)
             except Exception:
                 pass

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -34260,6 +34260,43 @@ def _is_malformed_to_hook(cmd):
     return has_subshell or has_double_home
 
 
+# Marker substrings that prove a UserPromptSubmit hook already drives the
+# quality-cache update. Two shapes exist in the wild and BOTH must count as
+# "installed", or ensure-health appends a duplicate legacy hook every session
+# (GitHub #155):
+#   * legacy standalone hook  -> `python3 '<mp>' quality-cache --quiet`
+#     (pre-5.11.93 script installs; the literal "quality-cache" is present).
+#   * #139 consolidated dispatcher (a299bf7, v5.11.93+) ->
+#     `... hooks/userpromptsubmit_runner.py ...`, which runs quality-cache
+#     *inside* the runner, so "quality-cache" NEVER appears in the command.
+# Matching only the first shape made every detection site treat the shipped
+# consolidated dispatcher as "hook missing", regressing #139.
+_QUALITY_CACHE_HOOK_MARKERS = ("quality-cache", "userpromptsubmit_runner.py")
+
+
+def _command_drives_quality_cache(command):
+    """True if a hook *command string* already runs the quality-cache update.
+
+    Recognizes both the legacy standalone hook and the #139 consolidated
+    in-process dispatcher (see `_QUALITY_CACHE_HOOK_MARKERS`).
+    """
+    blob = command or ""
+    return any(marker in blob for marker in _QUALITY_CACHE_HOOK_MARKERS)
+
+
+def _quality_cache_hook_present(groups):
+    """True if any UserPromptSubmit hook *group* already drives quality-cache.
+
+    `groups` is a settings.json / hooks.json ``UserPromptSubmit`` list. This is
+    the two-marker generalization of the old ``any("quality-cache" in str(h)
+    for h in groups)`` scan: it stringifies each group so it stays robust to the
+    canonical ``{"hooks": [{"command": ...}]}`` shape and any bare/legacy entry,
+    while recognizing the consolidated dispatcher that carries no literal
+    "quality-cache" substring (GitHub #155).
+    """
+    return any(_command_drives_quality_cache(str(group)) for group in (groups or []))
+
+
 def _is_quality_bar_installed(settings=None):
     """Check which quality bar components are installed.
 
@@ -34276,11 +34313,12 @@ def _is_quality_bar_installed(settings=None):
     if "statusline.js" in cmd and "token-optimizer" in cmd:
         result["statusline"] = True
 
-    # Check UserPromptSubmit hook (settings.json)
+    # Check UserPromptSubmit hook (settings.json). Recognizes both the legacy
+    # standalone hook and the #139 consolidated dispatcher (GitHub #155).
     hooks = (settings.get("hooks") or {})
     for group in (hooks.get("UserPromptSubmit") or []):
         for hook in (group.get("hooks") or []):
-            if "quality-cache" in (hook.get("command") or ""):
+            if _command_drives_quality_cache(hook.get("command") or ""):
                 result["hook"] = True
                 break
 
@@ -34295,7 +34333,7 @@ def _is_quality_bar_installed(settings=None):
                         plugin_hooks = json.load(f).get("hooks", {})
                     for group in (plugin_hooks.get("UserPromptSubmit") or []):
                         for hook in (group.get("hooks") or []):
-                            if "quality-cache" in (hook.get("command") or ""):
+                            if _command_drives_quality_cache(hook.get("command") or ""):
                                 result["hook"] = True
                                 break
                 except (json.JSONDecodeError, PermissionError, OSError):
@@ -39565,7 +39603,10 @@ def run_ensure_health():
                         statusline_cmd = (settings.get("statusLine") or {}).get("command", "") or ""
                         statusline_is_ours = "statusline.js" in statusline_cmd and "token-optimizer" in statusline_cmd
                         hooks = settings.get("hooks", {}).get("UserPromptSubmit", [])
-                        has_cache_hook = any("quality-cache" in str(h) for h in hooks)
+                        # Recognize the #139 consolidated dispatcher as well as
+                        # the legacy standalone hook, else this re-adds the
+                        # legacy hook every SessionStart (GitHub #155).
+                        has_cache_hook = _quality_cache_hook_present(hooks)
                         if has_statusline and not statusline_is_ours and has_cache_hook:
                             print(
                                 "  [Token Optimizer] Statusline was replaced (e.g., by /statusline). "
@@ -41601,7 +41642,10 @@ if __name__ == "__main__":
                 if not _is_plugin and not _qb_disabled and SETTINGS_PATH.exists():
                     _sh_settings = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
                     _sh_hooks = _sh_settings.get("hooks", {}).get("UserPromptSubmit", [])
-                    if not any("quality-cache" in str(h) for h in _sh_hooks):
+                    # Recognize the #139 consolidated dispatcher too, so a script
+                    # install whose canonical hook is already present is not
+                    # "healed" by appending a duplicate legacy hook (GitHub #155).
+                    if not _quality_cache_hook_present(_sh_hooks):
                         setup_quality_bar(quiet=True)
             except Exception:
                 pass

--- a/tests/test_ensure_health_quality_cache_155.py
+++ b/tests/test_ensure_health_quality_cache_155.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Regression: ensure-health must not re-add the legacy quality-cache hook (#155).
+
+Since #139 (a299bf7, v5.11.93) the shipped ``UserPromptSubmit`` hook is a single
+in-process dispatcher whose command execs ``hooks/userpromptsubmit_runner.py``
+and runs ``quality-cache`` INSIDE the runner. The literal ``quality-cache``
+substring no longer appears in the hook command.
+
+Before the fix, the three detection sites in measure.py tested only for the
+substring ``"quality-cache"``, so they treated the consolidated dispatcher as
+"hook missing". ensure-health then called ``setup_quality_bar`` which appended a
+fresh legacy ``python3 '<mp>' quality-cache --quiet`` group -- running
+quality-cache twice per prompt and re-introducing the per-prompt blocking cost
+#139 removed. The duplicate returned on every SessionStart.
+
+These tests pin the fix: with the canonical #139 dispatcher already present,
+the quality-cache hook is recognized as installed and setup_quality_bar does
+NOT append a legacy hook.
+
+Run: python3 -m pytest tests/test_ensure_health_quality_cache_155.py -v
+"""
+
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "skills" / "token-optimizer" / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import measure  # noqa: E402
+
+
+# The exact canonical UserPromptSubmit command shipped since #139 (hooks.json).
+# It runs quality-cache inside userpromptsubmit_runner.py and, crucially, does
+# NOT contain the literal substring "quality-cache".
+_DISPATCHER_CMD = (
+    'for b in bash /bin/bash /usr/bin/bash /usr/local/bin/bash /opt/homebrew/bin/bash; do '
+    'command -v "$b" >/dev/null 2>&1 && exec "$b" '
+    '"${CLAUDE_PLUGIN_ROOT}/hooks/python-launcher.sh" '
+    '"${CLAUDE_PLUGIN_ROOT}/hooks/run.py" hooks/userpromptsubmit_runner.py; done; exit 0'
+)
+
+
+def _dispatcher_group():
+    return {"hooks": [{"type": "command", "command": _DISPATCHER_CMD}]}
+
+
+def _legacy_group():
+    return {"hooks": [{"type": "command", "command": "python3 '/x/measure.py' quality-cache --quiet"}]}
+
+
+def _count_legacy_hooks(settings):
+    """Number of standalone legacy `quality-cache --quiet` UserPromptSubmit hooks."""
+    n = 0
+    for group in settings.get("hooks", {}).get("UserPromptSubmit", []):
+        for hook in group.get("hooks", []):
+            cmd = hook.get("command", "")
+            if "quality-cache" in cmd and "userpromptsubmit_runner.py" not in cmd:
+                n += 1
+    return n
+
+
+# --- premise: the dispatcher command really has no "quality-cache" substring ---
+
+def test_dispatcher_command_has_no_literal_quality_cache_substring():
+    # Guards the whole point of #155: the naive substring check silently misses
+    # the consolidated dispatcher.
+    assert "quality-cache" not in _DISPATCHER_CMD
+
+
+# --- unit: the detection helpers recognize both hook shapes ---
+
+def test_command_helper_recognizes_both_shapes():
+    assert measure._command_drives_quality_cache(_DISPATCHER_CMD) is True
+    assert measure._command_drives_quality_cache("python3 '/x/measure.py' quality-cache --quiet") is True
+    assert measure._command_drives_quality_cache("echo hello") is False
+    assert measure._command_drives_quality_cache("") is False
+    assert measure._command_drives_quality_cache(None) is False
+
+
+def test_group_helper_recognizes_dispatcher():
+    assert measure._quality_cache_hook_present([_dispatcher_group()]) is True
+    assert measure._quality_cache_hook_present([_legacy_group()]) is True
+    assert measure._quality_cache_hook_present([]) is False
+    assert measure._quality_cache_hook_present([{"hooks": [{"command": "echo hi"}]}]) is False
+
+
+def test_is_quality_bar_installed_sees_dispatcher():
+    settings = {"hooks": {"UserPromptSubmit": [_dispatcher_group()]}}
+    assert measure._is_quality_bar_installed(settings)["hook"] is True
+
+
+# --- integration: setup_quality_bar (what ensure-health calls) is a no-op ---
+
+def test_setup_quality_bar_does_not_readd_legacy_hook(monkeypatch, tmp_path):
+    """With the #139 dispatcher + our statusline present, setup_quality_bar must
+    not append a second, legacy quality-cache hook."""
+    statusline_cmd = "node '/install/skills/token-optimizer/statusline.js'"
+    settings = {
+        "statusLine": {"type": "command", "command": statusline_cmd},
+        "hooks": {"UserPromptSubmit": [_dispatcher_group()]},
+    }
+    settings_path = tmp_path / "settings.json"
+
+    # Force a script-install view of the world and capture any write.
+    monkeypatch.setattr(measure, "_is_running_from_plugin_cache", lambda: False)
+    monkeypatch.setattr(measure, "_is_plugin_installed", lambda: False)
+    monkeypatch.setattr(measure, "_read_settings_json", lambda: (settings, settings_path))
+
+    written = {}
+    monkeypatch.setattr(measure, "_write_settings_atomic", lambda data: written.update({"data": data}))
+    monkeypatch.setattr(measure, "_set_quality_bar_disabled", lambda *a, **k: None)
+
+    assert _count_legacy_hooks(settings) == 0, "precondition: no legacy hook yet"
+
+    measure.setup_quality_bar(quiet=True)
+
+    # Whether or not a write happened, no legacy quality-cache hook may exist.
+    final = written.get("data", settings)
+    assert _count_legacy_hooks(final) == 0, (
+        "ensure-health/setup_quality_bar re-added the legacy quality-cache hook "
+        "despite the #139 dispatcher already being installed (regression of #155)"
+    )
+    # The canonical dispatcher must still be present and untouched.
+    cmds = [
+        h.get("command", "")
+        for g in final.get("hooks", {}).get("UserPromptSubmit", [])
+        for h in g.get("hooks", [])
+    ]
+    assert any("userpromptsubmit_runner.py" in c for c in cmds), "dispatcher must be preserved"
+
+
+def test_plugin_cache_fallback_recognizes_shipped_hook(monkeypatch, tmp_path):
+    """The plugin-cache fallback in _is_quality_bar_installed must recognize the
+    shipped canonical hooks.json dispatcher too (issue #155 notes it would not)."""
+    import json
+
+    plugin_hooks_dir = tmp_path / "plugins" / "cache" / "mkt" / "token-optimizer" / "1.0" / "hooks"
+    plugin_hooks_dir.mkdir(parents=True)
+    (plugin_hooks_dir / "hooks.json").write_text(
+        json.dumps({"hooks": {"UserPromptSubmit": [_dispatcher_group()]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(measure, "CLAUDE_DIR", tmp_path)
+
+    # settings.json has no UserPromptSubmit hook -> forces the plugin-cache fallback.
+    result = measure._is_quality_bar_installed({"hooks": {}})
+    assert result["hook"] is True


### PR DESCRIPTION
Fixes #155.

## Root cause
Since #139 (a299bf7, v5.11.93) the shipped `UserPromptSubmit` hook is a single in-process dispatcher whose command execs `hooks/userpromptsubmit_runner.py` and runs `quality-cache` **inside** the runner. The literal substring `quality-cache` no longer appears in the hook command.

Three detection sites in `skills/token-optimizer/scripts/measure.py` probed only for that substring, so they treated the consolidated dispatcher as "hook missing":
- UserPromptSubmit self-heal probe (`ensure-health` path)
- SessionStart auto-restore probe (`has_cache_hook`)
- `_is_quality_bar_installed` (settings.json check + plugin-cache `hooks.json` fallback)

`ensure-health` then called `setup_quality_bar`, which appended a fresh legacy `python3 '<mp>' quality-cache --quiet` group. Result: `quality-cache` ran **twice per prompt** (re-introducing a slice of the per-prompt blocking cost #139 removed), and the duplicate was un-removable because the next `SessionStart` re-added it.

## Fix
Add two helpers, `_command_drives_quality_cache(command)` and `_quality_cache_hook_present(groups)`, that recognize **both** the legacy standalone hook and the #139 consolidated dispatcher (marker: `userpromptsubmit_runner.py`). Route all three detection sites through them, so an install whose canonical #139 hook is already present is recognized as "installed" and no legacy hook is appended.

The `setup-quality-bar --uninstall` path is deliberately left matching only `quality-cache`, so it strips the legacy add-on hook without ever removing the legitimate #139 dispatcher (which carries the other UserPromptSubmit subcommands).

## Tests
- New `tests/test_ensure_health_quality_cache_155.py` (6 cases): with the #139 dispatcher already installed, the hook is recognized (`_is_quality_bar_installed` + plugin-cache fallback) and `setup_quality_bar` does **not** re-add a legacy hook. Pins the premise that the dispatcher command has no `quality-cache` substring.
- Full existing suite: **1519 passed, 13 skipped, 0 failed**.
- `plugins/` and `cowork/` mirrors regenerated via the canonical sync scripts; `check-mirror-sync.sh` and `test_cowork_committed_plugin.py` green.

## Note on the cowork README change
`cowork_install.py --emit-committed` (the only supported regen path, required by the anti-drift test) also refreshed `cowork/token-optimizer/README.md`. That mirror was already stale on `main`: #156 updated the root README (BoostGraph scoping) without regenerating the cowork mirror. The refresh is unrelated to the hook logic and rides along because the generator rebuilds the whole tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmE9PrVMmmCBCbse8Uuap6
