### PR TITLE
Redact credentials before persisting command output AND the command line to the cross-turn dedup store

### DIFF
--- a/cowork/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
@@ -259,8 +259,9 @@ def _crossturn_dedup(command: str, output: str):
     identical case becomes a one-line note, a small change becomes just the diff.
     Reuses the (previously dormant) command_outputs store + delta_diff. The
     caller still attaches the progressive-disclosure pointer, so `expand`
-    recovers the full output even if the referenced run has scrolled out of
-    context -- the reference is self-sufficient, never a dangling pointer.
+    recovers the full (credential-redacted) output even if the referenced run
+    has scrolled out of context -- the reference is self-sufficient, never a
+    dangling pointer.
     Never raises (fail-open): any trouble returns None and normal output stands.
     """
     try:
@@ -279,10 +280,17 @@ def _crossturn_dedup(command: str, output: str):
             # archive path (archive_result._redact_credentials), so a secret in
             # command output never reaches the on-disk dedup store.
             safe_output = _redact_credentials(output)
+            # The command itself can carry inline secrets (an auth header, a
+            # -pPASSWORD, a connection string). Redact BEFORE truncating so a
+            # secret split across the 500-char cutoff can't survive, matching the
+            # archive path which redacts the command too. cmd_h stays on the raw
+            # command -- the hash is non-reversible, like out_h.
+            safe_command = _redact_credentials(command)[:500]
             prior = store.get_command_output(cmd_h)
             # Record THIS run (redacted output) for the next comparison BEFORE we
-            # return a delta, so deltas always chain off full outputs, not refs.
-            store.insert_command_output(cmd_h, command[:500], out_h, len(output), safe_output)
+            # return a delta, so deltas always chain off full (redacted) outputs,
+            # not refs.
+            store.insert_command_output(cmd_h, safe_command, out_h, len(output), safe_output)
             if not prior or not prior.get("compressed_output"):
                 return None
             # Recency guard: only reference a run from the last hour, a rough

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
@@ -269,15 +269,20 @@ def _crossturn_dedup(command: str, output: str):
             return None
         from session_store import SessionStore
         from delta_diff import content_hash, compute_delta
+        from archive_result import _redact_credentials
 
         store = SessionStore(session_id)
         try:
             cmd_h = content_hash(command.strip())
-            out_h = content_hash(output)
+            out_h = content_hash(output)  # identical-detection stays on raw bytes
+            # Redact before anything is persisted or diffed, mirroring the
+            # archive path (archive_result._redact_credentials), so a secret in
+            # command output never reaches the on-disk dedup store.
+            safe_output = _redact_credentials(output)
             prior = store.get_command_output(cmd_h)
-            # Record THIS run (full output) for the next comparison BEFORE we
+            # Record THIS run (redacted output) for the next comparison BEFORE we
             # return a delta, so deltas always chain off full outputs, not refs.
-            store.insert_command_output(cmd_h, command[:500], out_h, len(output), output)
+            store.insert_command_output(cmd_h, command[:500], out_h, len(output), safe_output)
             if not prior or not prior.get("compressed_output"):
                 return None
             # Recency guard: only reference a run from the last hour, a rough
@@ -290,7 +295,7 @@ def _crossturn_dedup(command: str, output: str):
                        f"output this session; unchanged.]")
             else:
                 delta, _stats = compute_delta(
-                    prior["compressed_output"], output, filename=label)
+                    prior["compressed_output"], safe_output, filename=label)
                 if not delta:
                     return None
                 ref = (f"[Token Optimizer: same as your previous `{label}` output "

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
@@ -259,8 +259,9 @@ def _crossturn_dedup(command: str, output: str):
     identical case becomes a one-line note, a small change becomes just the diff.
     Reuses the (previously dormant) command_outputs store + delta_diff. The
     caller still attaches the progressive-disclosure pointer, so `expand`
-    recovers the full output even if the referenced run has scrolled out of
-    context -- the reference is self-sufficient, never a dangling pointer.
+    recovers the full (credential-redacted) output even if the referenced run
+    has scrolled out of context -- the reference is self-sufficient, never a
+    dangling pointer.
     Never raises (fail-open): any trouble returns None and normal output stands.
     """
     try:
@@ -279,10 +280,17 @@ def _crossturn_dedup(command: str, output: str):
             # archive path (archive_result._redact_credentials), so a secret in
             # command output never reaches the on-disk dedup store.
             safe_output = _redact_credentials(output)
