### PR TITLE
fix(dashboard): heal HTML off the hook budget so the daemon-script update always runs

### DIFF
--- a/cowork/token-optimizer/README.md
+++ b/cowork/token-optimizer/README.md
@@ -210,8 +210,7 @@ These ten rows are the ones where Token Optimizer is the only 🟢 in the row: w
 
 |  | Token Optimizer | Headroom | RTK | Boost | context-mode | `/context` |
 |---|---|---|---|---|---|---|
-| Compaction survival | 🟢 Progressive checkpoints, restore, tool output digest | 🔴 | 🔴 | — | 🟡 Session guide only | 🔴 |
-| Session continuity | 🟢 Cross-session hints, cold-resume, checkpoint scoring | 🔴 | 🔴 | — | 🟡 Session guide | 🔴 |
+| Session continuity | 🟢 Progressive checkpoints before compaction + restore after, cross-session hints, cold-resume, tool-output digest; measured ~3.9M tokens / ~$19 recovered in a 30-day snapshot (checkpoint restores + lean resumes) | 🔴 | 🔴 | — | 🟡 Session guide only | 🔴 |
 | Structural waste audit | 🟢 Deep per-component (CLAUDE.md, skills, MCP, memory) | 🔴 | 🔴 | 🔴 | 🔴 | 🟡 Summary only |
 | CLAUDE.md and MEMORY.md health | 🟢 8 auditors + attention-curve scoring | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 |
 | Model routing and behavioral coaching | 🟢 12 detectors, subagent cost breakdown, anti-patterns | 🔴 | 🔴 | — | 🔴 | 🟡 Basic suggestions |
@@ -237,11 +236,11 @@ These ten rows are the ones where Token Optimizer is the only 🟢 in the row: w
 | Multi-platform | 🟢 Claude Code, VS Code, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15 integrations | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17 integrations | 🔴 Claude Code only |
 | Per-task model and effort advice | 🟢 `route` sizes the task before you spend | — | — | — | — | — |
 | Keep-Warm (cache TTL refresh) | 🟢 Opt-in ping before cache expiry, tripwire auto-off | 🔴 | 🔴 | — | 🔴 | 🔴 |
-| End-to-end task-outcome benchmark | 🔴 Output-token A/B only | — | — | 🟢 Vendor reports Terminal-Bench 2.0 with the same pass rate and ~12% lower cost | — | N/A |
+| End-to-end task-outcome benchmark | 🟡 Controlled A/B on 7 real tasks (output tokens) + measured real-session with/without savings; pass-rate study not yet run | — | — | 🟢 Vendor reports Terminal-Bench 2.0 with the same pass rate and ~12% lower cost | — | N/A |
 | Signed and checksum-verified install | 🟢 `CHECKSUMS.sha256` per release, verified at install, CI-enforced | — | — | 🔴 Installer verifies neither a checksum nor a signature | — | N/A |
 
 </details>
