### PR TITLE
Close git-branch safety-gate gaps (--move, --copy, --force not treated as destructive)

### DIFF
--- a/cowork/token-optimizer/skills/token-optimizer/scripts/pipeline_analyzer.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/pipeline_analyzer.py
@@ -21,7 +21,8 @@ SECURITY (post-adversarial-review hardening):
   env, command, xargs, tee, awk, aws, gcloud, az removed.
 - Cloud CLIs require explicit read-only subcommand allow-list.
 - git uses an explicit ALLOW-list (not deny-list).
-- git branch rejects -d/-D/--delete/-m/-M flags.
+- git branch rejects delete (-d/-D/--delete), rename (-m/-M/--move),
+  copy (-c/-C/--copy) and --force/-f flags.
 - find rejects -delete/-exec/-ok/-fprint/-fls.
 - sqlite3 rejects replace, vacuum, .import, .restore, pragma.
 - npm run / terraform state / git config / kubectl config / docker pull
@@ -345,8 +346,16 @@ _GIT_READ_ONLY_SUBCMDS = frozenset({
     "stash", "remote",
 })
 
-# git branch destructive flags.
-_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({"-d", "-D", "--delete", "-m", "-M"})
+# git branch destructive flags. Covers delete (-d/-D/--delete), rename
+# (-m/-M/--move) and copy (-c/-C/--copy, which are copy/force-copy, not
+# "create"), plus --force/-f. All are state-changing and must not pass the
+# read-only gate.
+_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({
+    "-d", "-D", "--delete",
+    "-m", "-M", "--move",
+    "-c", "-C", "--copy",
+    "-f", "--force",
+})
 
 # find destructive flags.
 _FIND_DESTRUCTIVE_FLAGS = frozenset({"-delete", "-exec", "-execdir", "-ok", "-okdir",

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/pipeline_analyzer.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/pipeline_analyzer.py
@@ -21,7 +21,8 @@ SECURITY (post-adversarial-review hardening):
   env, command, xargs, tee, awk, aws, gcloud, az removed.
 - Cloud CLIs require explicit read-only subcommand allow-list.
 - git uses an explicit ALLOW-list (not deny-list).
-- git branch rejects -d/-D/--delete/-m/-M flags.
+- git branch rejects delete (-d/-D/--delete), rename (-m/-M/--move),
+  copy (-c/-C/--copy) and --force/-f flags.
 - find rejects -delete/-exec/-ok/-fprint/-fls.
 - sqlite3 rejects replace, vacuum, .import, .restore, pragma.
 - npm run / terraform state / git config / kubectl config / docker pull
@@ -345,8 +346,16 @@ _GIT_READ_ONLY_SUBCMDS = frozenset({
     "stash", "remote",
 })
 
-# git branch destructive flags.
-_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({"-d", "-D", "--delete", "-m", "-M"})
+# git branch destructive flags. Covers delete (-d/-D/--delete), rename
+# (-m/-M/--move) and copy (-c/-C/--copy, which are copy/force-copy, not
+# "create"), plus --force/-f. All are state-changing and must not pass the
+# read-only gate.
+_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({
+    "-d", "-D", "--delete",
+    "-m", "-M", "--move",
+    "-c", "-C", "--copy",
+    "-f", "--force",
+})
 
 # find destructive flags.
 _FIND_DESTRUCTIVE_FLAGS = frozenset({"-delete", "-exec", "-execdir", "-ok", "-okdir",

--- a/skills/token-optimizer/scripts/pipeline_analyzer.py
+++ b/skills/token-optimizer/scripts/pipeline_analyzer.py
@@ -21,7 +21,8 @@ SECURITY (post-adversarial-review hardening):
   env, command, xargs, tee, awk, aws, gcloud, az removed.
 - Cloud CLIs require explicit read-only subcommand allow-list.
 - git uses an explicit ALLOW-list (not deny-list).
-- git branch rejects -d/-D/--delete/-m/-M flags.
+- git branch rejects delete (-d/-D/--delete), rename (-m/-M/--move),
+  copy (-c/-C/--copy) and --force/-f flags.
 - find rejects -delete/-exec/-ok/-fprint/-fls.
 - sqlite3 rejects replace, vacuum, .import, .restore, pragma.
 - npm run / terraform state / git config / kubectl config / docker pull
@@ -345,8 +346,16 @@ _GIT_READ_ONLY_SUBCMDS = frozenset({
     "stash", "remote",
 })
 
-# git branch destructive flags.
-_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({"-d", "-D", "--delete", "-m", "-M"})
+# git branch destructive flags. Covers delete (-d/-D/--delete), rename
+# (-m/-M/--move) and copy (-c/-C/--copy, which are copy/force-copy, not
+# "create"), plus --force/-f. All are state-changing and must not pass the
+# read-only gate.
+_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({
+    "-d", "-D", "--delete",
+    "-m", "-M", "--move",
+    "-c", "-C", "--copy",
+    "-f", "--force",
+})
 
 # find destructive flags.
 _FIND_DESTRUCTIVE_FLAGS = frozenset({"-delete", "-exec", "-execdir", "-ok", "-okdir",


### PR DESCRIPTION
## What
In `skills/token-optimizer/scripts/pipeline_analyzer.py`, the read-only classifier allows
any `git branch` invocation unless one of its tokens is in the destructive-flag set (line
349):

```python
_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({"-d", "-D", "--delete", "-m", "-M"})
```

The check is an exact-token membership test. It covers delete and short-form rename, but it
omits several destructive or state-changing branch operations:
`--move`, `--copy`, `-c`, `-C`, `--force`, and `-f`.

## Why it matters
`git branch --move old new` renames a branch, and `git branch -c`/`--copy` copies one, yet
both are classified as read-only and pass the gate. `--force` combined with delete/rename
changes the safety of the operation and is also unlisted. Anything that reaches this
classifier expecting it to fence off non-read-only git commands can be stepped past with a
long-form flag.

## How to fix
Add the missing forms to the set:

```python
_GIT_BRANCH_DESTRUCTIVE_FLAGS = frozenset({
    "-d", "-D", "--delete",
    "-m", "-M", "--move",
    "-c", "-C", "--copy",
    "-f", "--force",
})
```

(`-c`/`-C` are git's `--copy`/force-copy, not "create," and are genuinely state-changing, so
they belong here.) For defense in depth, consider also normalizing bundled short flags (for
example treating a token like `-df` as containing `-d`), since git accepts some combined short
options; without that normalization, `-f`/`--force` mainly matter as standalone tokens today.

## Repro
Feed `git branch --move main main2` (or `git branch -c a b`) to the classifier. It returns
read-only today; after the fix it returns the destructive-flag rejection.