+            # The command itself can carry inline secrets (an auth header, a
+            # -pPASSWORD, a connection string). Redact BEFORE truncating so a
+            # secret split across the 500-char cutoff can't survive, matching the
+            # archive path which redacts the command too. cmd_h stays on the raw
+            # command -- the hash is non-reversible, like out_h.
+            safe_command = _redact_credentials(command)[:500]
             prior = store.get_command_output(cmd_h)
             # Record THIS run (redacted output) for the next comparison BEFORE we
-            # return a delta, so deltas always chain off full outputs, not refs.
-            store.insert_command_output(cmd_h, command[:500], out_h, len(output), safe_output)
+            # return a delta, so deltas always chain off full (redacted) outputs,
+            # not refs.
+            store.insert_command_output(cmd_h, safe_command, out_h, len(output), safe_output)
             if not prior or not prior.get("compressed_output"):
                 return None
             # Recency guard: only reference a run from the last hour, a rough

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/bash_compress_hook.py
@@ -269,15 +269,20 @@ def _crossturn_dedup(command: str, output: str):
             return None
         from session_store import SessionStore
         from delta_diff import content_hash, compute_delta
+        from archive_result import _redact_credentials
 
         store = SessionStore(session_id)
         try:
             cmd_h = content_hash(command.strip())
-            out_h = content_hash(output)
+            out_h = content_hash(output)  # identical-detection stays on raw bytes
+            # Redact before anything is persisted or diffed, mirroring the
+            # archive path (archive_result._redact_credentials), so a secret in
+            # command output never reaches the on-disk dedup store.
+            safe_output = _redact_credentials(output)
             prior = store.get_command_output(cmd_h)
-            # Record THIS run (full output) for the next comparison BEFORE we
+            # Record THIS run (redacted output) for the next comparison BEFORE we
             # return a delta, so deltas always chain off full outputs, not refs.
-            store.insert_command_output(cmd_h, command[:500], out_h, len(output), output)
+            store.insert_command_output(cmd_h, command[:500], out_h, len(output), safe_output)
             if not prior or not prior.get("compressed_output"):
                 return None
             # Recency guard: only reference a run from the last hour, a rough