-An em dash means the capability was not verified from first-party material in the 2026-07-26 source audit; it is not a claim that the capability is absent. Boost's "pre-shell" and "shell-level" cells are sourced from its documented wrapper form (`boost <command>`); the mechanism `boost init` uses to wire an agent is not described in its first-party material. Token Optimizer's compression claims are tested against real sessions and an 87-fixture suite you can run yourself. **[Full benchmark methodology and results →](BENCHMARK.md)**
+An em dash means the capability was not verified from first-party material in the 2026-07-26 source audit (Boost's first-party material re-verified 2026-08-26); it is not a claim that the capability is absent. This page scores command-output compression only; JFrog Boost's separately-shipped BoostGraph, a local code-map its agent queries on request, is a different capability and out of scope here. Boost's "pre-shell" and "shell-level" cells are sourced from its documented wrapper form (`boost <command>`); the mechanism `boost init` uses to wire an agent is not described in its first-party material. Token Optimizer's compression claims are tested against real sessions and an 87-fixture suite you can run yourself. **[Full benchmark methodology and results →](BENCHMARK.md)**
 
 <p align="center">
   <a href="https://alexgreensh.github.io/token-optimizer/reference/comparison/"><img src="https://img.shields.io/badge/Read%20the%20official%20full%20comparison-in%20our%20docs-0b7285?style=for-the-badge" alt="Read the official full comparison page in our documentation"></a>

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6524,7 +6524,7 @@ def _dispatch_collect(args):
             pass
 
 
-def _spawn_detached_dashboard_selfheal(days=30):
+def _spawn_detached_dashboard_selfheal(days=30, force=False):
     """Rebuild the dashboard in a DETACHED, unbounded background process.
 
     Bug B self-heal: when a bounded hook-path regen is killed by the 20s budget
@@ -6539,6 +6539,12 @@ def _spawn_detached_dashboard_selfheal(days=30):
       * is quiet and never opens a browser.
     The child is unbounded, so it cannot itself time out and re-spawn -- no loop.
     Fire-and-forget; never raises (a failed self-heal must not break the hook).
+
+    ``force`` appends ``--force`` so the child bypasses the 60s write throttle.
+    Used by the version-bump self-heal: a stale file written seconds ago by a
+    just-killed regen must not throttle-skip the heal. The PR #154 version guard
+    still applies inside generate_standalone_dashboard (force governs the throttle,
+    not version precedence), so a forced heal never clobbers a newer dashboard.
     """
     try:
         env = dict(os.environ)
@@ -6547,13 +6553,16 @@ def _spawn_detached_dashboard_selfheal(days=30):
         # Detach so the child outlives the killed hook: POSIX new session, or
         # (on Windows) DETACHED_PROCESS. start_new_session is POSIX-only.
         popen_kw = {} if os.name == "nt" else {"start_new_session": True}
+        argv = [sys.executable, os.path.abspath(__file__),
+                "dashboard", "--quiet", "--days", str(int(days))]
+        if force:
+            argv.append("--force")
         # creationflags MUST be inlined and mention _NO_WINDOW (CREATE_NO_WINDOW,
         # 0 off-Windows) so a console-less Windows host never flashes a cmd window
         # -- and so the spawn-site invariant test can see it. DETACHED_PROCESS is 0
         # off-Windows, so this evaluates to 0 on POSIX (the only valid value there).
         subprocess.Popen(
-            [sys.executable, os.path.abspath(__file__),
-             "dashboard", "--quiet", "--days", str(int(days))],
+            argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -6599,6 +6608,10 @@ def _dispatch_dashboard(args):
     if not cp:
         days = 30
         quiet = "--quiet" in args or "-q" in args
+        # --force bypasses the 60s write throttle. The detached version-bump
+        # self-heal passes it so a stale file just written by a killed regen
+        # cannot throttle-skip the heal (the PR #154 version guard still applies).
+        force = "--force" in args
         for i, a in enumerate(args):
             if a == "--days" and i + 1 < len(args):
                 try:
@@ -6610,7 +6623,7 @@ def _dispatch_dashboard(args):
         )
         timed_out = False
         try:
-            out = generate_standalone_dashboard(days=days, quiet=quiet)
+            out = generate_standalone_dashboard(days=days, quiet=quiet, force=force)
         except _HookTimeout:
             out = None
             timed_out = True
@@ -21115,22 +21128,48 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             _regen_inflight = True
             try:
                 for step in ("collect", "dashboard"):
-                    r = subprocess.run(
-                        [sys.executable, target, step, "--quiet"],
-                        capture_output=True, text=True, timeout=REGEN_STEP_TIMEOUT,
-                        creationflags=_NO_WINDOW,
-                        # A human pressed Regenerate and is waiting: mark it
-                        # INTERACTIVE so the child is not killed by the 20s hook
-                        # budget (Bug B). The daemon's own REGEN_STEP_TIMEOUT is
-                        # the real, saner cap here.
-                        env={{**os.environ, "TOKEN_OPTIMIZER_INTERACTIVE": "1"}},
-                    )
+                    # A human pressed Regenerate: the "dashboard" step MUST carry
+                    # --force so the 60s write throttle can never silently no-op the
+                    # click into serving the same stale file (the very ambiguity that
+                    # let a two-day-old dashboard look freshly regenerated). collect
+                    # has no such throttle, so it needs no flag.
+                    argv = [sys.executable, target, step, "--quiet"]
+                    if step == "dashboard":
+                        argv.append("--force")
+                    # Retry ONCE on an intermittent hang (observed live: lock
+                    # contention makes the normally-~9s build blow past a single
+                    # REGEN_STEP_TIMEOUT shot), with a doubled cap on the retry,
+                    # rather than failing the whole click on one timed attempt.
+                    r = None
+                    _timeout_exc = None
+                    for _attempt in range(2):
+                        _to = REGEN_STEP_TIMEOUT if _attempt == 0 else REGEN_STEP_TIMEOUT * 2
+                        try:
+                            r = subprocess.run(
+                                argv,
+                                capture_output=True, text=True, timeout=_to,
+                                creationflags=_NO_WINDOW,
+                                # A human pressed Regenerate and is waiting: mark it
+                                # INTERACTIVE so the child is not killed by the 20s
+                                # hook budget (Bug B). The daemon's own per-attempt
+                                # timeout is the real, saner cap here.
+                                env={{**os.environ, "TOKEN_OPTIMIZER_INTERACTIVE": "1"}},
+                            )
+                            _timeout_exc = None
+                            break
+                        except subprocess.TimeoutExpired as _te:
+                            _timeout_exc = _te
+                            _log_regen("MANUAL regen %s timed out after %d seconds (attempt %d/2)" % (step, _to, _attempt + 1))
+                    if _timeout_exc is not None:
+                        _log_regen("MANUAL regen error: %s" % _timeout_exc)
+                        self._json_response(500, {{"ok": False, "step": step, "msg": "regeneration timed out: " + str(_timeout_exc)}})
+                        return
                     if r.returncode != 0:
                         msg = (r.stderr or r.stdout or "").strip()[:300] or ("%s exited %d" % (step, r.returncode))
                         _log_regen("MANUAL regen failed at %s: %s" % (step, msg))
                         self._json_response(500, {{"ok": False, "step": step, "msg": msg}})
                         return
-            except (subprocess.TimeoutExpired, OSError) as e:
+            except OSError as e:
                 _log_regen("MANUAL regen error: %s" % e)
                 self._json_response(500, {{"ok": False, "msg": "regeneration failed: " + str(e)}})
                 return
@@ -39116,9 +39155,22 @@ def run_ensure_health():
                 except OSError:
                     _fresh = False
             if not _fresh:
+                # Hand the ~9s rebuild to a DETACHED, unbounded, FORCED child
+                # instead of running it in-process. run_ensure_health() runs under
+                # an 8s SIGALRM budget (see the ensure-health dispatch), and this
+                # rebuild is ~9s, so an in-process call reliably tripped
+                # _HookTimeout (a BaseException the local `except Exception` cannot
+                # catch). That aborted the WHOLE ensure-health tick BEFORE the
+                # daemon-script auto-update block below ever ran -- so on a version
+                # bump both the HTML AND the daemon script stayed stale, and unlike
+                # the CLI dashboard path there was no detached-child fallback here
+                # to ever catch the HTML up. The detached child finishes the forced
+                # rebuild off the hot path (re-reading a now-healthy meter, which
+                # clears the runway placeholder), and this cheap spawn returns at
+                # once so execution always reaches the daemon-script update.
                 try:
-                    generate_standalone_dashboard(quiet=True, force=True)
-                    print(f"  [Token Optimizer] Refreshed dashboard to v{TOKEN_OPTIMIZER_VERSION}")
+                    _spawn_detached_dashboard_selfheal(days=30, force=True)
+                    print(f"  [Token Optimizer] Refreshing dashboard to v{TOKEN_OPTIMIZER_VERSION} in the background")
                 except Exception as _e:
                     print(f"  [Token Optimizer] dashboard refresh failed: {_e}", file=sys.stderr)
     except Exception as _e:

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6524,7 +6524,7 @@ def _dispatch_collect(args):
             pass
 
 
-def _spawn_detached_dashboard_selfheal(days=30):
+def _spawn_detached_dashboard_selfheal(days=30, force=False):
     """Rebuild the dashboard in a DETACHED, unbounded background process.
 
     Bug B self-heal: when a bounded hook-path regen is killed by the 20s budget
@@ -6539,6 +6539,12 @@ def _spawn_detached_dashboard_selfheal(days=30):
       * is quiet and never opens a browser.
     The child is unbounded, so it cannot itself time out and re-spawn -- no loop.
     Fire-and-forget; never raises (a failed self-heal must not break the hook).
+
+    ``force`` appends ``--force`` so the child bypasses the 60s write throttle.
+    Used by the version-bump self-heal: a stale file written seconds ago by a
+    just-killed regen must not throttle-skip the heal. The PR #154 version guard
+    still applies inside generate_standalone_dashboard (force governs the throttle,
+    not version precedence), so a forced heal never clobbers a newer dashboard.
     """
     try:
         env = dict(os.environ)
@@ -6547,13 +6553,16 @@ def _spawn_detached_dashboard_selfheal(days=30):
         # Detach so the child outlives the killed hook: POSIX new session, or
         # (on Windows) DETACHED_PROCESS. start_new_session is POSIX-only.
         popen_kw = {} if os.name == "nt" else {"start_new_session": True}
+        argv = [sys.executable, os.path.abspath(__file__),
+                "dashboard", "--quiet", "--days", str(int(days))]
+        if force:
+            argv.append("--force")
         # creationflags MUST be inlined and mention _NO_WINDOW (CREATE_NO_WINDOW,
         # 0 off-Windows) so a console-less Windows host never flashes a cmd window
         # -- and so the spawn-site invariant test can see it. DETACHED_PROCESS is 0
         # off-Windows, so this evaluates to 0 on POSIX (the only valid value there).
         subprocess.Popen(
-            [sys.executable, os.path.abspath(__file__),
-             "dashboard", "--quiet", "--days", str(int(days))],
+            argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -6599,6 +6608,10 @@ def _dispatch_dashboard(args):
     if not cp:
         days = 30
         quiet = "--quiet" in args or "-q" in args
+        # --force bypasses the 60s write throttle. The detached version-bump
+        # self-heal passes it so a stale file just written by a killed regen
+        # cannot throttle-skip the heal (the PR #154 version guard still applies).
+        force = "--force" in args
         for i, a in enumerate(args):
             if a == "--days" and i + 1 < len(args):
                 try:
@@ -6610,7 +6623,7 @@ def _dispatch_dashboard(args):
         )
         timed_out = False
         try:
-            out = generate_standalone_dashboard(days=days, quiet=quiet)
+            out = generate_standalone_dashboard(days=days, quiet=quiet, force=force)
         except _HookTimeout:
             out = None
             timed_out = True
@@ -21115,22 +21128,48 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             _regen_inflight = True
             try:
                 for step in ("collect", "dashboard"):
-                    r = subprocess.run(
-                        [sys.executable, target, step, "--quiet"],
-                        capture_output=True, text=True, timeout=REGEN_STEP_TIMEOUT,
-                        creationflags=_NO_WINDOW,
-                        # A human pressed Regenerate and is waiting: mark it
-                        # INTERACTIVE so the child is not killed by the 20s hook
-                        # budget (Bug B). The daemon's own REGEN_STEP_TIMEOUT is
-                        # the real, saner cap here.
-                        env={{**os.environ, "TOKEN_OPTIMIZER_INTERACTIVE": "1"}},
-                    )
+                    # A human pressed Regenerate: the "dashboard" step MUST carry
+                    # --force so the 60s write throttle can never silently no-op the
+                    # click into serving the same stale file (the very ambiguity that
+                    # let a two-day-old dashboard look freshly regenerated). collect
+                    # has no such throttle, so it needs no flag.
+                    argv = [sys.executable, target, step, "--quiet"]
+                    if step == "dashboard":
+                        argv.append("--force")
+                    # Retry ONCE on an intermittent hang (observed live: lock
+                    # contention makes the normally-~9s build blow past a single
+                    # REGEN_STEP_TIMEOUT shot), with a doubled cap on the retry,
+                    # rather than failing the whole click on one timed attempt.
+                    r = None
+                    _timeout_exc = None
+                    for _attempt in range(2):
+                        _to = REGEN_STEP_TIMEOUT if _attempt == 0 else REGEN_STEP_TIMEOUT * 2
+                        try:
+                            r = subprocess.run(
+                                argv,
+                                capture_output=True, text=True, timeout=_to,
+                                creationflags=_NO_WINDOW,
+                                # A human pressed Regenerate and is waiting: mark it
+                                # INTERACTIVE so the child is not killed by the 20s
+                                # hook budget (Bug B). The daemon's own per-attempt
+                                # timeout is the real, saner cap here.
+                                env={{**os.environ, "TOKEN_OPTIMIZER_INTERACTIVE": "1"}},
+                            )
+                            _timeout_exc = None
+                            break
+                        except subprocess.TimeoutExpired as _te:
+                            _timeout_exc = _te
+                            _log_regen("MANUAL regen %s timed out after %d seconds (attempt %d/2)" % (step, _to, _attempt + 1))
+                    if _timeout_exc is not None:
+                        _log_regen("MANUAL regen error: %s" % _timeout_exc)
+                        self._json_response(500, {{"ok": False, "step": step, "msg": "regeneration timed out: " + str(_timeout_exc)}})
+                        return
                     if r.returncode != 0:
                         msg = (r.stderr or r.stdout or "").strip()[:300] or ("%s exited %d" % (step, r.returncode))
                         _log_regen("MANUAL regen failed at %s: %s" % (step, msg))
                         self._json_response(500, {{"ok": False, "step": step, "msg": msg}})
                         return
-            except (subprocess.TimeoutExpired, OSError) as e:
+            except OSError as e:
                 _log_regen("MANUAL regen error: %s" % e)
                 self._json_response(500, {{"ok": False, "msg": "regeneration failed: " + str(e)}})
                 return
@@ -39116,9 +39155,22 @@ def run_ensure_health():
                 except OSError:
                     _fresh = False
             if not _fresh:
+                # Hand the ~9s rebuild to a DETACHED, unbounded, FORCED child
+                # instead of running it in-process. run_ensure_health() runs under
+                # an 8s SIGALRM budget (see the ensure-health dispatch), and this
+                # rebuild is ~9s, so an in-process call reliably tripped
+                # _HookTimeout (a BaseException the local `except Exception` cannot
+                # catch). That aborted the WHOLE ensure-health tick BEFORE the
+                # daemon-script auto-update block below ever ran -- so on a version
+                # bump both the HTML AND the daemon script stayed stale, and unlike
+                # the CLI dashboard path there was no detached-child fallback here
+                # to ever catch the HTML up. The detached child finishes the forced
+                # rebuild off the hot path (re-reading a now-healthy meter, which
+                # clears the runway placeholder), and this cheap spawn returns at
+                # once so execution always reaches the daemon-script update.
                 try:
-                    generate_standalone_dashboard(quiet=True, force=True)
-                    print(f"  [Token Optimizer] Refreshed dashboard to v{TOKEN_OPTIMIZER_VERSION}")
+                    _spawn_detached_dashboard_selfheal(days=30, force=True)
+                    print(f"  [Token Optimizer] Refreshing dashboard to v{TOKEN_OPTIMIZER_VERSION} in the background")
                 except Exception as _e:
                     print(f"  [Token Optimizer] dashboard refresh failed: {_e}", file=sys.stderr)
     except Exception as _e:

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -6524,7 +6524,7 @@ def _dispatch_collect(args):
             pass
 
 
-def _spawn_detached_dashboard_selfheal(days=30):
+def _spawn_detached_dashboard_selfheal(days=30, force=False):
     """Rebuild the dashboard in a DETACHED, unbounded background process.
 
     Bug B self-heal: when a bounded hook-path regen is killed by the 20s budget
@@ -6539,6 +6539,12 @@ def _spawn_detached_dashboard_selfheal(days=30):
       * is quiet and never opens a browser.
     The child is unbounded, so it cannot itself time out and re-spawn -- no loop.
     Fire-and-forget; never raises (a failed self-heal must not break the hook).
+
+    ``force`` appends ``--force`` so the child bypasses the 60s write throttle.
+    Used by the version-bump self-heal: a stale file written seconds ago by a
+    just-killed regen must not throttle-skip the heal. The PR #154 version guard
+    still applies inside generate_standalone_dashboard (force governs the throttle,
+    not version precedence), so a forced heal never clobbers a newer dashboard.
     """
     try:
         env = dict(os.environ)
@@ -6547,13 +6553,16 @@ def _spawn_detached_dashboard_selfheal(days=30):
         # Detach so the child outlives the killed hook: POSIX new session, or
         # (on Windows) DETACHED_PROCESS. start_new_session is POSIX-only.
         popen_kw = {} if os.name == "nt" else {"start_new_session": True}
+        argv = [sys.executable, os.path.abspath(__file__),
+                "dashboard", "--quiet", "--days", str(int(days))]
+        if force:
+            argv.append("--force")
         # creationflags MUST be inlined and mention _NO_WINDOW (CREATE_NO_WINDOW,
         # 0 off-Windows) so a console-less Windows host never flashes a cmd window
         # -- and so the spawn-site invariant test can see it. DETACHED_PROCESS is 0
         # off-Windows, so this evaluates to 0 on POSIX (the only valid value there).
         subprocess.Popen(
-            [sys.executable, os.path.abspath(__file__),
-             "dashboard", "--quiet", "--days", str(int(days))],
+            argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -6599,6 +6608,10 @@ def _dispatch_dashboard(args):
     if not cp:
         days = 30
         quiet = "--quiet" in args or "-q" in args
+        # --force bypasses the 60s write throttle. The detached version-bump
+        # self-heal passes it so a stale file just written by a killed regen
+        # cannot throttle-skip the heal (the PR #154 version guard still applies).
+        force = "--force" in args
         for i, a in enumerate(args):
             if a == "--days" and i + 1 < len(args):
                 try:
@@ -6610,7 +6623,7 @@ def _dispatch_dashboard(args):
         )
         timed_out = False
         try:
-            out = generate_standalone_dashboard(days=days, quiet=quiet)
+            out = generate_standalone_dashboard(days=days, quiet=quiet, force=force)
         except _HookTimeout:
             out = None
             timed_out = True
@@ -21115,22 +21128,48 @@ class Handler(http.server.SimpleHTTPRequestHandler):
             _regen_inflight = True
             try:
                 for step in ("collect", "dashboard"):
-                    r = subprocess.run(
-                        [sys.executable, target, step, "--quiet"],
-                        capture_output=True, text=True, timeout=REGEN_STEP_TIMEOUT,
-                        creationflags=_NO_WINDOW,
-                        # A human pressed Regenerate and is waiting: mark it
-                        # INTERACTIVE so the child is not killed by the 20s hook
-                        # budget (Bug B). The daemon's own REGEN_STEP_TIMEOUT is
-                        # the real, saner cap here.
-                        env={{**os.environ, "TOKEN_OPTIMIZER_INTERACTIVE": "1"}},
-                    )
+                    # A human pressed Regenerate: the "dashboard" step MUST carry
+                    # --force so the 60s write throttle can never silently no-op the
+                    # click into serving the same stale file (the very ambiguity that
+                    # let a two-day-old dashboard look freshly regenerated). collect
+                    # has no such throttle, so it needs no flag.
+                    argv = [sys.executable, target, step, "--quiet"]
+                    if step == "dashboard":
+                        argv.append("--force")
+                    # Retry ONCE on an intermittent hang (observed live: lock
+                    # contention makes the normally-~9s build blow past a single
+                    # REGEN_STEP_TIMEOUT shot), with a doubled cap on the retry,
+                    # rather than failing the whole click on one timed attempt.
+                    r = None
+                    _timeout_exc = None
+                    for _attempt in range(2):
+                        _to = REGEN_STEP_TIMEOUT if _attempt == 0 else REGEN_STEP_TIMEOUT * 2
+                        try:
+                            r = subprocess.run(
+                                argv,
+                                capture_output=True, text=True, timeout=_to,
+                                creationflags=_NO_WINDOW,
+                                # A human pressed Regenerate and is waiting: mark it
+                                # INTERACTIVE so the child is not killed by the 20s
+                                # hook budget (Bug B). The daemon's own per-attempt
+                                # timeout is the real, saner cap here.
+                                env={{**os.environ, "TOKEN_OPTIMIZER_INTERACTIVE": "1"}},
+                            )
+                            _timeout_exc = None
+                            break
+                        except subprocess.TimeoutExpired as _te:
+                            _timeout_exc = _te
+                            _log_regen("MANUAL regen %s timed out after %d seconds (attempt %d/2)" % (step, _to, _attempt + 1))
+                    if _timeout_exc is not None:
+                        _log_regen("MANUAL regen error: %s" % _timeout_exc)
+                        self._json_response(500, {{"ok": False, "step": step, "msg": "regeneration timed out: " + str(_timeout_exc)}})
+                        return
                     if r.returncode != 0:
                         msg = (r.stderr or r.stdout or "").strip()[:300] or ("%s exited %d" % (step, r.returncode))
                         _log_regen("MANUAL regen failed at %s: %s" % (step, msg))
                         self._json_response(500, {{"ok": False, "step": step, "msg": msg}})
                         return
-            except (subprocess.TimeoutExpired, OSError) as e:
+            except OSError as e:
                 _log_regen("MANUAL regen error: %s" % e)
                 self._json_response(500, {{"ok": False, "msg": "regeneration failed: " + str(e)}})
                 return
@@ -39116,9 +39155,22 @@ def run_ensure_health():
                 except OSError:
                     _fresh = False
             if not _fresh:
+                # Hand the ~9s rebuild to a DETACHED, unbounded, FORCED child
+                # instead of running it in-process. run_ensure_health() runs under
+                # an 8s SIGALRM budget (see the ensure-health dispatch), and this
+                # rebuild is ~9s, so an in-process call reliably tripped
+                # _HookTimeout (a BaseException the local `except Exception` cannot
+                # catch). That aborted the WHOLE ensure-health tick BEFORE the
+                # daemon-script auto-update block below ever ran -- so on a version
+                # bump both the HTML AND the daemon script stayed stale, and unlike
+                # the CLI dashboard path there was no detached-child fallback here
+                # to ever catch the HTML up. The detached child finishes the forced
+                # rebuild off the hot path (re-reading a now-healthy meter, which
+                # clears the runway placeholder), and this cheap spawn returns at
+                # once so execution always reaches the daemon-script update.
                 try:
-                    generate_standalone_dashboard(quiet=True, force=True)
-                    print(f"  [Token Optimizer] Refreshed dashboard to v{TOKEN_OPTIMIZER_VERSION}")
+                    _spawn_detached_dashboard_selfheal(days=30, force=True)
+                    print(f"  [Token Optimizer] Refreshing dashboard to v{TOKEN_OPTIMIZER_VERSION} in the background")
                 except Exception as _e:
                     print(f"  [Token Optimizer] dashboard refresh failed: {_e}", file=sys.stderr)
     except Exception as _e:

--- a/tests/test_dashboard_version_selfheal.py
+++ b/tests/test_dashboard_version_selfheal.py
@@ -1,0 +1,260 @@
+"""Version-bump dashboard/daemon self-heal must not strand the runway placeholder.
+
+ROOT CAUSE (compound). ``run_ensure_health()`` runs under an 8s SIGALRM hook
+budget (``_install_hook_budget(8)`` in the ensure-health dispatch). Its stale-HTML
+self-heal used to rebuild the dashboard IN-PROCESS via
+``generate_standalone_dashboard(quiet=True, force=True)`` -- a ~9s build that
+reliably tripped ``_HookTimeout`` (a ``BaseException`` the local ``except
+Exception`` cannot catch). That aborted the WHOLE ensure-health tick BEFORE the
+daemon-script auto-update block ran, so on a version bump BOTH the HTML and the
+daemon script stayed stale. And unlike the CLI ``dashboard`` path, the in-process
+call had no detached-child fallback to ever catch the HTML up. The runway card
+then kept serving the "Your live 5-hour and weekly limit view refreshes while you
+are actively working..." placeholder even though the live meter was healthy.
+
+FIX (class-level). The stale-HTML self-heal now hands the forced rebuild to the
+existing DETACHED, unbounded child (``_spawn_detached_dashboard_selfheal(force=
+True)``); the cheap spawn returns at once, so the daemon-script auto-update below
+is always reached (both heal). The daemon's synchronous ``api/regenerate`` also
+forces past the 60s write throttle and retries once on a hang instead of failing
+on a single ``REGEN_STEP_TIMEOUT`` shot.
+
+These tests fail at edit time if the fix is reverted or weakened, which is the
+recurrence that matters -- this dashboard bug has been "fixed" by symptom patches
+several times. Where there is no JS/subprocess runtime in the harness, the
+contract is asserted against the shipped source text (the same approach
+test_runway_card_wiring.py / test_dashboard_regen_retry.py take).
+
+Run: python3 -m pytest tests/test_dashboard_version_selfheal.py -v
+"""
+import importlib
+import inspect
+import sqlite3
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "skills" / "token-optimizer" / "scripts"
+ASSET = REPO / "skills" / "token-optimizer" / "assets" / "dashboard.html"
+
+PLACEHOLDER = "Your live 5-hour and weekly limit view refreshes"
+
+
+@pytest.fixture()
+def m(monkeypatch):
+    tmp = tempfile.mkdtemp(prefix="to-version-selfheal-")
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", tmp)
+    sys.path.insert(0, str(SCRIPTS))
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    importlib.reload(mod)
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+# --------------------------------------------------------------------------
+# 1. The detached self-heal learns --force WITHOUT changing its default argv.
+# --------------------------------------------------------------------------
+
+def test_selfheal_default_argv_is_unchanged(m, monkeypatch):
+    """The Bug B invariant still holds: the DEFAULT spawn carries no --force, so
+    the existing detached-child contract (test_dashboard_selfheal_bugB) is intact.
+    """
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, argv, **kw):
+            captured["argv"] = argv
+
+    monkeypatch.setattr(m.subprocess, "Popen", _FakePopen)
+    m._spawn_detached_dashboard_selfheal(days=30)
+    assert captured["argv"][1:] == [
+        m.os.path.abspath(m.__file__), "dashboard", "--quiet", "--days", "30"
+    ]
+    assert "--force" not in captured["argv"]
+
+
+def test_selfheal_force_appends_force_flag(m, monkeypatch):
+    """force=True appends --force so the child bypasses the 60s write throttle --
+    the version-bump heal must not throttle-skip on a stale file a killed regen
+    just wrote."""
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, argv, **kw):
+            captured["argv"] = argv
+
+    monkeypatch.setattr(m.subprocess, "Popen", _FakePopen)
+    m._spawn_detached_dashboard_selfheal(days=30, force=True)
+    assert captured["argv"][-1] == "--force"
+    assert captured["argv"][1:] == [
+        m.os.path.abspath(m.__file__), "dashboard", "--quiet", "--days", "30", "--force"
+    ]
+
+
+# --------------------------------------------------------------------------
+# 2. The dashboard CLI threads --force into generate_standalone_dashboard.
+# --------------------------------------------------------------------------
+
+def _run_dispatch(m, monkeypatch, args):
+    seen = {}
+
+    def _fake_gen(days=30, quiet=False, force=False):
+        seen["force"] = force
+        seen["quiet"] = quiet
+        return "/tmp/dash.html"
+
+    monkeypatch.setattr(m, "generate_standalone_dashboard", _fake_gen)
+    monkeypatch.setattr(m, "_running_under_hook", lambda: False)
+    monkeypatch.setattr(m, "_open_dashboard", lambda **k: None)
+    with pytest.raises(SystemExit):
+        m._dispatch_dashboard(args)
+    return seen
+
+
+def test_dispatch_dashboard_threads_force(m, monkeypatch):
+    seen = _run_dispatch(m, monkeypatch, ["--quiet", "--force"])
+    assert seen["force"] is True
+
+
+def test_dispatch_dashboard_defaults_to_no_force(m, monkeypatch):
+    seen = _run_dispatch(m, monkeypatch, ["--quiet"])
+    assert seen["force"] is False
+
+
+# --------------------------------------------------------------------------
+# 3. ensure-health: stale HTML heal is detached+forced, NOT in-process, and the
+#    daemon-script auto-update block follows it (so the fast spawn guarantees the
+#    daemon update is reached -- the compound-strand regression guard).
+# --------------------------------------------------------------------------
+
+def test_ensure_health_hands_html_heal_to_detached_forced_child(m):
+    src = inspect.getsource(m.run_ensure_health)
+    # The stale-HTML branch must hand off to the detached, forced child...
+    assert "_spawn_detached_dashboard_selfheal(days=30, force=True)" in src, (
+        "the stale-HTML self-heal must spawn the detached forced child, not run "
+        "the ~9s rebuild in-process under the 8s hook budget"
+    )
+    # ...and must NOT run the rebuild in-process (that is what tripped _HookTimeout
+    # and aborted the tick before the daemon-script update could run).
+    assert "generate_standalone_dashboard(quiet=True, force=True)" not in src, (
+        "the in-process forced regen is the compound-strand bug; it must be gone"
+    )
+
+
+def test_ensure_health_daemon_update_runs_after_html_heal(m):
+    """The daemon-script auto-update (version-marker check + regen) must sit AFTER
+    the HTML self-heal. With the heal now a fast detached spawn, the tick always
+    reaches the daemon update -- the block that was stranded when the in-process
+    regen blew the budget."""
+    src = inspect.getsource(m.run_ensure_health)
+    heal_at = src.index("_spawn_detached_dashboard_selfheal(days=30, force=True)")
+    daemon_at = src.index('TOKEN_OPTIMIZER_DAEMON_VERSION = "')
+    assert heal_at < daemon_at, "HTML heal must precede the daemon-script update"
+    # And the daemon update actually regenerates the script when the marker drifts.
+    assert "_generate_daemon_script()" in src
+
+
+# --------------------------------------------------------------------------
+# 4. Daemon api/regenerate: force past the throttle + retry on a hang, not a
+#    single REGEN_STEP_TIMEOUT shot.
+# --------------------------------------------------------------------------
+
+def test_daemon_regen_forces_dashboard_step_and_retries(m):
+    script = m._generate_daemon_script()
+    # The dashboard step forces past the 60s throttle so a human's Regenerate can
+    # never silently no-op into serving the same stale file.
+    assert 'argv.append("--force")' in script
+    # Retry once on an intermittent hang, with a doubled cap, instead of failing
+    # the whole click on one timed attempt.
+    assert "for _attempt in range(2)" in script
+    assert "REGEN_STEP_TIMEOUT * 2" in script
+    assert "except subprocess.TimeoutExpired" in script
+    # The generated daemon must still be valid Python.
+    import ast
+    ast.parse(script)
+
+
+# --------------------------------------------------------------------------
+# 5. The stranded placeholder IS the empty-windows state, and a healthy meter
+#    fills the windows -- so a completed forced refresh clears the placeholder.
+# --------------------------------------------------------------------------
+
+def _temp_trends(m, monkeypatch):
+    """A trends DB with real consumed + saved so the context lever is non-trivial
+    (mirrors test_runway_meter_freshness)."""
+    tmp = Path(tempfile.mkdtemp(prefix="to-version-selfheal-db-"))
+    dbp = tmp / "trends.db"
+    conn = sqlite3.connect(str(dbp))
+    conn.executescript(
+        """
+        CREATE TABLE session_log (id INTEGER PRIMARY KEY, date TEXT,
+            input_tokens INTEGER, output_tokens INTEGER);
+        CREATE TABLE savings_events (id INTEGER PRIMARY KEY, timestamp TEXT,
+            event_type TEXT, tokens_saved INTEGER);
+        CREATE TABLE compression_events (id INTEGER PRIMARY KEY, timestamp TEXT,
+            original_tokens INTEGER, compressed_tokens INTEGER, tier TEXT);
+        """
+    )
+    today = datetime.now().date().isoformat()
+    now_iso = datetime.now().isoformat()
+    conn.execute("INSERT INTO session_log(date,input_tokens,output_tokens) VALUES(?,?,?)",
+                 (today, 1_000_000, 200_000))
+    conn.execute("INSERT INTO savings_events(timestamp,event_type,tokens_saved) VALUES(?,?,?)",
+                 (now_iso, "archive", 50_000))
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(m, "_init_trends_db", lambda: sqlite3.connect(str(dbp)))
+    monkeypatch.setattr(m, "_input_rate_mix_ratio", lambda days=30: 1.4)
+
+
+def test_healthy_meter_fills_runway_windows(m, monkeypatch):
+    """A FRESH, healthy live meter yields non-empty runway windows. The dashboard
+    template renders the placeholder ONLY when the windows are empty (asserted
+    below), so a refresh that re-reads a healthy meter fills the bars and the
+    stranded placeholder cannot survive it."""
+    _temp_trends(m, monkeypatch)
+    monkeypatch.setattr(m, "_keepwarm_read_meters", lambda **k: {
+        "available": True, "stale": False, "five_hour_pct": 12.0,
+        "seven_day_pct": 10.0, "age_s": 3.0, "ts": time.time() - 3})
+    r = m.runway_snapshot(days=30)
+    assert r is not None
+    assert {w["key"] for w in r["windows"]} == {"five_hour", "seven_day"}
+
+
+def test_stale_meter_empties_windows_the_placeholder_state(m, monkeypatch):
+    """The mirror image: a meter older than every window empties the windows list.
+    That empty-windows state is exactly what the template renders as the
+    placeholder -- so a dashboard generated while the meter was stale strands the
+    placeholder until a refresh with a fresh meter (the fix) rebuilds it."""
+    _temp_trends(m, monkeypatch)
+    # age_s beyond the 7d span (168h) -> both windows are dropped as reset.
+    monkeypatch.setattr(m, "_keepwarm_read_meters", lambda **k: {
+        "available": True, "stale": True, "five_hour_pct": 12.0,
+        "seven_day_pct": 10.0, "age_s": 200 * 3600, "ts": time.time() - 200 * 3600})
+    r = m.runway_snapshot(days=30)
+    # Card still exists (headline multiplier from the ledger) but has no windows,
+    # which is the placeholder branch.
+    assert r is not None
+    assert r["windows"] == []
+
+
+def test_placeholder_is_strictly_the_empty_windows_branch():
+    """Source contract: the placeholder text appears exactly once in the shipped
+    dashboard, as the else-branch of ``rwCards ? <bars> : <placeholder>``, and
+    ``rwCards`` is built from ``rw.windows``. So whenever the injected runway
+    carries windows, the bars render and the placeholder cannot show -- tying the
+    functional tests above to what the user actually sees."""
+    html = ASSET.read_text(encoding="utf-8")
+    assert html.count(PLACEHOLDER) == 1
+    idx = html.index(PLACEHOLDER)
+    window = html[idx - 400:idx]
+    assert "rwCards" in window and "?" in window, "placeholder must be the rwCards ternary else-branch"
+    assert "rw.windows.map(" in html, "rwCards must derive from rw.windows"


