### PR TITLE
Harden hook I/O and runtime resource handling (stdin hang, temp-file planted-file attacks, fd leak, timer restore)

### DIFF
--- a/cowork/token-optimizer/hooks/module_runner.py
+++ b/cowork/token-optimizer/hooks/module_runner.py
@@ -44,7 +44,15 @@ def _warn_readonly_scripts_dir_once(scripts_dir: str) -> None:
             fresh = False
         if fresh:
             return
-        with open(marker, "w", encoding="utf-8") as fh:
+        # Open with O_NOFOLLOW so a symlink pre-created at this predictable,
+        # world-shared temp path by another local user is refused (raises
+        # ELOOP, swallowed by the outer `except Exception` below -> we just skip
+        # the warning) rather than followed to a victim file (CWE-377). O_TRUNC
+        # matches the "w" truncation. O_NOFOLLOW is absent on Windows; the
+        # getattr fallback of 0 makes it a no-op flag there.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(marker, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(str(time.time()))
         sys.stderr.write(
             f"[Token Optimizer] note: {scripts_dir} is not writable, so Python "

--- a/cowork/token-optimizer/hooks/module_runner.py
+++ b/cowork/token-optimizer/hooks/module_runner.py
@@ -44,13 +44,23 @@ def _warn_readonly_scripts_dir_once(scripts_dir: str) -> None:
             fresh = False
         if fresh:
             return
-        # Open with O_NOFOLLOW so a symlink pre-created at this predictable,
-        # world-shared temp path by another local user is refused (raises
-        # ELOOP, swallowed by the outer `except Exception` below -> we just skip
-        # the warning) rather than followed to a victim file (CWE-377). O_TRUNC
-        # matches the "w" truncation. O_NOFOLLOW is absent on Windows; the
-        # getattr fallback of 0 makes it a no-op flag there.
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        # This marker lives at a predictable, world-shared temp path, so another
+        # local user can pre-plant something hostile there (CWE-377). Defend
+        # against all of it: unlink any existing entry first (drops a planted
+        # symlink, FIFO, or hardlink by name -- a hardlink's target is left
+        # untouched), then create our own EXCLUSIVELY. O_EXCL means we only ever
+        # open a file we just created; O_NOFOLLOW + O_NONBLOCK close the tiny
+        # unlink->open race (a re-planted symlink fails ELOOP, a re-planted FIFO
+        # fails ENXIO instead of blocking the hook forever). Every failure here
+        # is swallowed by the outer `except Exception` -> the hook stays
+        # fail-open and just skips the once-a-day warning. O_NOFOLLOW/O_NONBLOCK
+        # are absent on Windows; the getattr fallback of 0 makes them no-ops.
+        try:
+            os.unlink(marker)
+        except OSError:
+            pass
+        flags = (os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                 | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
         fd = os.open(marker, flags, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(str(time.time()))

--- a/cowork/token-optimizer/hooks/posttooluse_runner.py
+++ b/cowork/token-optimizer/hooks/posttooluse_runner.py
@@ -398,11 +398,18 @@ def _handler_deadline(seconds: float):
             signal.signal(alarm_signal, previous_handler)
             previous_remaining, previous_interval = previous_timer
             if previous_remaining > 0:
-                setitimer(
-                    timer_kind,
-                    max(0.0, previous_remaining - elapsed),
-                    previous_interval,
-                )
+                outer_remaining = previous_remaining - elapsed
+                if outer_remaining > 0:
+                    # Outer deadline still has budget: re-arm it for what's left.
+                    setitimer(timer_kind, outer_remaining, previous_interval)
+                elif callable(previous_handler):
+                    # Outer deadline already elapsed while the inner block ran.
+                    # Passing max(0.0, ...) -> 0.0 to setitimer would DISARM it,
+                    # silently dropping the outer budget. Deliver it now instead
+                    # via the just-restored outer handler. (Skipped when the
+                    # previous handler is SIG_DFL/SIG_IGN, so we never turn an
+                    # expired timer into a process-killing default SIGALRM.)
+                    os.kill(os.getpid(), alarm_signal)
         except (OSError, ValueError):
             pass
         if elapsed >= seconds:

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/hook_io.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/hook_io.py
@@ -46,14 +46,44 @@ def read_stdin_hook_input(max_bytes: int = 1_048_576) -> dict:
         if sys.platform == "win32":
             data = _read_stdin_windows(max_bytes=max_bytes)
         else:
+            import os
             import select
-            if select.select([sys.stdin], [], [], _STDIN_TIMEOUT)[0]:
-                # Decode from the raw buffer as UTF-8 so a non-UTF-8 host locale
-                # can't corrupt or crash on non-ASCII hook payloads (e.g. Hebrew
-                # cwd / tool args). Mirrors the Windows path above.
-                data = sys.stdin.buffer.read(max_bytes).decode("utf-8", errors="replace")
-            else:
+            import time
+            if not select.select([sys.stdin], [], [], _STDIN_TIMEOUT)[0]:
                 return {}
+            try:
+                fd = sys.stdin.fileno()
+            except (OSError, ValueError, AttributeError):
+                fd = None
+            if fd is not None:
+                # select() only guarantees one byte is ready; a blocking
+                # read(max_bytes) would then hang until max_bytes or EOF, so a
+                # host that writes a partial payload and holds the pipe open
+                # defeats the timeout. Read what is actually available in a loop
+                # bounded by the same deadline, assembling chunked payloads
+                # without ever blocking past _STDIN_TIMEOUT.
+                deadline = time.monotonic() + _STDIN_TIMEOUT
+                chunks = []
+                total = 0
+                while total < max_bytes:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    if not select.select([sys.stdin], [], [], remaining)[0]:
+                        break  # timed out with no further data
+                    chunk = os.read(fd, max_bytes - total)
+                    if not chunk:
+                        break  # EOF: host closed stdin, payload complete
+                    chunks.append(chunk)
+                    total += len(chunk)
+                raw = b"".join(chunks)
+            else:
+                # Non-fd stdin (e.g. a test double): no pipe to hang on.
+                raw = sys.stdin.buffer.read(max_bytes)
+            # Decode from raw bytes as UTF-8 so a non-UTF-8 host locale can't
+            # corrupt or crash on non-ASCII hook payloads (e.g. Hebrew cwd /
+            # tool args). Mirrors the Windows path above.
+            data = raw.decode("utf-8", errors="replace")
         if not data:
             return {}
         parsed = json.loads(data)

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -439,16 +439,26 @@ def _write_dashboard_meta_atomic(meta_path):
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_name = tempfile.mkstemp(dir=str(meta_path.parent), prefix=".dashmeta-", suffix=".tmp")
+        fd_owned = False  # True once fdopen's file object owns (and will close) tmp_fd
         try:
             if hasattr(os, "fchmod"):  # POSIX only (os.fchmod is absent on Windows)
                 os.fchmod(tmp_fd, 0o600)
             with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                fd_owned = True
                 f.write(blob)
             os.replace(tmp_name, str(meta_path))
         except BaseException:
             # BaseException, not OSError: writers under a hook budget can raise
             # _HookTimeout mid-write; clean up the temp then re-raise so the
             # timeout still propagates (same contract as the HTML write).
+            # If we failed BEFORE fdopen took ownership (e.g. fchmod raised, or a
+            # budget fired between mkstemp and fdopen), the raw fd would leak;
+            # close it here. Once fdopen owns it, its `with` already closed it.
+            if not fd_owned:
+                try:
+                    os.close(tmp_fd)
+                except OSError:
+                    pass
             try:
                 os.unlink(tmp_name)
             except OSError:

--- a/hooks/module_runner.py
+++ b/hooks/module_runner.py
@@ -44,7 +44,15 @@ def _warn_readonly_scripts_dir_once(scripts_dir: str) -> None:
             fresh = False
         if fresh:
             return
-        with open(marker, "w", encoding="utf-8") as fh:
+        # Open with O_NOFOLLOW so a symlink pre-created at this predictable,
+        # world-shared temp path by another local user is refused (raises
+        # ELOOP, swallowed by the outer `except Exception` below -> we just skip
+        # the warning) rather than followed to a victim file (CWE-377). O_TRUNC
+        # matches the "w" truncation. O_NOFOLLOW is absent on Windows; the
+        # getattr fallback of 0 makes it a no-op flag there.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(marker, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(str(time.time()))
         sys.stderr.write(
             f"[Token Optimizer] note: {scripts_dir} is not writable, so Python "

--- a/hooks/module_runner.py
+++ b/hooks/module_runner.py
@@ -44,13 +44,23 @@ def _warn_readonly_scripts_dir_once(scripts_dir: str) -> None:
             fresh = False
         if fresh:
             return
-        # Open with O_NOFOLLOW so a symlink pre-created at this predictable,
-        # world-shared temp path by another local user is refused (raises
-        # ELOOP, swallowed by the outer `except Exception` below -> we just skip
-        # the warning) rather than followed to a victim file (CWE-377). O_TRUNC
-        # matches the "w" truncation. O_NOFOLLOW is absent on Windows; the
-        # getattr fallback of 0 makes it a no-op flag there.
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        # This marker lives at a predictable, world-shared temp path, so another
+        # local user can pre-plant something hostile there (CWE-377). Defend
+        # against all of it: unlink any existing entry first (drops a planted
+        # symlink, FIFO, or hardlink by name -- a hardlink's target is left
+        # untouched), then create our own EXCLUSIVELY. O_EXCL means we only ever
+        # open a file we just created; O_NOFOLLOW + O_NONBLOCK close the tiny
+        # unlink->open race (a re-planted symlink fails ELOOP, a re-planted FIFO
+        # fails ENXIO instead of blocking the hook forever). Every failure here
+        # is swallowed by the outer `except Exception` -> the hook stays
+        # fail-open and just skips the once-a-day warning. O_NOFOLLOW/O_NONBLOCK
+        # are absent on Windows; the getattr fallback of 0 makes them no-ops.
+        try:
+            os.unlink(marker)
+        except OSError:
+            pass
+        flags = (os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                 | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
         fd = os.open(marker, flags, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(str(time.time()))

--- a/hooks/posttooluse_runner.py
+++ b/hooks/posttooluse_runner.py
@@ -398,11 +398,18 @@ def _handler_deadline(seconds: float):
             signal.signal(alarm_signal, previous_handler)
             previous_remaining, previous_interval = previous_timer
             if previous_remaining > 0:
-                setitimer(
-                    timer_kind,
-                    max(0.0, previous_remaining - elapsed),
-                    previous_interval,
-                )
+                outer_remaining = previous_remaining - elapsed
+                if outer_remaining > 0:
+                    # Outer deadline still has budget: re-arm it for what's left.
+                    setitimer(timer_kind, outer_remaining, previous_interval)
+                elif callable(previous_handler):
+                    # Outer deadline already elapsed while the inner block ran.
+                    # Passing max(0.0, ...) -> 0.0 to setitimer would DISARM it,
+                    # silently dropping the outer budget. Deliver it now instead
+                    # via the just-restored outer handler. (Skipped when the
+                    # previous handler is SIG_DFL/SIG_IGN, so we never turn an
+                    # expired timer into a process-killing default SIGALRM.)
+                    os.kill(os.getpid(), alarm_signal)
         except (OSError, ValueError):
             pass
         if elapsed >= seconds:

--- a/plugins/token-optimizer/hooks/module_runner.py
+++ b/plugins/token-optimizer/hooks/module_runner.py
@@ -44,7 +44,15 @@ def _warn_readonly_scripts_dir_once(scripts_dir: str) -> None:
             fresh = False
         if fresh:
             return
-        with open(marker, "w", encoding="utf-8") as fh:
+        # Open with O_NOFOLLOW so a symlink pre-created at this predictable,
+        # world-shared temp path by another local user is refused (raises
+        # ELOOP, swallowed by the outer `except Exception` below -> we just skip
+        # the warning) rather than followed to a victim file (CWE-377). O_TRUNC
+        # matches the "w" truncation. O_NOFOLLOW is absent on Windows; the
+        # getattr fallback of 0 makes it a no-op flag there.
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(marker, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(str(time.time()))
         sys.stderr.write(
             f"[Token Optimizer] note: {scripts_dir} is not writable, so Python "

--- a/plugins/token-optimizer/hooks/module_runner.py
+++ b/plugins/token-optimizer/hooks/module_runner.py
@@ -44,13 +44,23 @@ def _warn_readonly_scripts_dir_once(scripts_dir: str) -> None:
             fresh = False
         if fresh:
             return
-        # Open with O_NOFOLLOW so a symlink pre-created at this predictable,
-        # world-shared temp path by another local user is refused (raises
-        # ELOOP, swallowed by the outer `except Exception` below -> we just skip
-        # the warning) rather than followed to a victim file (CWE-377). O_TRUNC
-        # matches the "w" truncation. O_NOFOLLOW is absent on Windows; the
-        # getattr fallback of 0 makes it a no-op flag there.
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        # This marker lives at a predictable, world-shared temp path, so another
+        # local user can pre-plant something hostile there (CWE-377). Defend
+        # against all of it: unlink any existing entry first (drops a planted
+        # symlink, FIFO, or hardlink by name -- a hardlink's target is left
+        # untouched), then create our own EXCLUSIVELY. O_EXCL means we only ever
+        # open a file we just created; O_NOFOLLOW + O_NONBLOCK close the tiny
+        # unlink->open race (a re-planted symlink fails ELOOP, a re-planted FIFO
+        # fails ENXIO instead of blocking the hook forever). Every failure here
+        # is swallowed by the outer `except Exception` -> the hook stays
+        # fail-open and just skips the once-a-day warning. O_NOFOLLOW/O_NONBLOCK
+        # are absent on Windows; the getattr fallback of 0 makes them no-ops.
+        try:
+            os.unlink(marker)
+        except OSError:
+            pass
+        flags = (os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                 | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
         fd = os.open(marker, flags, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(str(time.time()))

--- a/plugins/token-optimizer/hooks/posttooluse_runner.py
+++ b/plugins/token-optimizer/hooks/posttooluse_runner.py
@@ -398,11 +398,18 @@ def _handler_deadline(seconds: float):
             signal.signal(alarm_signal, previous_handler)
             previous_remaining, previous_interval = previous_timer
             if previous_remaining > 0:
-                setitimer(
-                    timer_kind,
-                    max(0.0, previous_remaining - elapsed),
-                    previous_interval,
-                )
+                outer_remaining = previous_remaining - elapsed
+                if outer_remaining > 0:
+                    # Outer deadline still has budget: re-arm it for what's left.
+                    setitimer(timer_kind, outer_remaining, previous_interval)
+                elif callable(previous_handler):
+                    # Outer deadline already elapsed while the inner block ran.
+                    # Passing max(0.0, ...) -> 0.0 to setitimer would DISARM it,
+                    # silently dropping the outer budget. Deliver it now instead
+                    # via the just-restored outer handler. (Skipped when the
+                    # previous handler is SIG_DFL/SIG_IGN, so we never turn an
+                    # expired timer into a process-killing default SIGALRM.)
+                    os.kill(os.getpid(), alarm_signal)
         except (OSError, ValueError):
             pass
         if elapsed >= seconds:

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/hook_io.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/hook_io.py
@@ -46,14 +46,44 @@ def read_stdin_hook_input(max_bytes: int = 1_048_576) -> dict:
         if sys.platform == "win32":
             data = _read_stdin_windows(max_bytes=max_bytes)
         else:
+            import os
             import select
-            if select.select([sys.stdin], [], [], _STDIN_TIMEOUT)[0]:
-                # Decode from the raw buffer as UTF-8 so a non-UTF-8 host locale
-                # can't corrupt or crash on non-ASCII hook payloads (e.g. Hebrew
-                # cwd / tool args). Mirrors the Windows path above.
-                data = sys.stdin.buffer.read(max_bytes).decode("utf-8", errors="replace")
-            else:
+            import time
+            if not select.select([sys.stdin], [], [], _STDIN_TIMEOUT)[0]:
                 return {}
+            try:
+                fd = sys.stdin.fileno()
+            except (OSError, ValueError, AttributeError):
+                fd = None
+            if fd is not None:
+                # select() only guarantees one byte is ready; a blocking
+                # read(max_bytes) would then hang until max_bytes or EOF, so a
+                # host that writes a partial payload and holds the pipe open
+                # defeats the timeout. Read what is actually available in a loop
+                # bounded by the same deadline, assembling chunked payloads
+                # without ever blocking past _STDIN_TIMEOUT.
+                deadline = time.monotonic() + _STDIN_TIMEOUT
+                chunks = []
+                total = 0
+                while total < max_bytes:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    if not select.select([sys.stdin], [], [], remaining)[0]:
+                        break  # timed out with no further data
+                    chunk = os.read(fd, max_bytes - total)
+                    if not chunk:
+                        break  # EOF: host closed stdin, payload complete
+                    chunks.append(chunk)
+                    total += len(chunk)
+                raw = b"".join(chunks)
+            else:
+                # Non-fd stdin (e.g. a test double): no pipe to hang on.
+                raw = sys.stdin.buffer.read(max_bytes)
+            # Decode from raw bytes as UTF-8 so a non-UTF-8 host locale can't
+            # corrupt or crash on non-ASCII hook payloads (e.g. Hebrew cwd /
+            # tool args). Mirrors the Windows path above.
+            data = raw.decode("utf-8", errors="replace")
         if not data:
             return {}
         parsed = json.loads(data)

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -439,16 +439,26 @@ def _write_dashboard_meta_atomic(meta_path):
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_name = tempfile.mkstemp(dir=str(meta_path.parent), prefix=".dashmeta-", suffix=".tmp")
+        fd_owned = False  # True once fdopen's file object owns (and will close) tmp_fd
         try:
             if hasattr(os, "fchmod"):  # POSIX only (os.fchmod is absent on Windows)
                 os.fchmod(tmp_fd, 0o600)
             with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                fd_owned = True
                 f.write(blob)
             os.replace(tmp_name, str(meta_path))
         except BaseException:
             # BaseException, not OSError: writers under a hook budget can raise
             # _HookTimeout mid-write; clean up the temp then re-raise so the
             # timeout still propagates (same contract as the HTML write).
+            # If we failed BEFORE fdopen took ownership (e.g. fchmod raised, or a
+            # budget fired between mkstemp and fdopen), the raw fd would leak;
+            # close it here. Once fdopen owns it, its `with` already closed it.
+            if not fd_owned:
+                try:
+                    os.close(tmp_fd)
+                except OSError:
+                    pass
             try:
                 os.unlink(tmp_name)
             except OSError:

--- a/skills/token-optimizer/scripts/hook_io.py
+++ b/skills/token-optimizer/scripts/hook_io.py
@@ -46,14 +46,44 @@ def read_stdin_hook_input(max_bytes: int = 1_048_576) -> dict:
         if sys.platform == "win32":
             data = _read_stdin_windows(max_bytes=max_bytes)
         else:
+            import os
             import select
-            if select.select([sys.stdin], [], [], _STDIN_TIMEOUT)[0]:
-                # Decode from the raw buffer as UTF-8 so a non-UTF-8 host locale
-                # can't corrupt or crash on non-ASCII hook payloads (e.g. Hebrew
-                # cwd / tool args). Mirrors the Windows path above.
-                data = sys.stdin.buffer.read(max_bytes).decode("utf-8", errors="replace")
-            else:
+            import time
+            if not select.select([sys.stdin], [], [], _STDIN_TIMEOUT)[0]:
                 return {}
+            try:
+                fd = sys.stdin.fileno()
+            except (OSError, ValueError, AttributeError):
+                fd = None
+            if fd is not None:
+                # select() only guarantees one byte is ready; a blocking
+                # read(max_bytes) would then hang until max_bytes or EOF, so a
+                # host that writes a partial payload and holds the pipe open
+                # defeats the timeout. Read what is actually available in a loop
+                # bounded by the same deadline, assembling chunked payloads
+                # without ever blocking past _STDIN_TIMEOUT.
+                deadline = time.monotonic() + _STDIN_TIMEOUT
+                chunks = []
+                total = 0
+                while total < max_bytes:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    if not select.select([sys.stdin], [], [], remaining)[0]:
+                        break  # timed out with no further data
+                    chunk = os.read(fd, max_bytes - total)
+                    if not chunk:
+                        break  # EOF: host closed stdin, payload complete
+                    chunks.append(chunk)
+                    total += len(chunk)
+                raw = b"".join(chunks)
+            else:
+                # Non-fd stdin (e.g. a test double): no pipe to hang on.
+                raw = sys.stdin.buffer.read(max_bytes)
+            # Decode from raw bytes as UTF-8 so a non-UTF-8 host locale can't
+            # corrupt or crash on non-ASCII hook payloads (e.g. Hebrew cwd /
+            # tool args). Mirrors the Windows path above.
+            data = raw.decode("utf-8", errors="replace")
         if not data:
             return {}
         parsed = json.loads(data)

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -439,16 +439,26 @@ def _write_dashboard_meta_atomic(meta_path):
     try:
         meta_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_fd, tmp_name = tempfile.mkstemp(dir=str(meta_path.parent), prefix=".dashmeta-", suffix=".tmp")
+        fd_owned = False  # True once fdopen's file object owns (and will close) tmp_fd
         try:
             if hasattr(os, "fchmod"):  # POSIX only (os.fchmod is absent on Windows)
                 os.fchmod(tmp_fd, 0o600)
             with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                fd_owned = True
                 f.write(blob)
             os.replace(tmp_name, str(meta_path))
         except BaseException:
             # BaseException, not OSError: writers under a hook budget can raise
             # _HookTimeout mid-write; clean up the temp then re-raise so the
             # timeout still propagates (same contract as the HTML write).
+            # If we failed BEFORE fdopen took ownership (e.g. fchmod raised, or a
+            # budget fired between mkstemp and fdopen), the raw fd would leak;
+            # close it here. Once fdopen owns it, its `with` already closed it.
+            if not fd_owned:
+                try:
+                    os.close(tmp_fd)
+                except OSError:
+                    pass
             try:
                 os.unlink(tmp_name)
             except OSError:


### PR DESCRIPTION
This groups four small, independent robustness fixes in the hook/runtime layer. They share
the theme of "a hook should never hang, leak, or clobber under adverse conditions," but each
stands alone and can be split into its own PR on request. Each has its own repro below.

## 1. skills/token-optimizer/scripts/hook_io.py - stdin read can block past its own timeout
`read_hook_input` guards the read with `select([sys.stdin], [], [], _STDIN_TIMEOUT)`, then
calls `sys.stdin.buffer.read(max_bytes)`. `select` only guarantees that at least one byte is
available; `read(max_bytes)` then blocks until it gets `max_bytes` or EOF. A host that writes
a partial payload and keeps the pipe open makes the hook hang indefinitely, defeating the
timeout.
Fix: after `select` signals readable, read what is available without blocking (a loop bounded
by the same deadline that still reassembles a chunked payload), rather than a blocking
`read(max_bytes)`.
Repro: pipe a partial JSON payload to the hook and hold the pipe open. The process hangs
today; with the fix it returns after the timeout.

## 2. hooks/module_runner.py - a predictable shared-temp marker is vulnerable to planted-file attacks
`_warn_readonly_scripts_dir_once` writes a once-a-day marker to
`gettempdir()/.token-optimizer-ro-pyc-<sha1(scripts_dir)[:12]>` via `open(marker, "w")`.
The path is world-predictable and lives in the shared temp dir, so on a multi-user host
another local user can pre-plant something hostile there (CWE-377):

- a symlink, and the write follows it to a victim file;
- a FIFO, and `open(..., O_WRONLY)` on a reader-less FIFO blocks the hook indefinitely (the
  function's `except` cannot interrupt a blocked syscall, defeating fail-open);
- a regular file or a hardlink to a victim, and the `"w"` truncation clobbers it.

Fix: remove any existing entry first, then create the marker exclusively, so the code only
ever opens a file it just made:

```python
try:
    os.unlink(marker)          # drops a planted symlink / FIFO / hardlink by name
except OSError:                # (a hardlink's target is left untouched)
    pass
flags = (os.O_WRONLY | os.O_CREAT | os.O_EXCL
         | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0))
fd = os.open(marker, flags, 0o600)
```

`O_EXCL` guarantees we never open a pre-existing entry; `O_NOFOLLOW` and `O_NONBLOCK` close
the tiny unlink-to-open race (a re-planted symlink fails `ELOOP`, a re-planted FIFO fails
`ENXIO` instead of blocking). Every failure here is swallowed by the existing
`except Exception: pass`, so the hook stays fail-open and just skips the warning.
`O_NOFOLLOW`/`O_NONBLOCK` are absent on Windows; the `getattr(..., 0)` fallback makes them
no-ops there. (Moving the marker under a per-user directory the tool owns would also remove
the cross-user race; the exclusive-create approach keeps the existing temp-dir location.)
Repro: on a shared temp dir, pre-plant the marker path as (a) a symlink to a victim file,
(b) a FIFO, or (c) a regular file, then trigger the read-only-scripts-dir branch. Today (a)
follows the symlink, (b) hangs the hook, and (c) truncates the file; after the fix each is
refused and the hook stays fail-open.

## 3. skills/token-optimizer/scripts/measure.py - file descriptor leak on interrupted atomic write
The dashboard-meta atomic write does `tmp_fd, tmp_name = tempfile.mkstemp(...)` then
`os.fchmod(tmp_fd, 0o600)` before `os.fdopen(tmp_fd, ...)`. If `os.fchmod` raises (or a hook
budget `_HookTimeout` fires) between `mkstemp` and `fdopen`, the `except` unlinks the temp
file but never closes `tmp_fd`, leaking the descriptor. Under a repeatedly-timing-out hook
this accumulates.
Fix: close `tmp_fd` on any error before `fdopen` takes ownership of it (once `fdopen`
succeeds, its `with` block owns the close).
Repro: force `os.fchmod` to raise and call the writer in a loop; the process fd count climbs
today and stays flat with the fix.

## 4. hooks/posttooluse_runner.py - restoring an already-expired outer timer disarms it
The nested budget timer saves and restores a previous `setitimer`. On restore it computes
`max(0.0, previous_remaining - elapsed)`. When the outer timer should already have expired
(`previous_remaining - elapsed <= 0`), this passes `0.0` to `setitimer`, which disarms the
timer instead of firing it, so the outer budget is silently dropped.
Fix: detect the `previous_remaining - elapsed <= 0` case explicitly and deliver the outer
budget immediately (via the just-restored handler) rather than round-tripping through
`setitimer` with a value that means "disarm." The delivery is guarded so it never fires into a
default/ignored handler. Arming a tiny positive interval would also fire, but it leaves a
spurious near-zero timer; handling the expired case directly is cleaner.
Repro: nest two budget contexts where the outer is already expired at inner exit. The outer
timeout never fires today; with the fix it fires immediately.
