### PR TITLE
Make external-value parsing robust (float-string token counts, SQLite path URIs)

### DIFF
--- a/cowork/token-optimizer/skills/token-optimizer/scripts/codex_state.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/codex_state.py
@@ -101,7 +101,14 @@ def _ro_connect(path: Path) -> Iterator[sqlite3.Connection]:
     Never writes, never checkpoints, never attaches. The caller must keep the
     open window minimal: introspect + one query + fetch, then exit.
     """
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
+    # Build the file: URI via Path.as_uri() rather than string interpolation:
+    # with uri=True, characters like ?, #, % and spaces in the path are URI
+    # syntax, so a path containing '?' would start the query string early and
+    # could drop or override mode=ro (opening the wrong DB, or read-write).
+    # as_uri() percent-encodes those, keeping the whole path in the path
+    # component. (Discovered DB paths are absolute, which as_uri() requires.)
+    db_uri = Path(path).as_uri()
+    conn = sqlite3.connect(f"{db_uri}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
     try:
         # Defense-in-depth: `mode=ro` blocks writes to this DB but not ATTACH;
         # `query_only` also blocks ATTACH and any write through the connection,

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/copilot_vscode.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/copilot_vscode.py
@@ -190,8 +190,13 @@ def _safe_int(value: Any, default: int = 0) -> int:
     if value is None:
         return default
     try:
-        return int(value)
-    except (TypeError, ValueError):
+        # Parse through float first so a float-shaped string ("1234.0",
+        # common in JSON exports) doesn't collapse to the default the way
+        # int("1234.0") would. int() still truncates toward zero, matching
+        # prior behavior for genuine float inputs. OverflowError guards
+        # against float("inf")-style values.
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
         return default
 
 

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/codex_state.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/codex_state.py
@@ -101,7 +101,14 @@ def _ro_connect(path: Path) -> Iterator[sqlite3.Connection]:
     Never writes, never checkpoints, never attaches. The caller must keep the
     open window minimal: introspect + one query + fetch, then exit.
     """
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
+    # Build the file: URI via Path.as_uri() rather than string interpolation:
+    # with uri=True, characters like ?, #, % and spaces in the path are URI
+    # syntax, so a path containing '?' would start the query string early and
+    # could drop or override mode=ro (opening the wrong DB, or read-write).
+    # as_uri() percent-encodes those, keeping the whole path in the path
+    # component. (Discovered DB paths are absolute, which as_uri() requires.)
+    db_uri = Path(path).as_uri()
+    conn = sqlite3.connect(f"{db_uri}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
     try:
         # Defense-in-depth: `mode=ro` blocks writes to this DB but not ATTACH;
         # `query_only` also blocks ATTACH and any write through the connection,

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/copilot_vscode.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/copilot_vscode.py
@@ -190,8 +190,13 @@ def _safe_int(value: Any, default: int = 0) -> int:
     if value is None:
         return default
     try:
-        return int(value)
-    except (TypeError, ValueError):
+        # Parse through float first so a float-shaped string ("1234.0",
+        # common in JSON exports) doesn't collapse to the default the way
+        # int("1234.0") would. int() still truncates toward zero, matching
+        # prior behavior for genuine float inputs. OverflowError guards
+        # against float("inf")-style values.
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
         return default
 
 

--- a/skills/token-optimizer/scripts/codex_state.py
+++ b/skills/token-optimizer/scripts/codex_state.py
@@ -101,7 +101,14 @@ def _ro_connect(path: Path) -> Iterator[sqlite3.Connection]:
     Never writes, never checkpoints, never attaches. The caller must keep the
     open window minimal: introspect + one query + fetch, then exit.
     """
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
+    # Build the file: URI via Path.as_uri() rather than string interpolation:
+    # with uri=True, characters like ?, #, % and spaces in the path are URI
+    # syntax, so a path containing '?' would start the query string early and
+    # could drop or override mode=ro (opening the wrong DB, or read-write).
+    # as_uri() percent-encodes those, keeping the whole path in the path
+    # component. (Discovered DB paths are absolute, which as_uri() requires.)
+    db_uri = Path(path).as_uri()
+    conn = sqlite3.connect(f"{db_uri}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
     try:
         # Defense-in-depth: `mode=ro` blocks writes to this DB but not ATTACH;
         # `query_only` also blocks ATTACH and any write through the connection,

--- a/skills/token-optimizer/scripts/copilot_vscode.py
+++ b/skills/token-optimizer/scripts/copilot_vscode.py
@@ -190,8 +190,13 @@ def _safe_int(value: Any, default: int = 0) -> int:
     if value is None:
         return default
     try:
-        return int(value)
-    except (TypeError, ValueError):
+        # Parse through float first so a float-shaped string ("1234.0",
+        # common in JSON exports) doesn't collapse to the default the way
+        # int("1234.0") would. int() still truncates toward zero, matching
+        # prior behavior for genuine float inputs. OverflowError guards
+        # against float("inf")-style values.
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
         return default
 
 


### PR DESCRIPTION
Two small parsing-robustness fixes for values that come from outside the process. They can be
split if preferred.

## 1. copilot_vscode.py:193 - token counts arriving as float-strings silently become 0
`_safe_int` does `int(value)` and returns the default on any `ValueError`:

```python
def _safe_int(value, default=0):
    if value is None:
        return default
    try:
        return int(value)
    except (TypeError, ValueError):
        return default
```

`int("1234")` works, but `int("1234.0")` raises `ValueError`, so a token count that a
producer emits as a float-shaped string (common in JSON exports) collapses to `0`. That
silently understates usage and savings math rather than failing loudly.
Fix: parse through float first, for example `return int(float(value))`, still guarded by the
same try/except.

## 2. codex_state.py:104 - SQLite path is interpolated into a URI without encoding
The read-only connect builds a URI by string interpolation:

```python
conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=_BUSY_TIMEOUT_SECONDS)
```

When `uri=True`, characters like `?`, `#`, and spaces in `path` are interpreted as URI
syntax, not literal path characters. A path containing `?` starts the query string early, so
`mode=ro` can be dropped or overridden and the wrong database (or none) is opened.
Fix: build the URI safely, for example
`sqlite3.connect(f"{Path(path).as_uri()}?mode=ro", uri=True, ...)`, or percent-encode the
path with `urllib.parse.quote` before interpolation. `Path.as_uri()` already percent-encodes
`?`, `#`, `%`, and spaces, which is exactly what stops the path from bleeding into the query
component.

## Repro
1. Call `_safe_int("1234.0")`; it returns `0` today and `1234` after the fix.
2. Point the codex state reader at a database whose absolute path contains a `?` or a space;
   the connection opens the wrong target or loses `mode=ro` today.