### PR DESCRIPTION
## Problem

The dashboard's runway card ("Your plan goes further") kept showing the placeholder

> Your live 5-hour and weekly limit view refreshes while you are actively working — it reappears here on your next session

instead of the real 5h/7d rate-limit savings, and it did **not** self-heal after a plugin upgrade — even though the live meter (`~/.claude/token-optimizer/rate-limits.json`) was healthy and `runway_snapshot()` returned correct windows. This "we shipped the fix but it's still broken" class has recurred several times via symptom patches.

## Root cause (compound strand, verified against current `main`)

`run_ensure_health()` (the SessionStart `ensure-health` hook) runs under an **8s** SIGALRM budget (`_install_hook_budget(8)`). Its two self-heal blocks run in order:

1. **HTML staleness heal**: on a stale sidecar it rebuilt the dashboard **in-process** via `generate_standalone_dashboard(quiet=True, force=True)`. That build is ~9s, which **exceeds the 8s budget**, so it raised `_HookTimeout` — a `BaseException` the local `except Exception` cannot catch.
2. **Daemon-script auto-update**: regenerates `dashboard-server.py` when its baked `TOKEN_OPTIMIZER_DAEMON_VERSION` marker differs from the installed version, then restarts.

Because block 1 blew the budget and `_HookTimeout` propagated, the tick aborted at the outer handler ("hook budget exceeded; skipping ensure-health tick") **before block 2 ran**. On a version bump, **both** the HTML and the daemon script stayed stale. And unlike the CLI `dashboard` path, the in-process call had **no** detached-child fallback to ever catch the HTML up. The runway card renders the placeholder exactly when the injected runway has no live windows (`dashboard.html`: `rwCards ? bars : placeholder`), the state any build captures while the meter is momentarily stale — and a static, never-rebuilt dashboard strands it.

