### PR TITLE
Escape interpolated fields in the trusted VS Code status tooltip

### DIFF
--- a/vscode-extension/src/format.ts
+++ b/vscode-extension/src/format.ts
@@ -144,10 +144,10 @@ export function buildTooltip(s: Snapshot, opts: RenderOptions): string {
     lines.push(`| Context | \`${fillBar(s.fillPct)}\` ${s.fillPct}%${src} |`);
   }
   if (s.contextQ) {
-    lines.push(`| ContextQ | ${s.contextQ.grade} (${s.contextQ.score})${s.contextQ.stale ? ' _(cached)_' : ''} |`);
+    lines.push(`| ContextQ | ${escapeMd(String(s.contextQ.grade))} (${escapeMd(String(s.contextQ.score))})${s.contextQ.stale ? ' _(cached)_' : ''} |`);
   }
   if (s.eff) {
-    lines.push(`| Efficiency | ${s.eff.grade} (${s.eff.score}) |`);
+    lines.push(`| Efficiency | ${escapeMd(String(s.eff.grade))} (${escapeMd(String(s.eff.score))}) |`);
   }
   // Say so when fill is present but scores aren't yet — reads as "pending" not "broken".
   if (qualityPending(s)) {
@@ -263,11 +263,11 @@ function warningParts(s: Snapshot): string[] {
   const parts: string[] = [];
   if (s.fillWarning) {
     const bang = s.fillWarning.level === 'CRITICAL' ? '!' : '';
-    parts.push(`Fill ${s.fillWarning.value}%${bang}`);
+    parts.push(`Fill ${escapeMd(String(s.fillWarning.value))}%${bang}`);
   }
   if (s.toolWarning) {
     const bang = s.toolWarning.level === 'CRITICAL' ? '!' : '';
-    parts.push(`Tools ${s.toolWarning.value}${bang}`);
+    parts.push(`Tools ${escapeMd(String(s.toolWarning.value))}${bang}`);
   }
   return parts;
 }


### PR DESCRIPTION
## What
The VS Code extension builds its status-bar tooltip as a `MarkdownString` with
`isTrusted = true` (`vscode-extension/src/statusBar.ts:38`), which enables clickable
`command:` links inside the tooltip. In `vscode-extension/src/format.ts` (around lines
147-158) several fields are interpolated into that markdown without escaping, for example:

```ts
lines.push(`| ContextQ | ${s.contextQ.grade} (${s.contextQ.score})... |`);
lines.push(`| Efficiency | ${s.eff.grade} (${s.eff.score}) |`);
const warn = warningParts(s); // values also interpolated below
```

These values originate from the on-disk cache JSON parsed in `cacheReader.ts`
(`q.resource_health_grade || q.grade || gradeFor(score)`).

## Why it matters
In a trusted `MarkdownString`, a markdown link whose target is a `command:` URI executes a
VS Code command on click. Today the interpolated grade/score/warning values are normally
tool-computed enums, so this is defense in depth rather than a known live exploit. But
because the sink is a trusted tooltip and the source is a file on disk, any value that is or
becomes attacker-influenced (a crafted cache file, or a warning string derived from session
content) could inject a `](command:...)` link. Escaping closes the class of issue regardless
of current provenance.

## How to fix
The file already defines `escapeMd` (line 23) and already applies it to other interpolated
fields (`s.model`, `s.effort`, agent descriptions at lines 118 and 175). The fix is to extend
that existing pattern to the fields it currently misses: the `contextQ`/`eff` grade and score
cells and the values produced by `warningParts`:

```ts
lines.push(`| ContextQ | ${escapeMd(String(s.contextQ.grade))} (${escapeMd(String(s.contextQ.score))})... |`);
```

Since `escapeMd` is already the house style here, this reads as finishing an existing
convention rather than adding a new one. `escapeMd` escapes `[`, `]`, `(`, and `)` (its
character class is `` /[\\`*_[\]()<>|#]/ ``), which are exactly the characters a
`](command:...)` payload needs, so it does neutralize the injection rather than only
cosmetically altering it.

## Repro
Write a cache file whose `grade` (or a warning value) is
`[x](command:workbench.action.terminal.new)` (the leading `[` is what forms the markdown
link), then hover the status bar. The tooltip renders a clickable command link today; after
escaping, the text renders literally.
