### PR TITLE
Fix NameError in structure_map top-level render (triples declaration lost to a comment)

### DIFF
--- a/cowork/token-optimizer/skills/token-optimizer/scripts/structure_map.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/structure_map.py
@@ -1663,7 +1663,8 @@ def _render_top_level(
 
     # Build (label, name, lineno) triples so centrality can order symbols
     # before the MAX_TOP_LEVEL_SYMBOLS truncation, keeping the most-referenced
-    # symbols instead of the first-N-by-source-order triples: List[Tuple[str, str, int]] = []
+    # symbols instead of the first-N-by-source-order.
+    triples: List[Tuple[str, str, int]] = []
     for cls in classes:
         triples.append((f"{cls.signature} @ L{cls.lineno}", cls.name, cls.lineno))
     for func in functions:

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/structure_map.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/structure_map.py
@@ -1663,7 +1663,8 @@ def _render_top_level(
 
     # Build (label, name, lineno) triples so centrality can order symbols
     # before the MAX_TOP_LEVEL_SYMBOLS truncation, keeping the most-referenced
-    # symbols instead of the first-N-by-source-order triples: List[Tuple[str, str, int]] = []
+    # symbols instead of the first-N-by-source-order.
+    triples: List[Tuple[str, str, int]] = []
     for cls in classes:
         triples.append((f"{cls.signature} @ L{cls.lineno}", cls.name, cls.lineno))
     for func in functions:

--- a/skills/token-optimizer/scripts/structure_map.py
+++ b/skills/token-optimizer/scripts/structure_map.py
@@ -1663,7 +1663,8 @@ def _render_top_level(
 
     # Build (label, name, lineno) triples so centrality can order symbols
     # before the MAX_TOP_LEVEL_SYMBOLS truncation, keeping the most-referenced
-    # symbols instead of the first-N-by-source-order triples: List[Tuple[str, str, int]] = []
+    # symbols instead of the first-N-by-source-order.
+    triples: List[Tuple[str, str, int]] = []
     for cls in classes:
         triples.append((f"{cls.signature} @ L{cls.lineno}", cls.name, cls.lineno))
     for func in functions:


### PR DESCRIPTION
## What
In `skills/token-optimizer/scripts/structure_map.py`, the function `_render_top_level`
(defined at line 1649, called at line 1585) references a local `triples` list, but its
declaration was accidentally folded into a comment. Line 1666 reads:

```python
    # symbols instead of the first-N-by-source-order triples: List[Tuple[str, str, int]] = []
```

The `triples: List[Tuple[str, str, int]] = []` initialization is part of that comment, so
`triples.append(...)` a few lines down (1668, 1670, 1672) hits an undefined name.

## Why it matters
Any time `_render_top_level` runs on a module that has classes or functions, it raises
`NameError: name 'triples' is not defined`. Depending on the caller's error handling this
either crashes the render or silently drops the top-level symbol section from the structure
map, which is exactly the output this function exists to produce. A sibling function further
down (near line 1699) builds an equivalent `triples` list with the declaration present, so
the intended line is clear.

## How to fix
Restore the declaration on its own line, immediately before the first `triples.append`:

```python
    # Build (label, name, lineno) triples so centrality can order symbols
    # before the MAX_TOP_LEVEL_SYMBOLS truncation, keeping the most-referenced
    # symbols instead of the first-N-by-source-order.
    triples: List[Tuple[str, str, int]] = []
    for cls in classes:
        triples.append((f"{cls.signature} @ L{cls.lineno}", cls.name, cls.lineno))
    ...
```

## Repro
Call `_render_top_level` (or the public entry point at line 1585) on any source file that
defines at least one class, function, or top-level assignment. It raises `NameError` on the
first `triples.append`.
A unit test that renders a two-function module and asserts the "symbols (...)" section
appears will fail today and pass after the fix.