This predates and survives PR #154 (which added a version-downgrade guard; it did not touch the ordering or the budget-bound in-process regen).

## Fix (class-level — make it incapable of staying stranded on a version change)

- **`ensure-health` hands the forced rebuild to the existing DETACHED, unbounded child** (`_spawn_detached_dashboard_selfheal`, now with `force=True`) instead of running it in-process under the budget. The cheap spawn returns at once, so the tick **always reaches the daemon-script auto-update**. The child re-reads a now-healthy meter and fills the windows, clearing the placeholder.
- **Teach the `dashboard` CLI a `--force` flag** and thread it to `generate_standalone_dashboard`, so the detached heal bypasses the 60s write throttle (a stale file a killed regen just wrote must not throttle-skip the heal). The **PR #154 version-downgrade guard still applies** — `force` governs the throttle, not version precedence — so a heal never clobbers a newer dashboard.
- **Make the daemon's synchronous `api/regenerate` robust**: force the dashboard step past the throttle (a human's Regenerate must never silently no-op into serving the same stale file) and **retry once with a doubled cap** on an intermittent lock-contention hang, instead of a single `REGEN_STEP_TIMEOUT` (45s) shot.

`measure.py` is mirrored to all three shipped copies: `plugins/` (direct copy, per `test_duplicate_script_sync`) and `cowork/` via its canonical builder `cowork_install.py --emit-committed` (per `test_cowork_committed_plugin`). The re-emit also refreshed `cowork/.../README.md`, which was already stale on `main` (PR #156 updated the root README but never re-emitted the cowork mirror), incidentally greening a pre-existing red `test_rebuild_emit_committed_leaves_git_clean`.

## Tests

New `tests/test_dashboard_version_selfheal.py` (10 tests): the detached+forced heal argv (and that the default argv is unchanged, preserving the Bug B invariant), the CLI `--force` threading, the `ensure-health` ordering (compound-strand guard — asserts the in-process regen is gone and the daemon update follows the heal), the daemon `api/regenerate` force+retry, and the healthy-vs-stale-meter → windows → placeholder chain. Verified these fail on pre-fix `main`.

**Full suite: `1523 passed, 13 skipped` (`python3 -m pytest tests/`).**

## Security Disclosure

No security-relevant changes. The daemon's localhost/token/origin defenses are untouched; the `api/regenerate` change only adds `--force` and a retry to an already-authenticated handler. The detached heal reuses the existing, security-reviewed `_spawn_detached_dashboard_selfheal` spawn path.

## Agent Disclosure

Claude Code · claude-opus-4-8 did the bulk of the work.