@@ -290,7 +295,7 @@ def _crossturn_dedup(command: str, output: str):
                        f"output this session; unchanged.]")
             else:
                 delta, _stats = compute_delta(
-                    prior["compressed_output"], output, filename=label)
+                    prior["compressed_output"], safe_output, filename=label)
                 if not delta:
                     return None
                 ref = (f"[Token Optimizer: same as your previous `{label}` output "

--- a/skills/token-optimizer/scripts/bash_compress_hook.py
+++ b/skills/token-optimizer/scripts/bash_compress_hook.py
@@ -259,8 +259,9 @@ def _crossturn_dedup(command: str, output: str):
     identical case becomes a one-line note, a small change becomes just the diff.
     Reuses the (previously dormant) command_outputs store + delta_diff. The
     caller still attaches the progressive-disclosure pointer, so `expand`
-    recovers the full output even if the referenced run has scrolled out of
-    context -- the reference is self-sufficient, never a dangling pointer.
+    recovers the full (credential-redacted) output even if the referenced run
+    has scrolled out of context -- the reference is self-sufficient, never a
+    dangling pointer.
     Never raises (fail-open): any trouble returns None and normal output stands.
     """
     try:
@@ -279,10 +280,17 @@ def _crossturn_dedup(command: str, output: str):
             # archive path (archive_result._redact_credentials), so a secret in
             # command output never reaches the on-disk dedup store.
             safe_output = _redact_credentials(output)
+            # The command itself can carry inline secrets (an auth header, a
+            # -pPASSWORD, a connection string). Redact BEFORE truncating so a
+            # secret split across the 500-char cutoff can't survive, matching the
+            # archive path which redacts the command too. cmd_h stays on the raw
+            # command -- the hash is non-reversible, like out_h.
+            safe_command = _redact_credentials(command)[:500]
             prior = store.get_command_output(cmd_h)
             # Record THIS run (redacted output) for the next comparison BEFORE we
-            # return a delta, so deltas always chain off full outputs, not refs.
-            store.insert_command_output(cmd_h, command[:500], out_h, len(output), safe_output)
+            # return a delta, so deltas always chain off full (redacted) outputs,
+            # not refs.
+            store.insert_command_output(cmd_h, safe_command, out_h, len(output), safe_output)
             if not prior or not prior.get("compressed_output"):
                 return None
             # Recency guard: only reference a run from the last hour, a rough

--- a/skills/token-optimizer/scripts/bash_compress_hook.py
+++ b/skills/token-optimizer/scripts/bash_compress_hook.py
@@ -269,15 +269,20 @@ def _crossturn_dedup(command: str, output: str):
             return None
         from session_store import SessionStore
         from delta_diff import content_hash, compute_delta
+        from archive_result import _redact_credentials
 
         store = SessionStore(session_id)
         try:
             cmd_h = content_hash(command.strip())
-            out_h = content_hash(output)
+            out_h = content_hash(output)  # identical-detection stays on raw bytes
+            # Redact before anything is persisted or diffed, mirroring the
+            # archive path (archive_result._redact_credentials), so a secret in
+            # command output never reaches the on-disk dedup store.
+            safe_output = _redact_credentials(output)
             prior = store.get_command_output(cmd_h)
-            # Record THIS run (full output) for the next comparison BEFORE we
+            # Record THIS run (redacted output) for the next comparison BEFORE we
             # return a delta, so deltas always chain off full outputs, not refs.
-            store.insert_command_output(cmd_h, command[:500], out_h, len(output), output)
+            store.insert_command_output(cmd_h, command[:500], out_h, len(output), safe_output)
             if not prior or not prior.get("compressed_output"):
                 return None
             # Recency guard: only reference a run from the last hour, a rough
@@ -290,7 +295,7 @@ def _crossturn_dedup(command: str, output: str):
                        f"output this session; unchanged.]")
             else:
                 delta, _stats = compute_delta(
-                    prior["compressed_output"], output, filename=label)
+                    prior["compressed_output"], safe_output, filename=label)
                 if not delta:
                     return None
                 ref = (f"[Token Optimizer: same as your previous `{label}` output "


### PR DESCRIPTION
## What
The cross-turn dedup path persists to the `command_outputs` SQLite table without credential
redaction, on two of its arguments. In `skills/token-optimizer/scripts/bash_compress_hook.py`,
`_crossturn_dedup` calls:

```python
store.insert_command_output(cmd_h, command[:500], out_h, len(output), output)
```

Both the `output` argument (stored as `compressed_output`) and the `command[:500]` argument
(stored as the command text) are written verbatim. The sibling persistence path in
`archive_result.py` already runs `_redact_credentials(...)` on both the response and the
command before writing, so the two disk-persistence paths are inconsistent and this one leaks.

## Why it matters
Secrets reach disk from two directions here:

- Command output: `cat .env`, `env`, `aws configure list`, or a `curl` that echoes an auth header.
- The command line itself: an inline `Authorization: Bearer ...` header, a `-pPASSWORD`, or a
  connection string with embedded credentials.

Either way the plaintext secret is written to the on-disk dedup database and persists across
sessions. The project already commits to credential redaction on the archive path and in its
privacy docs, so this is a gap against an existing guarantee, not a new policy.

## How to fix
Redact both sides before anything is persisted or diffed, reusing the same
`_redact_credentials` wrapper the archive path uses. Two details matter. The stored
`compressed_output` is not just display text; it is fed back into
`compute_delta(prior["compressed_output"], ...)` on the next run, so the output must be
redacted consistently on both sides of the delta. And the command must be redacted BEFORE the
500-char truncation, so a secret straddling the cutoff cannot survive. The identical-output
and command hashes stay on the raw bytes (the hash is non-reversible):

```python
out_h = content_hash(output)                        # identical-detection stays on raw bytes
safe_output = _redact_credentials(output)
safe_command = _redact_credentials(command)[:500]   # redact BEFORE truncating
store.insert_command_output(cmd_h, safe_command, out_h, len(output), safe_output)
...
delta, _stats = compute_delta(prior["compressed_output"], safe_output, filename=label)
```

The delta then compares redacted-against-redacted (accurate, secrets appear as stable
placeholders on both sides), the exact-repeat path still matches via the raw hash, and no
plaintext secret reaches disk from either the output or the command. Reusing the existing
`_redact_credentials` wrapper keeps this consistent with the archive path.

## Repro
In one session (so the dedup store is populated), run a Bash command twice whose stdout
contains a token-shaped string, and separately run a command with a secret in the command line
itself (for example `curl -H 'Authorization: Bearer <token>' ...`). Inspect the session's
SQLite `command_outputs` table: the output and command columns hold the raw secret today; after
the fix they hold the redacted placeholder.
