### PR TITLE
feat(teams): admin-enabled org telemetry emitter (off by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ decisions.md
 # Internal working dirs — never ship (Alex Mode hard rule)
 handoff/
 scratchpad/
+fleet.json
+fleet-outbox.jsonl
+fleet-cursor.json
+fleet.log

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -118,9 +118,21 @@ Manual deletion: remove the following directories:
 
 ## Cross-Platform
 
-The same privacy guarantees apply across all supported platforms (Claude Code, Codex, OpenCode, Hermes). Data paths vary by platform but the architecture is identical: local-only, zero network, credential-redacted storage.
+The same privacy guarantees apply across all supported platforms (Claude Code, Codex, OpenCode, Hermes). Data paths vary by platform but the architecture is identical: local-only, zero network by default, credential-redacted storage. The one exception is the admin-enabled org telemetry channel described below.
 
 Consent is tracked per-runtime. A user running both Claude Code and Codex must acknowledge consent separately in each runtime.
+
+## Teams edition: admin-enabled org telemetry
+
+Token Optimizer has a separate Teams edition for organizations. It is **admin-enabled, not opt-in by the individual**: nothing is emitted unless an org admin has placed a `fleet.json` (mode 0600) in Token Optimizer's config dir holding a collector `endpoint`, an ingest `token` (or `token_env`), and a per-org `hash_key` (or `hash_key_env`). Environment variables alone never enable emission; `TO_FLEET_DISABLE=1` on one machine overrides everything. When active, the local dashboard shows a banner ("Org telemetry active: sending session aggregates to ...") and `fleet_emitter.py --status` reports the state.
+
+**Exactly what is sent, per session** (aggregates Token Optimizer already computes and stores locally): platform, pseudonymous user/host/project identifiers (HMAC-SHA256 keyed by the org's `hash_key`, truncated), token counts (input, output, cache read, cache create, reported), model names and per-model token split, cost in USD with its `cost_source`, counted savings (tokens and USD) with a `savings_coverage` marker, quality score/grade, timestamps, and one account-level limit-meter reading when the meter is available. The envelope also carries `billing_mode` (`api`/`subscription`/`unknown`), `savings_method`, and a `models_redacted` count. If the admin sets `send_user_label: true`, the canonical identity string (config user, else `TO_FLEET_USER`, else gitconfig email, else OS username) travels as `user_label`; it is absent otherwise.
+
+**Never sent**: prompts, assistant responses, file contents, file paths, command text, tool output, topics, slugs. The allowlist is enforced on keys AND values before serialisation; model names not matching a strict pattern are replaced with `custom-<hmac>` and counted in `models_redacted`.
+
+**Pseudonymity**: identifiers are pseudonymous, re-identifiable by the org's collector operator by design (the operator holds the `hash_key`). Delivery is fail-open and bounded: events queue in a local outbox (0600) and drain with at most two 3-second POSTs per session-end flush; a down collector never blocks a hook. Inspect exactly what would be sent with `python3 fleet_emitter.py --dry-run` — the output is sensitive (it contains your org's aggregates) and is meant to be shared deliberately with whoever runs the collector. A one-line entry per flush lands in `fleet.log`.
+
+Claude Code's own OTel exporter can also point at the collector (OTLP/HTTP) as a second ingest path; only `api_request` metrics are retained. See `docs/teams-telemetry.md` for admin setup, credential placement and rotation.
 
 ## Source Available
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="依存関係ゼロ">
-  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="テレメトリゼロ">
+  <img src="https://img.shields.io/badge/telemetry-off_by_default-brightgreen" alt="テレメトリデフォルトオフ">
   <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="プラットフォーム">
   <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="ライセンス: PolyForm Noncommercial"></a>
@@ -231,7 +231,7 @@ RTKとBoostは最初の面に到達します。Headroomは最初と3番目に到
 | キャッシュセーフ | 🟢 既存のコンテキストプレフィックスを変更しない | 🟡 プロキシモードが進行中を書き換え | 🟢 pre-shellのみ | 🟢 pre-shellのみ | 🟡 MCPオーバーヘッド | 🟢 |
 | ゼロベースラインコンテキストオーバーヘッド | 🟢 外部プロセス、コンテキスト注入なし | 🔴 指示を注入 | 🟢 シェルレベルのみ | 🟢 シェルレベルのみ | 🔴 MCPサーバーオーバーヘッド | 🟢 ネイティブ |
 | ゼロランタイム依存 | 🟢 純標準ライブラリ(Python/TypeScript) | 🟡 Python + Rust + オプションモデル | 🟢 単一Rustバイナリ | 🟢 単一バイナリ | 🟡 SQLiteアダプタが必要 | 🟢 N/A |
-| ゼロテレメトリ | 🟢 マシンから何も出ない | 🟡 `HEADROOM_TELEMETRY`オプトイン、デフォルトオフ | 🟡 オプトイン | 🔴 呼び出されたコマンド、コマンド引数、終了コード、期間、CI属性、IPを収集 | 🟡 様々 | 🟢 |
+| デフォルトでテレメトリなし | 🟢 組織の管理者が Teams 版コレクターを有効化しない限り、マシンから何も出ない(PRIVACY.md 参照) | 🟡 `HEADROOM_TELEMETRY`オプトイン、デフォルトオフ | 🟡 オプトイン | 🔴 呼び出されたコマンド、コマンド引数、終了コード、期間、CI属性、IPを収集 | 🟡 様々 | 🟢 |
 | マルチプラットフォーム | 🟢 Claude Code、VS Code、Codex、OpenClaw、OpenCode、Hermes、Copilot | 🟢 Claude Code、Cursor、Codex、Aider、Copilot | 🟢 15統合 | 🟡 Cursor、Claude Code、Copilot、Codex CLI | 🟢 17統合 | 🔴 Claude Codeのみ |
 | タスク別のモデルとeffortの助言 | 🟢 `route`がお金を使う前にタスクを計量 | — | — | — | — | — |
 | Keep-Warm(キャッシュTTLリフレッシュ) | 🟢 キャッシュ期限前のオプトインping、トリップワイヤー自動オフ | 🔴 | 🔴 | — | 🔴 | 🔴 |
@@ -612,7 +612,7 @@ python3 measure.py inject-routing              # 注入
 <details>
 <summary><b>📡 どこかにデータを送信しますか?</b></summary>
 
-分析なし、テレメトリエンドポイントなし、製品データはマシンから出ません。計測イベントはあなたが所有するローカルSQLiteの行です。ゼロのネットワーク呼び出し。
+デフォルトでは、分析なし、テレメトリエンドポイントなし、製品データはマシンから出ません。計測イベントはあなたが所有するローカルSQLiteの行です。ゼロのネットワーク呼び出し——ただし組織の管理者が Teams 版の組織テレメトリコレクターを有効化した場合を除きます(PRIVACY.md 参照)。その場合、セッションごとの集計(プロンプトや内容は決して含まない)が管理者指定のコレクターに送信され、ダッシュボードにバナーが表示されます。
 
 </details>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -29,7 +29,7 @@
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="의존성 없음">
-  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="텔레메트리 없음">
+  <img src="https://img.shields.io/badge/telemetry-off_by_default-brightgreen" alt="텔레메트리 기본 꺼짐">
   <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9 이상">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="플랫폼">
   <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="라이선스: PolyForm Noncommercial"></a>
@@ -231,7 +231,7 @@ RTK와 Boost는 첫 번째 표면에 도달합니다. Headroom은 첫 번째와 
 | 캐시 안전 | 🟢 기존 컨텍스트 접두사 수정 안 함 | 🟡 프록시 모드가 진행 중 재작성 | 🟢 사전 셸만 | 🟢 사전 셸만 | 🟡 MCP 오버헤드 | 🟢 |
 | 기준선 컨텍스트 오버헤드 없음 | 🟢 외부 프로세스, 컨텍스트 주입 없음 | 🔴 지시 주입 | 🟢 셸 수준만 | 🟢 셸 수준만 | 🔴 MCP 서버 오버헤드 | 🟢 네이티브 |
 | 런타임 의존성 없음 | 🟢 순수 표준 라이브러리 (Python/TypeScript) | 🟡 Python + Rust + 선택적 모델 | 🟢 단일 Rust 바이너리 | 🟢 단일 바이너리 | 🟡 SQLite 어댑터 필요 | 🟢 N/A |
-| 텔레메트리 없음 | 🟢 기계 밖으로 아무것도 나가지 않음 | 🟡 `HEADROOM_TELEMETRY` 옵트인, 기본 꺼짐 | 🟡 옵트인 | 🔴 호출된 명령, 명령 인자, 종료 코드, 지속 시간, CI 속성, IP 수집 | 🟡 다양함 | 🟢 |
+| 기본 텔레메트리 없음 | 🟢 조직 관리자가 Teams 에디션 수집기를 활성화하지 않는 한 기계 밖으로 아무것도 나가지 않음 (PRIVACY.md 참조) | 🟡 `HEADROOM_TELEMETRY` 옵트인, 기본 꺼짐 | 🟡 옵트인 | 🔴 호출된 명령, 명령 인자, 종료 코드, 지속 시간, CI 속성, IP 수집 | 🟡 다양함 | 🟢 |
 | 멀티 플랫폼 | 🟢 Claude Code, VS Code, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15개 통합 | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17개 통합 | 🔴 Claude Code만 |
 | 작업별 모델 및 노력 조언 | 🟢 `route`가 돈 쓰기 전에 작업 크기 측정 | — | — | — | — | — |
 | 킵 웜(Keep-Warm) (캐시 TTL 갱신) | 🟢 캐시 만료 전 옵트인 핑, 트립와이어 자동 꺼짐 | 🔴 | 🔴 | — | 🔴 | 🔴 |
@@ -612,7 +612,7 @@ python3 measure.py inject-routing              # 주입
 <details>
 <summary><b>📡 어디론가 데이터를 보내나요?</b></summary>
 
-분석 없음, 텔레메트리 엔드포인트 없음, 제품 데이터가 기계 밖으로 나가지 않음. 측정 이벤트는 사용자가 소유한 로컬 SQLite 행. 네트워크 호출 없음.
+기본적으로 분석 없음, 텔레메트리 엔드포인트 없음, 제품 데이터가 기계 밖으로 나가지 않음. 측정 이벤트는 사용자가 소유한 로컬 SQLite 행. 네트워크 호출 없음——조직 관리자가 Teams 에디션 조직 텔레메트리 수집기를 활성화한 경우는 예외입니다 (PRIVACY.md 참조). 그 경우 세션별 집계(프롬프트나 콘텐츠는 절대 제외)가 관리자가 지정한 수집기로 전송되며 대시보드에 배너가 표시됩니다.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="Zero Dependencies">
-  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="Zero Telemetry">
+  <img src="https://img.shields.io/badge/telemetry-off_by_default-brightgreen" alt="Telemetry off by default">
   <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platform">
   <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="License: PolyForm Noncommercial"></a>
@@ -157,7 +157,7 @@ Quickest path (Claude Code plugin install):
 - 🗄️ **Session Continuity**: cross-session hints, cold-resume, checkpoint scoring
 - 📦 **Active Compression**: 9 features, all on by default (delta diffs, skeletons, bash/search compression, lean-output nudges, quality nudges, loop detection, activity mode, decision extraction)
 - 📊 **Quality Scoring**: 7 signals, real-time, letter grades S–F
-- 🗃️ **Session Database**: SQLite, 15 tables, full audit trail, zero network
+- 🗃️ **Session Database**: SQLite, 15 tables, full audit trail, zero network by default
 - 🔍 **Progressive Disclosure**: large outputs archived, expand on demand
 - 🧠 **Context Intel Digest**: post-compaction re-orientation without re-reads
 - 🔀 **Model Routing Nudges**: steers to the right tier for the task
@@ -232,7 +232,7 @@ These ten rows are the ones where Token Optimizer is the only 🟢 in the row: w
 | Cache-safe | 🟢 Never modifies existing context prefix | 🟡 Proxy mode rewrites in-flight | 🟢 Pre-shell only | 🟢 Pre-shell only | 🟡 MCP overhead | 🟢 |
 | Zero baseline context overhead | 🟢 External process, no context injection | 🔴 Injects instructions | 🟢 Shell-level only | 🟢 Shell-level only | 🔴 MCP server overhead | 🟢 Native |
 | Zero runtime dependencies | 🟢 Pure stdlib (Python/TypeScript) | 🟡 Python + Rust + optional model | 🟢 Single Rust binary | 🟢 Single binary | 🟡 SQLite adapter required | 🟢 N/A |
-| Zero telemetry | 🟢 Nothing leaves the machine | 🟡 `HEADROOM_TELEMETRY` opt-in, off by default | 🟡 Opt-in | 🔴 Collects commands invoked, command arguments, exit codes, duration, CI attributes, IP | 🟡 Varies | 🟢 |
+| Zero telemetry by default | 🟢 Nothing leaves the machine unless an org admin enables the Teams-edition collector (see PRIVACY.md) | 🟡 `HEADROOM_TELEMETRY` opt-in, off by default | 🟡 Opt-in | 🔴 Collects commands invoked, command arguments, exit codes, duration, CI attributes, IP | 🟡 Varies | 🟢 |
 | Multi-platform | 🟢 Claude Code, VS Code, Cowork, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15 integrations | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17 integrations | 🔴 Claude Code only |
 | Per-task model and effort advice | 🟢 `route` sizes the task before you spend | — | — | — | — | — |
 | Keep-Warm (cache TTL refresh) | 🟢 Opt-in ping before cache expiry, tripwire auto-off | 🔴 | 🔴 | — | 🔴 | 🔴 |
@@ -655,7 +655,7 @@ No. Token Optimizer never touches content already in your context. It works on n
 <details>
 <summary><b>📡 Does it send any data anywhere?</b></summary>
 
-No analytics, no telemetry endpoint, no product data leaves your machine. Measurement events are local SQLite rows you own. Zero network calls.
+No analytics, no telemetry endpoint, no product data leaves your machine by default. Measurement events are local SQLite rows you own. Zero network calls — unless your org admin has enabled the Teams-edition org telemetry collector (see PRIVACY.md), in which case per-session aggregates (never prompts, never content) are sent to the collector your admin chose, and the dashboard shows a banner saying so.
 
 </details>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="零依赖">
-  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="零遥测">
+  <img src="https://img.shields.io/badge/telemetry-off_by_default-brightgreen" alt="遥测默认关闭">
   <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="平台">
   <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="许可证: PolyForm Noncommercial"></a>
@@ -231,7 +231,7 @@ RTK 和 Boost 到达第一个面。Headroom 到达第一个和第三个。Token 
 | 缓存安全 | 🟢 从不修改现有上下文前缀 | 🟡 代理模式重写进行中的 | 🟢 仅 pre-shell | 🟢 仅 pre-shell | 🟡 MCP 开销 | 🟢 |
 | 零基线上下文开销 | 🟢 外部进程,无上下文注入 | 🔴 注入指令 | 🟢 仅 shell 级 | 🟢 仅 shell 级 | 🔴 MCP 服务器开销 | 🟢 原生 |
 | 零运行时依赖 | 🟢 纯标准库(Python/TypeScript) | 🟡 Python + Rust + 可选模型 | 🟢 单个 Rust 二进制 | 🟢 单个二进制 | 🟡 需要 SQLite 适配器 | 🟢 N/A |
-| 零遥测 | 🟢 不离开机器 | 🟡 `HEADROOM_TELEMETRY` opt-in,默认关 | 🟡 opt-in | 🔴 收集调用的命令、命令参数、退出码、时长、CI 属性、IP | 🟡 各异 | 🟢 |
+| 默认零遥测 | 🟢 除非组织管理员启用 Teams 版收集器,否则不离开机器(见 PRIVACY.md) | 🟡 `HEADROOM_TELEMETRY` opt-in,默认关 | 🟡 opt-in | 🔴 收集调用的命令、命令参数、退出码、时长、CI 属性、IP | 🟡 各异 | 🟢 |
 | 多平台 | 🟢 Claude Code、VS Code、Codex、OpenClaw、OpenCode、Hermes、Copilot | 🟢 Claude Code、Cursor、Codex、Aider、Copilot | 🟢 15 个集成 | 🟡 Cursor、Claude Code、Copilot、Codex CLI | 🟢 17 个集成 | 🔴 仅 Claude Code |
 | 按任务的模型和力度建议 | 🟢 `route` 在你花钱前衡量任务 | — | — | — | — | — |
 | Keep-Warm(缓存 TTL 刷新) | 🟢 缓存过期前 opt-in ping,绊线自动关 | 🔴 | 🔴 | — | 🔴 | 🔴 |
@@ -612,7 +612,7 @@ python3 measure.py inject-routing              # 注入
 <details>
 <summary><b>📡 它会把任何数据发到任何地方吗?</b></summary>
 
-无分析,无遥测端点,无产品数据离开你的机器。测量事件是你拥有的本地 SQLite 行。零网络调用。
+默认情况下,无分析,无遥测端点,无产品数据离开你的机器。测量事件是你拥有的本地 SQLite 行。零网络调用——除非你的组织管理员启用了 Teams 版组织遥测收集器(见 PRIVACY.md),此时每会话聚合数据(绝不包含提示词或内容)会发送到管理员指定的收集器,并且仪表板会显示横幅。
 
 </details>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,7 +101,7 @@ Bash compression output preserves credential-containing lines verbatim (not reda
 
 **At rest:** Token Optimizer does not encrypt local data stores. Data protection relies on filesystem permissions (`0o700` directories, `0o600` files). For environments requiring encryption at rest, enable FileVault (macOS) or LUKS (Linux) at the OS level.
 
-**In transit:** No data is transmitted. The dashboard server uses plain HTTP but is bound to loopback only (`127.0.0.1`), so traffic never leaves the network stack.
+**In transit:** No data is transmitted by default. The dashboard server uses plain HTTP but is bound to loopback only (`127.0.0.1`), so traffic never leaves the network stack. The one exception is the admin-enabled org telemetry channel (Teams edition, see PRIVACY.md): when an admin has placed a `fleet.json`, per-session aggregates POST to that collector over at most two 3-second bounded requests per flush.
 
 ---
 
@@ -175,7 +175,7 @@ Token Optimizer installs hooks into the host platform's `settings.json` via the 
 | No encryption at rest | Filesystem permissions (0o700/0o600). Use OS-level encryption for additional protection. |
 | No admin policy enforcement / MDM | Single-user local tool. Config is per-user, no org-wide lockdown. |
 | No structured audit log | Functional telemetry (checkpoint events, compression events) provides partial coverage. |
-| No TLS on dashboard | Loopback-only binding. Traffic never leaves the machine. |
+| No TLS on dashboard | Loopback-only binding. Traffic never leaves the machine. Org telemetry (admin-enabled fleet.json) posts to the admin's collector instead; see PRIVACY.md. |
 | settings.json is user-writable | Hook registrations have no integrity verification. A local attacker with filesystem access could modify hook configuration. |
 | Transcript preservation | Token Optimizer sets `cleanupPeriodDays=99999` in settings.json to preserve transcripts for trend analysis. This is intentional and documented. Users can override this setting. Transcripts are the host platform's data, not Token Optimizer's. |
 

--- a/cowork/token-optimizer/PRIVACY.md
+++ b/cowork/token-optimizer/PRIVACY.md
@@ -118,9 +118,21 @@ Manual deletion: remove the following directories:
 
 ## Cross-Platform
 
-The same privacy guarantees apply across all supported platforms (Claude Code, Codex, OpenCode, Hermes). Data paths vary by platform but the architecture is identical: local-only, zero network, credential-redacted storage.
+The same privacy guarantees apply across all supported platforms (Claude Code, Codex, OpenCode, Hermes). Data paths vary by platform but the architecture is identical: local-only, zero network by default, credential-redacted storage. The one exception is the admin-enabled org telemetry channel described below.
 
 Consent is tracked per-runtime. A user running both Claude Code and Codex must acknowledge consent separately in each runtime.
+
+## Teams edition: admin-enabled org telemetry
+
+Token Optimizer has a separate Teams edition for organizations. It is **admin-enabled, not opt-in by the individual**: nothing is emitted unless an org admin has placed a `fleet.json` (mode 0600) in Token Optimizer's config dir holding a collector `endpoint`, an ingest `token` (or `token_env`), and a per-org `hash_key` (or `hash_key_env`). Environment variables alone never enable emission; `TO_FLEET_DISABLE=1` on one machine overrides everything. When active, the local dashboard shows a banner ("Org telemetry active: sending session aggregates to ...") and `fleet_emitter.py --status` reports the state.
+
+**Exactly what is sent, per session** (aggregates Token Optimizer already computes and stores locally): platform, pseudonymous user/host/project identifiers (HMAC-SHA256 keyed by the org's `hash_key`, truncated), token counts (input, output, cache read, cache create, reported), model names and per-model token split, cost in USD with its `cost_source`, counted savings (tokens and USD) with a `savings_coverage` marker, quality score/grade, timestamps, and one account-level limit-meter reading when the meter is available. The envelope also carries `billing_mode` (`api`/`subscription`/`unknown`), `savings_method`, and a `models_redacted` count. If the admin sets `send_user_label: true`, the canonical identity string (config user, else `TO_FLEET_USER`, else gitconfig email, else OS username) travels as `user_label`; it is absent otherwise.
+
+**Never sent**: prompts, assistant responses, file contents, file paths, command text, tool output, topics, slugs. The allowlist is enforced on keys AND values before serialisation; model names not matching a strict pattern are replaced with `custom-<hmac>` and counted in `models_redacted`.
+
+**Pseudonymity**: identifiers are pseudonymous, re-identifiable by the org's collector operator by design (the operator holds the `hash_key`). Delivery is fail-open and bounded: events queue in a local outbox (0600) and drain with at most two 3-second POSTs per session-end flush; a down collector never blocks a hook. Inspect exactly what would be sent with `python3 fleet_emitter.py --dry-run` — the output is sensitive (it contains your org's aggregates) and is meant to be shared deliberately with whoever runs the collector. A one-line entry per flush lands in `fleet.log`.
+
+Claude Code's own OTel exporter can also point at the collector (OTLP/HTTP) as a second ingest path; only `api_request` metrics are retained. See `docs/teams-telemetry.md` for admin setup, credential placement and rotation.
 
 ## Source Available
 

--- a/cowork/token-optimizer/README.md
+++ b/cowork/token-optimizer/README.md
@@ -29,7 +29,7 @@
 </p>
 <p align="center">
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="Zero Dependencies">
-  <img src="https://img.shields.io/badge/telemetry-none-brightgreen" alt="Zero Telemetry">
+  <img src="https://img.shields.io/badge/telemetry-off_by_default-brightgreen" alt="Telemetry off by default">
   <img src="https://img.shields.io/badge/python-3.9+-blue" alt="Python 3.9+">
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey" alt="Platform">
   <a href="https://github.com/alexgreensh/token-optimizer/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-PolyForm%20Noncommercial-blue.svg" alt="License: PolyForm Noncommercial"></a>
@@ -157,7 +157,7 @@ Quickest path (Claude Code plugin install):
 - 🗄️ **Session Continuity**: cross-session hints, cold-resume, checkpoint scoring
 - 📦 **Active Compression**: 9 features, all on by default (delta diffs, skeletons, bash/search compression, lean-output nudges, quality nudges, loop detection, activity mode, decision extraction)
 - 📊 **Quality Scoring**: 7 signals, real-time, letter grades S–F
-- 🗃️ **Session Database**: SQLite, 15 tables, full audit trail, zero network
+- 🗃️ **Session Database**: SQLite, 15 tables, full audit trail, zero network by default
 - 🔍 **Progressive Disclosure**: large outputs archived, expand on demand
 - 🧠 **Context Intel Digest**: post-compaction re-orientation without re-reads
 - 🔀 **Model Routing Nudges**: steers to the right tier for the task
@@ -232,7 +232,7 @@ These ten rows are the ones where Token Optimizer is the only 🟢 in the row: w
 | Cache-safe | 🟢 Never modifies existing context prefix | 🟡 Proxy mode rewrites in-flight | 🟢 Pre-shell only | 🟢 Pre-shell only | 🟡 MCP overhead | 🟢 |
 | Zero baseline context overhead | 🟢 External process, no context injection | 🔴 Injects instructions | 🟢 Shell-level only | 🟢 Shell-level only | 🔴 MCP server overhead | 🟢 Native |
 | Zero runtime dependencies | 🟢 Pure stdlib (Python/TypeScript) | 🟡 Python + Rust + optional model | 🟢 Single Rust binary | 🟢 Single binary | 🟡 SQLite adapter required | 🟢 N/A |
-| Zero telemetry | 🟢 Nothing leaves the machine | 🟡 `HEADROOM_TELEMETRY` opt-in, off by default | 🟡 Opt-in | 🔴 Collects commands invoked, command arguments, exit codes, duration, CI attributes, IP | 🟡 Varies | 🟢 |
+| Zero telemetry by default | 🟢 Nothing leaves the machine unless an org admin enables the Teams-edition collector (see PRIVACY.md) | 🟡 `HEADROOM_TELEMETRY` opt-in, off by default | 🟡 Opt-in | 🔴 Collects commands invoked, command arguments, exit codes, duration, CI attributes, IP | 🟡 Varies | 🟢 |
 | Multi-platform | 🟢 Claude Code, VS Code, Cowork, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15 integrations | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17 integrations | 🔴 Claude Code only |
 | Per-task model and effort advice | 🟢 `route` sizes the task before you spend | — | — | — | — | — |
 | Keep-Warm (cache TTL refresh) | 🟢 Opt-in ping before cache expiry, tripwire auto-off | 🔴 | 🔴 | — | 🔴 | 🔴 |
@@ -655,7 +655,7 @@ No. Token Optimizer never touches content already in your context. It works on n
 <details>
 <summary><b>📡 Does it send any data anywhere?</b></summary>
 
-No analytics, no telemetry endpoint, no product data leaves your machine. Measurement events are local SQLite rows you own. Zero network calls.
+No analytics, no telemetry endpoint, no product data leaves your machine by default. Measurement events are local SQLite rows you own. Zero network calls — unless your org admin has enabled the Teams-edition org telemetry collector (see PRIVACY.md), in which case per-session aggregates (never prompts, never content) are sent to the collector your admin chose, and the dashboard shows a banner saying so.
 
 </details>
 

--- a/cowork/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/cowork/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -2046,6 +2046,8 @@ window.__TOKEN_DATA__ = null;
 
   <!-- MAIN -->
   <main class="main-col">
+    <!-- Org telemetry banner (Teams edition): rendered only when active -->
+    <div id="fleet-telemetry-banner" style="display:none;font-size:12px;font-family:var(--font-mono);padding:6px 12px;border:1px solid var(--c-border);border-radius:6px;margin:8px 0 0;color:var(--c-text-dim);"></div>
     <!-- Overview View -->
     <div class="view active" id="view-overview">
       <header class="header">
@@ -7009,6 +7011,14 @@ document.addEventListener('DOMContentLoaded', function() {
     if (data.version) brandParts.push('v' + data.version);
     if (data.runtime === 'codex') brandParts.push('Codex');
     brandMeta.textContent = brandParts.join(' \u00b7 ');
+  }
+  // Org telemetry banner (Teams edition): visible only when an admin-enabled
+  // fleet.json is active on this machine. textContent only, never innerHTML.
+  var fleetBanner = document.getElementById('fleet-telemetry-banner');
+  if (fleetBanner && data.fleet_telemetry && data.fleet_telemetry.active) {
+    fleetBanner.textContent = 'Org telemetry active: sending session aggregates to '
+      + (data.fleet_telemetry.endpoint_host || 'unknown endpoint');
+    fleetBanner.style.display = 'block';
   }
 
   function startApp() { DB.init(data); refreshSavingsLive(); }

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/fleet_emitter.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/fleet_emitter.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""Admin-enabled org telemetry emitter (Token Optimizer Teams edition).
+
+OFF BY DEFAULT, and file-only: nothing is emitted unless an org admin has
+placed a ``fleet.json`` (mode 0600) in Token Optimizer's config dir holding
+``endpoint``, ``hash_key`` and either ``token`` or ``token_env``. Environment
+variables alone never enable emission (a cloned repo's settings must not be
+able to switch telemetry on). ``TO_FLEET_DISABLE=1`` overrides everything.
+
+What it sends when enabled: per-session aggregates Token Optimizer already
+stores locally (platform, pseudonymous ids, token counts, model split, cost,
+counted savings, one account-level limit-meter reading, timestamps). Never
+prompts, never responses, never file contents, never file paths, never command
+text, never tool output. The allowlist below is enforced on keys AND values
+before serialisation.
+
+Delivery: events queue in a local outbox (JSONL, 0600, atomic writes) first,
+then the outbox is drained with bounded POSTs (3s timeout, at most two batches
+per flush, redirects refused). A failed POST leaves the outbox intact; the id
+cursor advances only after a 2xx. Every entry point is fail-open: nothing here
+can raise into a hook.
+
+Inspect exactly what would be sent: ``python3 fleet_emitter.py --dry-run``
+(output is sensitive: it contains this org's pseudonymous aggregates).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import stat
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+SCHEMA = "to.fleet.v1"
+
+ENV_DISABLE = "TO_FLEET_DISABLE"
+ENV_CONFIG = "TO_FLEET_CONFIG"
+ENV_USER = "TO_FLEET_USER"
+ENV_HASH_KEY = "TO_FLEET_HASH_KEY"
+
+CONFIG_FILENAME = "fleet.json"
+OUTBOX_NAME = "fleet-outbox.jsonl"
+CURSOR_NAME = "fleet-cursor.json"
+LOG_NAME = "fleet.log"
+
+MAX_BATCH = 200            # events per POST
+MAX_POSTS_PER_FLUSH = 2    # bounded network time per session-end flush
+MAX_OUTBOX = 500           # events kept locally while the collector is down
+MAX_OUTBOX_AGE_DAYS = 7
+RECENT_DAYS = 2            # re-send rows this recent so backfilled columns land
+MIN_NETWORK_SECONDS = 7.0  # skip the network step when less budget remains
+TIMEOUT_S = 3.0
+LOG_MAX_LINES = 200
+TMP_MAX_AGE_S = 600
+
+_MODEL_RE = re.compile(r"^[A-Za-z0-9._:@-]{1,80}$")
+_HASHISH_RE = re.compile(r"^(?:[0-9a-f]{16,32}|p-[0-9a-f]{30})$")
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+_LOOPBACK = ("127.0.0.1", "localhost", "::1")
+
+# Every key a wire event may carry. Anything else is stripped by sanitize_event().
+EVENT_KEYS = frozenset({
+    "type", "session_uuid", "platform", "project_hash", "date",
+    "started_at", "ended_at", "duration_minutes",
+    "input_tokens", "output_tokens", "cache_read_tokens", "cache_create_tokens",
+    "reported_input_tokens", "reported_output_tokens", "api_calls", "message_count",
+    "models", "cost_usd", "cost_source", "savings", "savings_coverage",
+    "quality_score", "quality_grade",
+})
+ENVELOPE_KEYS = frozenset({
+    "schema", "sent_at", "to_version", "user_hash", "host_hash",
+    "limit", "billing_mode", "savings_method", "models_redacted",
+    "user_label", "events",
+})
+_MODEL_PART_KEYS = ("fresh_input", "cache_read", "cache_create", "output")
+_STR_KEYS = frozenset({"type", "session_uuid", "platform", "project_hash", "date",
+                       "started_at", "ended_at", "cost_source", "savings_coverage",
+                       "quality_grade"})
+
+
+def clamp(text, length=120):
+    """Clamp to printable ASCII (control chars and non-ASCII dropped)."""
+    return "".join(c for c in str(text or "") if 32 <= ord(c) < 127)[:length]
+
+
+# --------------------------------------------------------------------------- #
+# Configuration (file-only enablement, R2/R2a/R2b)
+# --------------------------------------------------------------------------- #
+
+def load_config(env=None, config_dir=None):
+    """Return a config dict, or None when telemetry is not configured.
+
+    A fleet.json is REQUIRED. Env vars alone never enable. The file must be
+    owner-readable only; a group/world-readable file is ignored with a logged
+    reason. TO_FLEET_CONFIG must resolve inside config_dir when config_dir is
+    given. Endpoints must be https:// except loopback http.
+    """
+    env = os.environ if env is None else env
+    if (env.get(ENV_DISABLE) or "").strip().lower() in ("1", "true", "yes", "on"):
+        return None
+    base = Path(config_dir).expanduser() if config_dir else _default_config_dir(env)
+    override = (env.get(ENV_CONFIG) or "").strip()
+    if override:
+        p = Path(override).expanduser().resolve()
+        try:
+            p.relative_to(base.resolve())
+        except ValueError:
+            return None
+    else:
+        p = base / CONFIG_FILENAME
+    try:
+        if not p.is_file():
+            return None
+        mode = p.stat().st_mode
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            log_line(None, f"config ignored: {p.name} is group/world-readable")
+            return None
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict) or raw.get("enabled") is False:
+        return None
+    endpoint = str(raw.get("endpoint") or "").strip()
+    token = str(raw.get("token") or "").strip()
+    if not token:
+        token = (env.get(str(raw.get("token_env") or "") or "") or "").strip()
+    hash_key = str(raw.get("hash_key") or "").strip()
+    if not hash_key:
+        hk_env = str(raw.get("hash_key_env") or "").strip()
+        hash_key = (env.get(hk_env) or "").strip() if hk_env else \
+            (env.get(ENV_HASH_KEY) or "").strip()
+    if not endpoint or not token or not hash_key:
+        return None
+    endpoint = clamp(endpoint, 300)
+    scheme, _, rest = endpoint.partition("://")
+    host = rest.split("/")[0].split(":")[0].lower()
+    if scheme == "http" and host not in _LOOPBACK:
+        return None
+    if scheme not in ("http", "https"):
+        return None
+    return {
+        "endpoint": endpoint.rstrip("/"),
+        "token": token,
+        "hash_key": hash_key,
+        "user": clamp(raw.get("user") or "", 120),
+        "send_user_label": bool(raw.get("send_user_label", False)),
+        "source": str(p),
+    }
+
+
+def _default_config_dir(env):
+    """Mirror measure.CONFIG_DIR cheaply (no measure import when disabled)."""
+    base = (env.get("TOKEN_OPTIMIZER_CONFIG_DIR") or "").strip()
+    if base:
+        return Path(base).expanduser()
+    runtime = (env.get("TOKEN_OPTIMIZER_RUNTIME") or "").strip().lower()
+    home = Path(env.get("HOME") or env.get("USERPROFILE") or str(Path.home()))
+    if runtime == "codex":
+        return home / ".codex" / "token-optimizer"
+    if runtime == "opencode":
+        return home / ".local" / "share" / "opencode" / "token-optimizer"
+    if runtime == "hermes":
+        return home / ".hermes" / "token-optimizer"
+    if runtime == "copilot":
+        return home / ".copilot" / "token-optimizer"
+    return home / ".claude" / "token-optimizer"
+
+
+def is_enabled(env=None, config_dir=None):
+    return load_config(env=env, config_dir=config_dir) is not None
+
+
+def enable(endpoint, token, hash_key, config_dir=None, env=None):
+    """Write fleet.json at mode 0600. Returns (ok, path_or_reason)."""
+    env = os.environ if env is None else env
+    base = Path(config_dir).expanduser() if config_dir else _default_config_dir(env)
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+        path = base / CONFIG_FILENAME
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"endpoint": endpoint, "token": token, "hash_key": hash_key}, fh)
+            fh.write("\n")
+        os.chmod(str(path), 0o600)
+        return True, str(path)
+    except OSError as exc:
+        return False, exc.__class__.__name__
+
+
+# --------------------------------------------------------------------------- #
+# Pseudonymous identity (R3/R3a, KTD7: HMAC keyed by the org hash_key)
+# --------------------------------------------------------------------------- #
+
+def canonical_identity(cfg, env=None, home=None):
+    """fleet.json user -> TO_FLEET_USER -> gitconfig user.email -> OS user."""
+    env = os.environ if env is None else env
+    if cfg.get("user"):
+        return cfg["user"]
+    v = (env.get(ENV_USER) or "").strip()
+    if v:
+        return v
+    gitconfig = Path(home or Path.home()) / ".gitconfig"
+    try:
+        in_user = False
+        for line in gitconfig.read_text(encoding="utf-8", errors="replace").splitlines():
+            s = line.strip()
+            if s.startswith("["):
+                in_user = s.lower().startswith("[user")
+                continue
+            if in_user and "=" in s:
+                k, _, val = s.partition("=")
+                if k.strip().lower() == "email" and val.strip():
+                    return val.strip()
+    except OSError:
+        pass
+    try:
+        import getpass
+        return getpass.getuser()
+    except Exception:
+        return "unknown"
+
+
+def _hmac(hash_key, value, length):
+    return hmac.new(hash_key.encode("utf-8"), str(value).encode("utf-8"),
+                    hashlib.sha256).hexdigest()[:length]
+
+
+def user_hash(cfg, env=None, home=None):
+    return _hmac(cfg["hash_key"], canonical_identity(cfg, env, home), 32)
+
+
+def host_hash(cfg):
+    try:
+        import socket
+        host = socket.gethostname()
+    except Exception:
+        host = "unknown"
+    return _hmac(cfg["hash_key"], host, 16)
+
+
+def project_hash(cfg, project):
+    return _hmac(cfg["hash_key"], project or "", 16)
+
+
+def session_uuid_for(cfg, row_uuid, jsonl_path):
+    """R4a: stored uuid verbatim; NULL falls back to the filename UUID, then an
+    HMAC of the path (the path itself never leaves the machine)."""
+    if row_uuid:
+        s = str(row_uuid).strip()
+        if _UUID_RE.fullmatch(s):
+            return s.lower()
+        return _hmac(cfg["hash_key"], "sid:" + s, 32)
+    m = _UUID_RE.search(Path(str(jsonl_path or "")).name)
+    if m:
+        return m.group(0).lower()
+    if jsonl_path:
+        return "p-" + _hmac(cfg["hash_key"], "path:" + str(jsonl_path), 30)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Value sanitisation (R4: allowlist on keys AND values)
+# --------------------------------------------------------------------------- #
+
+def _num(value, default=0):
+    try:
+        if value is None:
+            return default
+        n = float(value)
+        if n != n or n in (float("inf"), float("-inf")):
+            return default
+        return int(n) if float(n).is_integer() else round(n, 6)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def sanitize_model_name(cfg, name):
+    """Strip a provider prefix; enforce the R4 pattern; redact otherwise."""
+    raw = str(name or "")
+    stripped = raw.rsplit("/", 1)[-1] if "/" in raw else raw
+    if _MODEL_RE.fullmatch(stripped):
+        return stripped, False
+    return "custom-" + _hmac(cfg["hash_key"], "model:" + raw, 16), True
+
+
+def sanitize_event(cfg, event):
+    """Allowlist filter. Returns a clean dict or None when the event is unusable."""
+    if not isinstance(event, dict):
+        return None
+    out = {}
+    redacted = 0
+    for key, value in event.items():
+        if key not in EVENT_KEYS:
+            continue
+        if key == "models":
+            models = {}
+            if isinstance(value, dict):
+                for model, parts in value.items():
+                    if not isinstance(parts, dict):
+                        continue
+                    clean, was_redacted = sanitize_model_name(cfg, model)
+                    redacted += 1 if was_redacted else 0
+                    models[clean] = {k: _num(parts.get(k)) for k in _MODEL_PART_KEYS}
+            out[key] = models
+        elif key == "savings":
+            sv = value if isinstance(value, dict) else {}
+            out[key] = {"tokens": _num(sv.get("tokens")),
+                        "cost_usd": round(_num(sv.get("cost_usd"), 0.0), 6)}
+        elif key == "limit":
+            out[key] = None
+            if isinstance(value, dict):
+                out[key] = {
+                    "five_hour_pct": _num(value.get("five_hour_pct"), None),
+                    "seven_day_pct": _num(value.get("seven_day_pct"), None),
+                    "ts": _num(value.get("ts"), None),
+                }
+        elif key in _STR_KEYS:
+            out[key] = None if value is None else clamp(value, 64)
+            if key == "project_hash" and out[key] and not _HASHISH_RE.fullmatch(out[key]):
+                out[key] = _hmac(cfg.get("hash_key", ""), "proj:" + out[key], 16)
+        else:
+            out[key] = _num(value, None)
+    if out.get("type") != "session" or not out.get("session_uuid"):
+        return None
+    out["models_redacted"] = redacted
+    return out
+
+
+def build_payload(cfg, events, version, env=None, home=None, meters=None,
+                  billing_mode="unknown", savings_method="none"):
+    """Envelope + sanitised events. Envelope keys are the frozen ENVELOPE_KEYS."""
+    clean, redacted = [], 0
+    for ev in events:
+        c = sanitize_event(cfg, ev)
+        if c is None:
+            continue
+        redacted += c.pop("models_redacted", 0)
+        clean.append(c)
+    payload = {
+        "schema": SCHEMA,
+        "sent_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to_version": clamp(version or "unknown", 40),
+        "user_hash": user_hash(cfg, env, home),
+        "host_hash": host_hash(cfg),
+        "billing_mode": clamp(billing_mode or "unknown", 20),
+        "savings_method": clamp(savings_method or "none", 40),
+        "models_redacted": redacted,
+        "events": clean,
+    }
+    if isinstance(meters, dict) and meters.get("available"):
+        payload["limit"] = {
+            "five_hour_pct": _num(meters.get("five_hour_pct"), None),
+            "seven_day_pct": _num(meters.get("seven_day_pct"), None),
+            "ts": _num(meters.get("ts"), None),
+        }
+    if cfg.get("send_user_label"):
+        payload["user_label"] = clamp(canonical_identity(cfg, env, home), 120)
+    assert set(payload) <= ENVELOPE_KEYS
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Event building from trends.db (R4a-R4c, R6a, R6b)
+# --------------------------------------------------------------------------- #
+
+def build_session_events(conn, cfg, cursor_id=0, watermark="", runtime="claude",
+                         cost_fn=None, model_cost_fn=None, max_events=MAX_OUTBOX,
+                         now=None):
+    """Union of three bounded queries (R6a/R6b), ascending id, capped so a
+    backlog drains over flushes. Returns (events, max_id_seen, max_computed_at)."""
+    now = now or datetime.now()
+    recent_cutoff = (now - timedelta(days=RECENT_DAYS)).strftime("%Y-%m-%d")
+    budget = max(0, int(max_events))
+    ids = set()
+    for (rid,) in conn.execute(
+            "SELECT id FROM session_log WHERE id > ? ORDER BY id ASC LIMIT ?",
+            (int(cursor_id or 0), budget)):
+        ids.add(int(rid))
+    for (rid,) in conn.execute(
+            "SELECT id FROM session_log WHERE date >= ? ORDER BY id ASC LIMIT ?",
+            (recent_cutoff, budget)):
+        ids.add(int(rid))
+    if watermark:
+        for (rid,) in conn.execute(
+                "SELECT s.id FROM session_log s WHERE s.session_uuid IN "
+                "(SELECT DISTINCT session_uuid FROM counted_reread "
+                " WHERE computed_at > ?) AND s.id > 0 ORDER BY s.id ASC LIMIT ?",
+                (str(watermark), budget)):
+            ids.add(int(rid))
+    if not ids:
+        return [], int(cursor_id or 0), str(watermark or "")
+    rows = conn.execute(
+        "SELECT id, jsonl_path, date, project, duration_minutes, input_tokens, "
+        "output_tokens, message_count, api_calls, cache_create_1h_tokens, "
+        "cache_create_5m_tokens, model_usage_json, model_usage_breakdown_json, "
+        "collected_at, quality_score, quality_grade, session_uuid, is_sidechain, "
+        "reported_input_tokens, reported_output_tokens, platform, "
+        "cost_usd, cost_source "
+        "FROM session_log WHERE id IN (%s) ORDER BY id ASC" % ",".join("?" * len(ids)),
+        tuple(sorted(ids))).fetchall()
+    events, max_id = [], int(cursor_id or 0)
+    for (rid, jsonl_path, date, project, duration, in_tok, out_tok, msgs, calls,
+         cc1h, cc5m, model_usage_json, breakdown_json, collected_at, qscore, qgrade,
+         row_uuid, sidechain, rep_in, rep_out, platform, cost_usd, cost_source) in rows:
+        max_id = max(max_id, int(rid or 0))
+        if sidechain:
+            continue
+        suuid = session_uuid_for(cfg, row_uuid, jsonl_path)
+        if not suuid:
+            continue
+        try:
+            breakdown = json.loads(breakdown_json) if breakdown_json else {}
+        except (TypeError, ValueError):
+            breakdown = {}
+        if not isinstance(breakdown, dict):
+            breakdown = {}
+        models, cache_read, cache_create = {}, 0, 0
+        for model, parts in breakdown.items():
+            if not isinstance(parts, dict):
+                continue
+            clean, _ = sanitize_model_name(cfg, model)
+            models[clean] = {k: _num(parts.get(k)) for k in _MODEL_PART_KEYS}
+            cache_read += _num(parts.get("cache_read"))
+            cache_create += _num(parts.get("cache_create"))
+        # R4b cost precedence: stored -> breakdown -> dominant-model fallback.
+        cost, used_source = 0.0, None
+        if cost_source:
+            cost, used_source = _num(cost_usd, 0.0), clamp(cost_source, 40)
+        elif breakdown and cost_fn is not None:
+            try:
+                cost = float(cost_fn(breakdown, cache_create_1h=cc1h,
+                                     cache_create_5m=cc5m) or 0.0)
+            except Exception:
+                cost = 0.0
+        elif model_cost_fn is not None:
+            try:
+                usage = json.loads(model_usage_json) if model_usage_json else {}
+            except (TypeError, ValueError):
+                usage = {}
+            if isinstance(usage, dict) and usage:
+                dominant = max(usage, key=lambda m: _num(usage[m]
+                               if isinstance(usage[m], dict) else usage[m]))
+                parts = breakdown.get(dominant, {}) if isinstance(breakdown, dict) else {}
+                cost = float(model_cost_fn(dominant, _num(parts.get("fresh_input")),
+                                           _num(parts.get("output")),
+                                           _num(parts.get("cache_read")),
+                                           _num(parts.get("cache_create"))) or 0.0)
+        counted = runtime == "claude"
+        tokens, sav_cost = _counted_savings(conn, suuid) if counted else (0, 0.0)
+        events.append({
+            "type": "session",
+            "session_uuid": suuid,
+            "platform": clamp(platform or "unknown", 32),
+            "project_hash": project_hash(cfg, project),
+            "date": clamp(date, 10),
+            "started_at": None,
+            "ended_at": clamp(collected_at, 32),
+            "duration_minutes": _num(duration, None),
+            "input_tokens": _num(in_tok, None),
+            "output_tokens": _num(out_tok, None),
+            "cache_read_tokens": cache_read,
+            "cache_create_tokens": cache_create,
+            "reported_input_tokens": _num(rep_in, None),
+            "reported_output_tokens": _num(rep_out, None),
+            "api_calls": _num(calls, None),
+            "message_count": _num(msgs, None),
+            "models": models,
+            "cost_usd": round(cost, 6),
+            "cost_source": used_source,
+            "savings": {"tokens": tokens, "cost_usd": round(sav_cost, 6)},
+            "savings_coverage": "counted" if counted else "unsupported_platform",
+            "quality_score": _num(qscore, None),
+            "quality_grade": clamp(qgrade, 8) if qgrade else None,
+            "_src_id": int(rid),
+        })
+    try:
+        wm = conn.execute("SELECT MAX(computed_at) FROM counted_reread").fetchone()
+        max_wm = str(wm[0]) if wm and wm[0] else str(watermark or "")
+    except Exception:
+        max_wm = str(watermark or "")
+    return events, max_id, max_wm
+
+
+def _counted_savings(conn, session_uuid):
+    """R4c: the counted_reread ledger sums for one session."""
+    tokens, cost = 0, 0.0
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(tokens),0), COALESCE(SUM(oneshot_usd + reread_usd),0) "
+            "FROM counted_reread WHERE session_uuid = ?", (session_uuid,)).fetchone()
+        if row:
+            tokens, cost = int(row[0] or 0), float(row[1] or 0.0)
+    except Exception:
+        pass
+    return tokens, cost
+
+
+# --------------------------------------------------------------------------- #
+# Outbox, cursor, log (atomic 0600 writes, R6)
+# --------------------------------------------------------------------------- #
+
+def _write_private(path, text):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.parent / f".{path.name}.{os.getpid()}.{os.urandom(4).hex()}.tmp"
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.chmod(str(tmp), 0o600)
+        os.replace(str(tmp), str(path))
+    except BaseException:
+        try:
+            os.unlink(str(tmp))
+        except OSError:
+            pass
+        raise
+
+
+def snapshot_dir_ok(snapshot_dir):
+    """R6: a group/world-writable snapshot dir disables emission."""
+    if snapshot_dir is None:
+        return False
+    try:
+        st = os.stat(str(snapshot_dir))
+        return not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+    except OSError:
+        return False
+
+
+def reap_stale_tmp(snapshot_dir, now=None):
+    now = time.time() if now is None else now
+    try:
+        for p in Path(snapshot_dir).glob("*.tmp"):
+            try:
+                if now - p.stat().st_mtime > TMP_MAX_AGE_S:
+                    p.unlink()
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+def log_line(snapshot_dir, message):
+    try:
+        path = Path(snapshot_dir) / LOG_NAME if snapshot_dir else None
+        if path is None:
+            return
+        stamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = []
+        if path.exists():
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        lines.append(f"{stamp} {clamp(message, 300)}")
+        _write_private(path, "\n".join(lines[-LOG_MAX_LINES:]) + "\n")
+    except Exception:
+        pass
+
+
+def read_state(snapshot_dir):
+    """Cursor + savings watermark from one file."""
+    try:
+        data = json.loads((Path(snapshot_dir) / CURSOR_NAME).read_text(encoding="utf-8"))
+        return int(data.get("last_id") or 0), str(data.get("watermark") or "")
+    except Exception:
+        return 0, ""
+
+
+def write_state(snapshot_dir, last_id, watermark):
+    try:
+        _write_private(Path(snapshot_dir) / CURSOR_NAME, json.dumps({
+            "last_id": int(last_id), "watermark": str(watermark or ""),
+            "updated_at": datetime.utcnow().isoformat() + "Z"}))
+    except Exception:
+        pass
+
+
+def read_outbox(snapshot_dir):
+    items = []
+    try:
+        path = Path(snapshot_dir) / OUTBOX_NAME
+        if not path.exists():
+            return items
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and isinstance(rec.get("event"), dict):
+                items.append(rec)
+    except OSError:
+        pass
+    return items
+
+
+def write_outbox(snapshot_dir, items):
+    try:
+        path = Path(snapshot_dir) / OUTBOX_NAME
+        if not items:
+            if path.exists():
+                path.unlink()
+            return
+        _write_private(path, "".join(
+            json.dumps(i, separators=(",", ":")) + "\n" for i in items))
+    except Exception:
+        pass
+
+
+def enqueue(snapshot_dir, events, source_ids=None, now=None):
+    """Append sanitised events to the outbox, dedup by session_uuid (newest
+    wins), enforce the size and age caps. Returns the number now queued."""
+    now = now or datetime.utcnow()
+    reap_stale_tmp(snapshot_dir, now.timestamp())
+    items = read_outbox(snapshot_dir)
+    by_uuid = {r["event"].get("session_uuid"): r for r in items}
+    source_ids = source_ids or {}
+    for ev in events:
+        if not isinstance(ev, dict) or ev.get("type") != "session":
+            continue
+        by_uuid[ev["session_uuid"]] = {
+            "queued_at": now.isoformat() + "Z",
+            "id": int(source_ids.get(ev["session_uuid"], 0)),
+            "event": ev,
+        }
+    cutoff = (now - timedelta(days=MAX_OUTBOX_AGE_DAYS)).isoformat()
+    merged = [r for r in by_uuid.values() if str(r.get("queued_at", "")) >= cutoff]
+    merged.sort(key=lambda r: (str(r.get("queued_at", "")), int(r.get("id") or 0)))
+    merged = merged[-MAX_OUTBOX:]
+    write_outbox(snapshot_dir, merged)
+    return len(merged)
+
+
+def drain_outbox(snapshot_dir, cfg, version, post=None, max_posts=MAX_POSTS_PER_FLUSH,
+                 env=None, home=None, billing_mode="unknown", savings_method="none",
+                 meters=None):
+    """Send queued events in bounded batches. The cursor advances only over
+    acked ids (R6a). Returns stats. Never raises."""
+    post = post or post_payload
+    stats = {"sent": 0, "posts": 0, "failed": 0, "remaining": 0, "status": None}
+    try:
+        items = read_outbox(snapshot_dir)
+        last_id, watermark = read_state(snapshot_dir)
+        posts = 0
+        while items and posts < max_posts:
+            batch, ids = items[:MAX_BATCH], []
+            for rec in batch:
+                rid = int(rec.get("id") or 0)
+                if rid:
+                    ids.append(rid)
+            ok, status, _detail = post(cfg, batch, version, env=env, home=home,
+                                       billing_mode=billing_mode,
+                                       savings_method=savings_method, meters=meters)
+            stats["posts"] += 1
+            posts += 1
+            stats["status"] = status
+            if not ok:
+                stats["failed"] += 1
+                break
+            stats["sent"] += len(batch)
+            items = items[len(batch):]
+            if ids:
+                last_id = max(last_id, max(ids))
+            write_state(snapshot_dir, last_id, watermark)
+        write_outbox(snapshot_dir, items)
+        stats["remaining"] = len(items)
+    except Exception as exc:
+        stats["failed"] += 1
+        stats["status"] = exc.__class__.__name__
+    return stats
+
+
+# --------------------------------------------------------------------------- #
+# Network (lazy import; redirects refused, R6c)
+# --------------------------------------------------------------------------- #
+
+class _NoRedirect(Exception):
+    pass
+
+
+def post_payload(cfg, records, version, timeout=TIMEOUT_S, env=None, home=None,
+                 billing_mode="unknown", savings_method="none", meters=None):
+    """POST one batch of outbox records as a to.fleet.v1 envelope.
+    Returns (ok, status, detail). Never raises."""
+    try:
+        import urllib.error
+        import urllib.request
+
+        class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, req, fp, code, msg, headers, newurl):
+                raise _NoRedirect(f"redirect {code} refused")
+
+        events = [r.get("event") for r in records if isinstance(r, dict)]
+        payload = build_payload(cfg, events, version, env=env, home=home,
+                                meters=meters, billing_mode=billing_mode,
+                                savings_method=savings_method)
+        body = json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+        req = urllib.request.Request(
+            cfg["endpoint"].rstrip("/") + "/v1/ingest", data=body, method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {cfg['token']}",
+                "User-Agent": f"token-optimizer-fleet/{clamp(version or 'unknown', 40)}",
+            })
+        opener = urllib.request.build_opener(_NoRedirectHandler)
+        with opener.open(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", 200)
+            return (200 <= status < 300), status, ""
+    except _NoRedirect as exc:
+        return False, 0, str(exc)
+    except Exception as exc:  # HTTPError, URLError, socket.timeout, ValueError
+        status = int(getattr(exc, "code", 0) or 0)
+        return False, status, exc.__class__.__name__
+
+
+# --------------------------------------------------------------------------- #
+# Flush entry point (called from the session-end flush worker tail, R5)
+# --------------------------------------------------------------------------- #
+
+def emit_after_flush(trends_db=None, snapshot_dir=None, config_dir=None, runtime="claude",
+                     version="unknown", cost_fn=None, model_cost_fn=None, meters_fn=None,
+                     billing_mode="unknown", time_left_fn=None, env=None, home=None):
+    """Build events, enqueue, drain. Fail-open; returns a stats dict or None."""
+    env = os.environ if env is None else env
+    try:
+        cfg = load_config(env=env, config_dir=config_dir)
+        if cfg is None:
+            return None
+        if not snapshot_dir_ok(snapshot_dir):
+            log_line(snapshot_dir, "emission skipped: snapshot dir group/world-writable")
+            return None
+        reap_stale_tmp(snapshot_dir)
+        conn = sqlite_connect(trends_db)
+        if conn is None:
+            return None
+        try:
+            last_id, watermark = read_state(snapshot_dir)
+            outbox_len = len(read_outbox(snapshot_dir))
+            events, max_id, max_wm = build_session_events(
+                conn, cfg, cursor_id=last_id, watermark=watermark, runtime=runtime,
+                cost_fn=cost_fn, model_cost_fn=model_cost_fn,
+                max_events=max(0, MAX_OUTBOX - outbox_len))
+            meters = None
+            if meters_fn is not None:
+                try:
+                    meters = meters_fn()
+                except Exception:
+                    meters = None
+            if events:
+                ids = {e["session_uuid"]: e.pop("_src_id", 0) for e in events}
+                enqueue(snapshot_dir, events, source_ids=ids)
+            log_line(snapshot_dir, f"flush: {len(events)} new events, "
+                                   f"outbox={len(read_outbox(snapshot_dir))}, "
+                                   f"endpoint={cfg['endpoint']}")
+            if time_left_fn is not None:
+                try:
+                    if float(time_left_fn()) < MIN_NETWORK_SECONDS:
+                        return {"skipped_network": True}
+                except Exception:
+                    pass
+            return drain_outbox(snapshot_dir, cfg, version, env=env, home=home,
+                                billing_mode=billing_mode,
+                                savings_method="counted_reread" if runtime == "claude"
+                                else "none", meters=meters)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    except Exception as exc:
+        log_line(snapshot_dir, f"emit failed: {exc.__class__.__name__}")
+        return None
+
+
+def sqlite_connect(trends_db):
+    try:
+        import sqlite3
+        conn = sqlite3.connect(str(trends_db), timeout=5.0)
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# CLI (R7). Paths come from measure (KTD9); no path resolver of its own.
+# --------------------------------------------------------------------------- #
+
+def _measure():
+    import importlib
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    if "measure" in sys.modules and not hasattr(sys.modules["measure"], "__file__"):
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    return mod
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if "--enable" in argv:
+        i = argv.index("--enable")
+        vals = argv[i + 1:i + 4]
+        if len(vals) < 3:
+            print("usage: fleet_emitter.py --enable <endpoint> <ingest-token> <hash-key>")
+            return 2
+        ok, where = enable(*vals)
+        print(("wrote " if ok else "failed: ") + str(where))
+        return 0 if ok else 1
+    m = _measure()
+    cfg = load_config(config_dir=str(m.CONFIG_DIR))
+    if "--status" in argv:
+        if cfg is None:
+            print("FLEET TELEMETRY: DISABLED (no valid fleet.json)")
+        else:
+            outbox = len(read_outbox(str(m.SNAPSHOT_DIR)))
+            last_id, _wm = read_state(str(m.SNAPSHOT_DIR))
+            host = cfg["endpoint"].split("://", 1)[-1].split("/")[0]
+            print(f"FLEET TELEMETRY: ENABLED endpoint={host} source={cfg['source']} "
+                  f"outbox={outbox} cursor={last_id}")
+        return 0
+    if cfg is None:
+        return 0
+    if "--dry-run" in argv:
+        conn = sqlite_connect(m.TRENDS_DB)
+        if conn is None:
+            print("no trends.db")
+            return 1
+        last_id, wm = read_state(str(m.SNAPSHOT_DIR))
+        events, _mid, _w = build_session_events(conn, cfg, cursor_id=last_id,
+                                                watermark=wm, runtime="claude",
+                                                cost_fn=m._cost_from_model_breakdown,
+                                                model_cost_fn=m._get_model_cost)
+        conn.close()
+        meters = None
+        try:
+            meters = m._keepwarm_read_meters()
+        except Exception:
+            pass
+        payload = build_payload(cfg, events, m.TOKEN_OPTIMIZER_VERSION, meters=meters,
+                                billing_mode="unknown", savings_method="counted_reread")
+        print(json.dumps(payload, indent=2))
+        print("SENSITIVE: pseudonymous org aggregates; share deliberately.", file=sys.stderr)
+        return 0
+    # --flush [--all]
+    meters = None
+    try:
+        meters = m._keepwarm_read_meters()
+    except Exception:
+        pass
+    conn = sqlite_connect(m.TRENDS_DB)
+    if conn is None:
+        return 1
+    last_id, wm = read_state(str(m.SNAPSHOT_DIR))
+    if "--all" in argv:
+        last_id, wm = 0, ""
+    events, max_id, max_wm = build_session_events(
+        conn, cfg, cursor_id=last_id, watermark=wm, runtime="claude",
+        cost_fn=m._cost_from_model_breakdown, model_cost_fn=m._get_model_cost)
+    conn.close()
+    if events:
+        ids = {e["session_uuid"]: e.pop("_src_id", 0) for e in events}
+        enqueue(str(m.SNAPSHOT_DIR), events, source_ids=ids)
+    stats = drain_outbox(str(m.SNAPSHOT_DIR), cfg, m.TOKEN_OPTIMIZER_VERSION,
+                         savings_method="counted_reread", meters=meters)
+    print(json.dumps(stats))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6602,6 +6602,18 @@ def generate_standalone_dashboard(days=30, quiet=False, force=False):
         "runtime": detect_runtime(),
         "runtime_label": runtime_name_for_humans(),
     }
+    # Teams edition (R2d): when org telemetry is active on this machine, the
+    # developer whose sessions are emitted sees it on the local dashboard.
+    try:
+        import fleet_emitter as _fleet
+        _fcfg = _fleet.load_config(config_dir=str(CONFIG_DIR))
+        data["fleet_telemetry"] = {
+            "active": _fcfg is not None,
+            "endpoint_host": (_fcfg["endpoint"].split("://", 1)[-1].split("/")[0]
+                              if _fcfg else ""),
+        }
+    except Exception:
+        data["fleet_telemetry"] = {"active": False, "endpoint_host": ""}
     data = _sanitize_dashboard_paths(data)
 
     template = template_path.read_text(encoding="utf-8")
@@ -6826,6 +6838,21 @@ def _run_session_end_flush_worker(args):
             except Exception:
                 pass
     except _HookTimeout:
+        pass
+    # Teams-edition org telemetry (admin-enabled, OFF by default). Runs in the
+    # worker tail, outside the refresh block's exception paths: fail-open, and
+    # the network step is skipped when the 20s budget is nearly spent. The
+    # watchdog's os._exit(0) never unwinds here, so the emitter writes its
+    # outbox atomically before any POST.
+    try:
+        import fleet_emitter
+        fleet_emitter.emit_after_flush(
+            trends_db=TRENDS_DB, snapshot_dir=SNAPSHOT_DIR, config_dir=CONFIG_DIR,
+            runtime=detect_runtime(), version=TOKEN_OPTIMIZER_VERSION,
+            cost_fn=_cost_from_model_breakdown, model_cost_fn=_get_model_cost,
+            meters_fn=_keepwarm_read_meters, billing_mode=fleet_billing_mode(),
+            time_left_fn=old_budget.remaining)
+    except Exception:
         pass
     finally:
         _clear_hook_budget(old_budget)
@@ -12700,6 +12727,33 @@ def keepwarm_billing_mode(env=None, claude_json_path=None, settings_path=None):
         return "subscription"
     # Rung 4: nothing detectable -> conservative subscription (off).
     return "subscription"
+
+
+def fleet_billing_mode(env=None, claude_json_path=None, settings_path=None):
+    """Billing class for the org-telemetry emitter (Teams edition).
+
+    Same ladder as keepwarm_billing_mode, but the 'nothing detectable' rung
+    maps to 'unknown', never 'subscription': keep-warm must assume the worst
+    (an unknown user is subscription and stays off), while telemetry must not
+    claim a billing mode it cannot see.
+    """
+    if env is None:
+        env = os.environ
+    if _keepwarm_env_says_api(env):
+        return "api"
+    json_verdict = _keepwarm_json_says_api(
+        claude_json_path if claude_json_path is not None
+        else _keepwarm_default_claude_json_path())
+    if json_verdict == "api":
+        return "api"
+    settings_verdict = _keepwarm_json_says_api(
+        settings_path if settings_path is not None
+        else _keepwarm_default_settings_path())
+    if settings_verdict == "api":
+        return "api"
+    if json_verdict == "subscription":
+        return "subscription"
+    return "unknown"
 
 
 def keepwarm_consent():

--- a/docs-site/src/content/docs/install/claude-code-vscode.mdx
+++ b/docs-site/src/content/docs/install/claude-code-vscode.mdx
@@ -59,7 +59,7 @@ Everything the CLI does, the extension does, because the same hooks run in the V
 
 ## Dashboard bookmark
 
-Click either status-bar item to open the dashboard at `http://localhost:24842/token-optimizer`. The extension does zero network activity except one localhost probe to that port, and only when you click. To keep the URL live between sessions, set up the daemon from the CLI:
+Click either status-bar item to open the dashboard at `http://localhost:24842/token-optimizer`. By default the extension does zero network activity except one localhost probe to that port, and only when you click. To keep the URL live between sessions, set up the daemon from the CLI:
 
 ```bash
 python3 measure.py setup-daemon

--- a/docs-site/src/content/docs/reference/comparison.mdx
+++ b/docs-site/src/content/docs/reference/comparison.mdx
@@ -62,7 +62,7 @@ The table covers the six tools most often compared to Token Optimizer. Status: �
 | Cache-safe | 🟢 Never modifies existing context prefix | 🟡 Proxy mode rewrites in-flight | 🟢 Pre-shell only | 🟢 Pre-shell only | 🟡 MCP overhead | 🟢 |
 | Zero baseline context overhead | 🟢 External process, no context injection | 🔴 Injects instructions | 🟢 Shell-level only | 🟢 Shell-level only | 🔴 MCP server overhead | 🟢 Native |
 | Zero runtime dependencies | 🟢 Pure stdlib (Python/TypeScript) | 🟡 Python + Rust + optional model | 🟢 Single Rust binary | 🟢 Single binary | 🟡 SQLite adapter required | 🟢 N/A |
-| Zero telemetry | 🟢 Nothing leaves the machine | 🟡 Anonymous aggregate telemetry, opt-in via `HEADROOM_TELEMETRY`, off by default | 🟡 Opt-in | 🔴 Beta Agreement §6 covers commands invoked, command arguments, exit codes, duration, CI attributes, IP | 🟡 Varies | 🟢 |
+| Zero telemetry by default | 🟢 Nothing leaves the machine unless an org admin enables the Teams-edition collector (see PRIVACY.md) | 🟡 Anonymous aggregate telemetry, opt-in via `HEADROOM_TELEMETRY`, off by default | 🟡 Opt-in | 🔴 Beta Agreement §6 covers commands invoked, command arguments, exit codes, duration, CI attributes, IP | 🟡 Varies | 🟢 |
 | Signed and checksum-verified install | 🟢 `CHECKSUMS.sha256` on every release, verified at install; CI fails a release that cannot be installed | — | — | 🔴 `install.sh` verifies neither a checksum nor a signature on either download path | — | N/A |
 | Multi-platform | 🟢 Claude Code, VS Code, Cowork, Codex, OpenClaw, OpenCode, Hermes, Copilot | 🟢 Claude Code, Cursor, Codex, Aider, Copilot | 🟢 15 integrations | 🟡 Cursor, Claude Code, Copilot, Codex CLI | 🟢 17 integrations | 🔴 Claude Code only |
 

--- a/docs-site/src/content/docs/reference/data-and-privacy.mdx
+++ b/docs-site/src/content/docs/reference/data-and-privacy.mdx
@@ -26,7 +26,7 @@ These are read locally and never transmitted.
 
 ## Where data lives
 
-![Session database flow: two local SQLite databases, nothing leaves your machine](/images/session-database-flow.svg)
+![Session database flow: two local SQLite databases, by default nothing leaves your machine](/images/session-database-flow.svg)
 
 
 Every store is created with restrictive permissions: directories `0o700` (owner only), files `0o600` (owner read/write only).
@@ -96,7 +96,7 @@ To delete by hand instead, remove these directories:
 
 ## Cross-platform
 
-The same guarantees hold on every supported platform: local-only, zero network, credential-redacted storage. Data paths vary by platform; the architecture is identical. On Hermes, the adapter opens `state.db` read-only and immutable (`mode=ro&immutable=1` with `PRAGMA query_only = ON`) and never writes back to it.
+The same guarantees hold on every supported platform: local-only, zero network by default, credential-redacted storage. Data paths vary by platform; the architecture is identical. On Hermes, the adapter opens `state.db` read-only and immutable (`mode=ro&immutable=1` with `PRAGMA query_only = ON`) and never writes back to it. The one exception to zero network is the admin-enabled org telemetry channel (Teams edition): when an org admin places a `fleet.json` on the machine, per-session aggregates (never prompts, never content) POST to the org's collector. See PRIVACY.md and `docs/teams-telemetry.md`.
 
 ## Source available
 

--- a/docs/teams-telemetry.md
+++ b/docs/teams-telemetry.md
@@ -32,7 +32,12 @@ python3 fleet_emitter.py --status
 `--enable` writes `fleet.json` at mode 0600. The token may instead come from a
 secret manager via `"token_env": "ACME_FLEET_TOKEN"` in the file; the hash key
 likewise via `"hash_key_env"`. A group- or world-readable `fleet.json` is
-ignored. Kill switch on one machine: `TO_FLEET_DISABLE=1`.
+ignored. **Windows note:** win32 does not enforce POSIX file modes, and
+`os.stat` there reports group/world read bits on ordinary files, so the 0600
+check fails and `fleet.json` is ignored — emission is fail-closed and
+effectively unavailable on Windows until a platform-aware check lands. That is
+the accepted behaviour: an unverifiable config never enables telemetry.
+Kill switch on one machine: `TO_FLEET_DISABLE=1`.
 
 Inspect what would be sent: `python3 fleet_emitter.py --dry-run` (output is
 sensitive — pseudonymous org aggregates; share deliberately).

--- a/docs/teams-telemetry.md
+++ b/docs/teams-telemetry.md
@@ -1,0 +1,74 @@
+# Teams edition: org telemetry (admin guide)
+
+Token Optimizer's Teams edition adds an **admin-enabled** telemetry channel and a
+private collector + org dashboard. It is off by default and file-only: nothing
+leaves a machine until an org admin places a `fleet.json` there. See `PRIVACY.md`
+for the exact field list and the never-sent list.
+
+## 1. Run the collector
+
+The collector lives in the private `token-optimizer-teams` repo (single-file
+Python, sqlite, stdlib only):
+
+```bash
+python3 to_teams.py add-org "Acme Corp"     # prints ingest token, admin token, hash_key — once
+python3 to_teams.py serve --port 8787       # binds 127.0.0.1 by default
+```
+
+Non-loopback binds require `--bind 0.0.0.0 --behind-tls` and a TLS-terminating
+proxy in front (see the deploy note in that repo). `/healthz` needs no auth;
+everything else needs a scoped bearer token.
+
+## 2. Enable machines
+
+On each developer machine (config dir is `~/.claude/token-optimizer/` on Claude
+Code; runtime-specific elsewhere):
+
+```bash
+python3 fleet_emitter.py --enable https://collector.acme.internal <ingest-token> <hash-key>
+python3 fleet_emitter.py --status
+```
+
+`--enable` writes `fleet.json` at mode 0600. The token may instead come from a
+secret manager via `"token_env": "ACME_FLEET_TOKEN"` in the file; the hash key
+likewise via `"hash_key_env"`. A group- or world-readable `fleet.json` is
+ignored. Kill switch on one machine: `TO_FLEET_DISABLE=1`.
+
+Inspect what would be sent: `python3 fleet_emitter.py --dry-run` (output is
+sensitive — pseudonymous org aggregates; share deliberately).
+
+## 3. Claude Code OTel as a second ingest path
+
+Team/Enterprise admins can point Claude Code's OTel exporter at the collector
+instead of (or alongside) the emitter. Put the ingest token in **user-level**
+settings, never a committed `.claude/settings.json`:
+
+```bash
+export CLAUDE_CODE_ENABLE_OTEL=1
+export OTEL_METRICS_EXPORTER=otlphttp
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.acme.internal:8787
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <ingest-token>"
+```
+
+Only `claude_code.api_request` events are retained; everything else is dropped
+before any write. OTel writes never lower an emitter-written value and never
+touch savings.
+
+## 4. Rotation and remediation
+
+```bash
+python3 to_teams.py rotate-token --org <id> --scope ingest    # old ingest token dies; identities unchanged
+python3 to_teams.py rotate-identity-key --org <id>            # history-breaking: all hashes change
+python3 to_teams.py delete-session --org <id> --session <uuid>
+python3 to_teams.py purge-user --org <id> --user-hash <hash>
+```
+
+## 5. Dashboard
+
+```bash
+python3 to_teams.py dashboard --org <id>    # writes org-dashboard.html (0600)
+```
+
+Views: org overview, per person (subscription-vs-API, hosts seen), per model,
+per platform, limit proximity, % saved (with measured share), seat
+right-sizing (heuristic).

--- a/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -2046,6 +2046,8 @@ window.__TOKEN_DATA__ = null;
 
   <!-- MAIN -->
   <main class="main-col">
+    <!-- Org telemetry banner (Teams edition): rendered only when active -->
+    <div id="fleet-telemetry-banner" style="display:none;font-size:12px;font-family:var(--font-mono);padding:6px 12px;border:1px solid var(--c-border);border-radius:6px;margin:8px 0 0;color:var(--c-text-dim);"></div>
     <!-- Overview View -->
     <div class="view active" id="view-overview">
       <header class="header">
@@ -7009,6 +7011,14 @@ document.addEventListener('DOMContentLoaded', function() {
     if (data.version) brandParts.push('v' + data.version);
     if (data.runtime === 'codex') brandParts.push('Codex');
     brandMeta.textContent = brandParts.join(' \u00b7 ');
+  }
+  // Org telemetry banner (Teams edition): visible only when an admin-enabled
+  // fleet.json is active on this machine. textContent only, never innerHTML.
+  var fleetBanner = document.getElementById('fleet-telemetry-banner');
+  if (fleetBanner && data.fleet_telemetry && data.fleet_telemetry.active) {
+    fleetBanner.textContent = 'Org telemetry active: sending session aggregates to '
+      + (data.fleet_telemetry.endpoint_host || 'unknown endpoint');
+    fleetBanner.style.display = 'block';
   }
 
   function startApp() { DB.init(data); refreshSavingsLive(); }

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/fleet_emitter.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/fleet_emitter.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""Admin-enabled org telemetry emitter (Token Optimizer Teams edition).
+
+OFF BY DEFAULT, and file-only: nothing is emitted unless an org admin has
+placed a ``fleet.json`` (mode 0600) in Token Optimizer's config dir holding
+``endpoint``, ``hash_key`` and either ``token`` or ``token_env``. Environment
+variables alone never enable emission (a cloned repo's settings must not be
+able to switch telemetry on). ``TO_FLEET_DISABLE=1`` overrides everything.
+
+What it sends when enabled: per-session aggregates Token Optimizer already
+stores locally (platform, pseudonymous ids, token counts, model split, cost,
+counted savings, one account-level limit-meter reading, timestamps). Never
+prompts, never responses, never file contents, never file paths, never command
+text, never tool output. The allowlist below is enforced on keys AND values
+before serialisation.
+
+Delivery: events queue in a local outbox (JSONL, 0600, atomic writes) first,
+then the outbox is drained with bounded POSTs (3s timeout, at most two batches
+per flush, redirects refused). A failed POST leaves the outbox intact; the id
+cursor advances only after a 2xx. Every entry point is fail-open: nothing here
+can raise into a hook.
+
+Inspect exactly what would be sent: ``python3 fleet_emitter.py --dry-run``
+(output is sensitive: it contains this org's pseudonymous aggregates).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import stat
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+SCHEMA = "to.fleet.v1"
+
+ENV_DISABLE = "TO_FLEET_DISABLE"
+ENV_CONFIG = "TO_FLEET_CONFIG"
+ENV_USER = "TO_FLEET_USER"
+ENV_HASH_KEY = "TO_FLEET_HASH_KEY"
+
+CONFIG_FILENAME = "fleet.json"
+OUTBOX_NAME = "fleet-outbox.jsonl"
+CURSOR_NAME = "fleet-cursor.json"
+LOG_NAME = "fleet.log"
+
+MAX_BATCH = 200            # events per POST
+MAX_POSTS_PER_FLUSH = 2    # bounded network time per session-end flush
+MAX_OUTBOX = 500           # events kept locally while the collector is down
+MAX_OUTBOX_AGE_DAYS = 7
+RECENT_DAYS = 2            # re-send rows this recent so backfilled columns land
+MIN_NETWORK_SECONDS = 7.0  # skip the network step when less budget remains
+TIMEOUT_S = 3.0
+LOG_MAX_LINES = 200
+TMP_MAX_AGE_S = 600
+
+_MODEL_RE = re.compile(r"^[A-Za-z0-9._:@-]{1,80}$")
+_HASHISH_RE = re.compile(r"^(?:[0-9a-f]{16,32}|p-[0-9a-f]{30})$")
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+_LOOPBACK = ("127.0.0.1", "localhost", "::1")
+
+# Every key a wire event may carry. Anything else is stripped by sanitize_event().
+EVENT_KEYS = frozenset({
+    "type", "session_uuid", "platform", "project_hash", "date",
+    "started_at", "ended_at", "duration_minutes",
+    "input_tokens", "output_tokens", "cache_read_tokens", "cache_create_tokens",
+    "reported_input_tokens", "reported_output_tokens", "api_calls", "message_count",
+    "models", "cost_usd", "cost_source", "savings", "savings_coverage",
+    "quality_score", "quality_grade",
+})
+ENVELOPE_KEYS = frozenset({
+    "schema", "sent_at", "to_version", "user_hash", "host_hash",
+    "limit", "billing_mode", "savings_method", "models_redacted",
+    "user_label", "events",
+})
+_MODEL_PART_KEYS = ("fresh_input", "cache_read", "cache_create", "output")
+_STR_KEYS = frozenset({"type", "session_uuid", "platform", "project_hash", "date",
+                       "started_at", "ended_at", "cost_source", "savings_coverage",
+                       "quality_grade"})
+
+
+def clamp(text, length=120):
+    """Clamp to printable ASCII (control chars and non-ASCII dropped)."""
+    return "".join(c for c in str(text or "") if 32 <= ord(c) < 127)[:length]
+
+
+# --------------------------------------------------------------------------- #
+# Configuration (file-only enablement, R2/R2a/R2b)
+# --------------------------------------------------------------------------- #
+
+def load_config(env=None, config_dir=None):
+    """Return a config dict, or None when telemetry is not configured.
+
+    A fleet.json is REQUIRED. Env vars alone never enable. The file must be
+    owner-readable only; a group/world-readable file is ignored with a logged
+    reason. TO_FLEET_CONFIG must resolve inside config_dir when config_dir is
+    given. Endpoints must be https:// except loopback http.
+    """
+    env = os.environ if env is None else env
+    if (env.get(ENV_DISABLE) or "").strip().lower() in ("1", "true", "yes", "on"):
+        return None
+    base = Path(config_dir).expanduser() if config_dir else _default_config_dir(env)
+    override = (env.get(ENV_CONFIG) or "").strip()
+    if override:
+        p = Path(override).expanduser().resolve()
+        try:
+            p.relative_to(base.resolve())
+        except ValueError:
+            return None
+    else:
+        p = base / CONFIG_FILENAME
+    try:
+        if not p.is_file():
+            return None
+        mode = p.stat().st_mode
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            log_line(None, f"config ignored: {p.name} is group/world-readable")
+            return None
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict) or raw.get("enabled") is False:
+        return None
+    endpoint = str(raw.get("endpoint") or "").strip()
+    token = str(raw.get("token") or "").strip()
+    if not token:
+        token = (env.get(str(raw.get("token_env") or "") or "") or "").strip()
+    hash_key = str(raw.get("hash_key") or "").strip()
+    if not hash_key:
+        hk_env = str(raw.get("hash_key_env") or "").strip()
+        hash_key = (env.get(hk_env) or "").strip() if hk_env else \
+            (env.get(ENV_HASH_KEY) or "").strip()
+    if not endpoint or not token or not hash_key:
+        return None
+    endpoint = clamp(endpoint, 300)
+    scheme, _, rest = endpoint.partition("://")
+    host = rest.split("/")[0].split(":")[0].lower()
+    if scheme == "http" and host not in _LOOPBACK:
+        return None
+    if scheme not in ("http", "https"):
+        return None
+    return {
+        "endpoint": endpoint.rstrip("/"),
+        "token": token,
+        "hash_key": hash_key,
+        "user": clamp(raw.get("user") or "", 120),
+        "send_user_label": bool(raw.get("send_user_label", False)),
+        "source": str(p),
+    }
+
+
+def _default_config_dir(env):
+    """Mirror measure.CONFIG_DIR cheaply (no measure import when disabled)."""
+    base = (env.get("TOKEN_OPTIMIZER_CONFIG_DIR") or "").strip()
+    if base:
+        return Path(base).expanduser()
+    runtime = (env.get("TOKEN_OPTIMIZER_RUNTIME") or "").strip().lower()
+    home = Path(env.get("HOME") or env.get("USERPROFILE") or str(Path.home()))
+    if runtime == "codex":
+        return home / ".codex" / "token-optimizer"
+    if runtime == "opencode":
+        return home / ".local" / "share" / "opencode" / "token-optimizer"
+    if runtime == "hermes":
+        return home / ".hermes" / "token-optimizer"
+    if runtime == "copilot":
+        return home / ".copilot" / "token-optimizer"
+    return home / ".claude" / "token-optimizer"
+
+
+def is_enabled(env=None, config_dir=None):
+    return load_config(env=env, config_dir=config_dir) is not None
+
+
+def enable(endpoint, token, hash_key, config_dir=None, env=None):
+    """Write fleet.json at mode 0600. Returns (ok, path_or_reason)."""
+    env = os.environ if env is None else env
+    base = Path(config_dir).expanduser() if config_dir else _default_config_dir(env)
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+        path = base / CONFIG_FILENAME
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"endpoint": endpoint, "token": token, "hash_key": hash_key}, fh)
+            fh.write("\n")
+        os.chmod(str(path), 0o600)
+        return True, str(path)
+    except OSError as exc:
+        return False, exc.__class__.__name__
+
+
+# --------------------------------------------------------------------------- #
+# Pseudonymous identity (R3/R3a, KTD7: HMAC keyed by the org hash_key)
+# --------------------------------------------------------------------------- #
+
+def canonical_identity(cfg, env=None, home=None):
+    """fleet.json user -> TO_FLEET_USER -> gitconfig user.email -> OS user."""
+    env = os.environ if env is None else env
+    if cfg.get("user"):
+        return cfg["user"]
+    v = (env.get(ENV_USER) or "").strip()
+    if v:
+        return v
+    gitconfig = Path(home or Path.home()) / ".gitconfig"
+    try:
+        in_user = False
+        for line in gitconfig.read_text(encoding="utf-8", errors="replace").splitlines():
+            s = line.strip()
+            if s.startswith("["):
+                in_user = s.lower().startswith("[user")
+                continue
+            if in_user and "=" in s:
+                k, _, val = s.partition("=")
+                if k.strip().lower() == "email" and val.strip():
+                    return val.strip()
+    except OSError:
+        pass
+    try:
+        import getpass
+        return getpass.getuser()
+    except Exception:
+        return "unknown"
+
+
+def _hmac(hash_key, value, length):
+    return hmac.new(hash_key.encode("utf-8"), str(value).encode("utf-8"),
+                    hashlib.sha256).hexdigest()[:length]
+
+
+def user_hash(cfg, env=None, home=None):
+    return _hmac(cfg["hash_key"], canonical_identity(cfg, env, home), 32)
+
+
+def host_hash(cfg):
+    try:
+        import socket
+        host = socket.gethostname()
+    except Exception:
+        host = "unknown"
+    return _hmac(cfg["hash_key"], host, 16)
+
+
+def project_hash(cfg, project):
+    return _hmac(cfg["hash_key"], project or "", 16)
+
+
+def session_uuid_for(cfg, row_uuid, jsonl_path):
+    """R4a: stored uuid verbatim; NULL falls back to the filename UUID, then an
+    HMAC of the path (the path itself never leaves the machine)."""
+    if row_uuid:
+        s = str(row_uuid).strip()
+        if _UUID_RE.fullmatch(s):
+            return s.lower()
+        return _hmac(cfg["hash_key"], "sid:" + s, 32)
+    m = _UUID_RE.search(Path(str(jsonl_path or "")).name)
+    if m:
+        return m.group(0).lower()
+    if jsonl_path:
+        return "p-" + _hmac(cfg["hash_key"], "path:" + str(jsonl_path), 30)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Value sanitisation (R4: allowlist on keys AND values)
+# --------------------------------------------------------------------------- #
+
+def _num(value, default=0):
+    try:
+        if value is None:
+            return default
+        n = float(value)
+        if n != n or n in (float("inf"), float("-inf")):
+            return default
+        return int(n) if float(n).is_integer() else round(n, 6)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def sanitize_model_name(cfg, name):
+    """Strip a provider prefix; enforce the R4 pattern; redact otherwise."""
+    raw = str(name or "")
+    stripped = raw.rsplit("/", 1)[-1] if "/" in raw else raw
+    if _MODEL_RE.fullmatch(stripped):
+        return stripped, False
+    return "custom-" + _hmac(cfg["hash_key"], "model:" + raw, 16), True
+
+
+def sanitize_event(cfg, event):
+    """Allowlist filter. Returns a clean dict or None when the event is unusable."""
+    if not isinstance(event, dict):
+        return None
+    out = {}
+    redacted = 0
+    for key, value in event.items():
+        if key not in EVENT_KEYS:
+            continue
+        if key == "models":
+            models = {}
+            if isinstance(value, dict):
+                for model, parts in value.items():
+                    if not isinstance(parts, dict):
+                        continue
+                    clean, was_redacted = sanitize_model_name(cfg, model)
+                    redacted += 1 if was_redacted else 0
+                    models[clean] = {k: _num(parts.get(k)) for k in _MODEL_PART_KEYS}
+            out[key] = models
+        elif key == "savings":
+            sv = value if isinstance(value, dict) else {}
+            out[key] = {"tokens": _num(sv.get("tokens")),
+                        "cost_usd": round(_num(sv.get("cost_usd"), 0.0), 6)}
+        elif key == "limit":
+            out[key] = None
+            if isinstance(value, dict):
+                out[key] = {
+                    "five_hour_pct": _num(value.get("five_hour_pct"), None),
+                    "seven_day_pct": _num(value.get("seven_day_pct"), None),
+                    "ts": _num(value.get("ts"), None),
+                }
+        elif key in _STR_KEYS:
+            out[key] = None if value is None else clamp(value, 64)
+            if key == "project_hash" and out[key] and not _HASHISH_RE.fullmatch(out[key]):
+                out[key] = _hmac(cfg.get("hash_key", ""), "proj:" + out[key], 16)
+        else:
+            out[key] = _num(value, None)
+    if out.get("type") != "session" or not out.get("session_uuid"):
+        return None
+    out["models_redacted"] = redacted
+    return out
+
+
+def build_payload(cfg, events, version, env=None, home=None, meters=None,
+                  billing_mode="unknown", savings_method="none"):
+    """Envelope + sanitised events. Envelope keys are the frozen ENVELOPE_KEYS."""
+    clean, redacted = [], 0
+    for ev in events:
+        c = sanitize_event(cfg, ev)
+        if c is None:
+            continue
+        redacted += c.pop("models_redacted", 0)
+        clean.append(c)
+    payload = {
+        "schema": SCHEMA,
+        "sent_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to_version": clamp(version or "unknown", 40),
+        "user_hash": user_hash(cfg, env, home),
+        "host_hash": host_hash(cfg),
+        "billing_mode": clamp(billing_mode or "unknown", 20),
+        "savings_method": clamp(savings_method or "none", 40),
+        "models_redacted": redacted,
+        "events": clean,
+    }
+    if isinstance(meters, dict) and meters.get("available"):
+        payload["limit"] = {
+            "five_hour_pct": _num(meters.get("five_hour_pct"), None),
+            "seven_day_pct": _num(meters.get("seven_day_pct"), None),
+            "ts": _num(meters.get("ts"), None),
+        }
+    if cfg.get("send_user_label"):
+        payload["user_label"] = clamp(canonical_identity(cfg, env, home), 120)
+    assert set(payload) <= ENVELOPE_KEYS
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Event building from trends.db (R4a-R4c, R6a, R6b)
+# --------------------------------------------------------------------------- #
+
+def build_session_events(conn, cfg, cursor_id=0, watermark="", runtime="claude",
+                         cost_fn=None, model_cost_fn=None, max_events=MAX_OUTBOX,
+                         now=None):
+    """Union of three bounded queries (R6a/R6b), ascending id, capped so a
+    backlog drains over flushes. Returns (events, max_id_seen, max_computed_at)."""
+    now = now or datetime.now()
+    recent_cutoff = (now - timedelta(days=RECENT_DAYS)).strftime("%Y-%m-%d")
+    budget = max(0, int(max_events))
+    ids = set()
+    for (rid,) in conn.execute(
+            "SELECT id FROM session_log WHERE id > ? ORDER BY id ASC LIMIT ?",
+            (int(cursor_id or 0), budget)):
+        ids.add(int(rid))
+    for (rid,) in conn.execute(
+            "SELECT id FROM session_log WHERE date >= ? ORDER BY id ASC LIMIT ?",
+            (recent_cutoff, budget)):
+        ids.add(int(rid))
+    if watermark:
+        for (rid,) in conn.execute(
+                "SELECT s.id FROM session_log s WHERE s.session_uuid IN "
+                "(SELECT DISTINCT session_uuid FROM counted_reread "
+                " WHERE computed_at > ?) AND s.id > 0 ORDER BY s.id ASC LIMIT ?",
+                (str(watermark), budget)):
+            ids.add(int(rid))
+    if not ids:
+        return [], int(cursor_id or 0), str(watermark or "")
+    rows = conn.execute(
+        "SELECT id, jsonl_path, date, project, duration_minutes, input_tokens, "
+        "output_tokens, message_count, api_calls, cache_create_1h_tokens, "
+        "cache_create_5m_tokens, model_usage_json, model_usage_breakdown_json, "
+        "collected_at, quality_score, quality_grade, session_uuid, is_sidechain, "
+        "reported_input_tokens, reported_output_tokens, platform, "
+        "cost_usd, cost_source "
+        "FROM session_log WHERE id IN (%s) ORDER BY id ASC" % ",".join("?" * len(ids)),
+        tuple(sorted(ids))).fetchall()
+    events, max_id = [], int(cursor_id or 0)
+    for (rid, jsonl_path, date, project, duration, in_tok, out_tok, msgs, calls,
+         cc1h, cc5m, model_usage_json, breakdown_json, collected_at, qscore, qgrade,
+         row_uuid, sidechain, rep_in, rep_out, platform, cost_usd, cost_source) in rows:
+        max_id = max(max_id, int(rid or 0))
+        if sidechain:
+            continue
+        suuid = session_uuid_for(cfg, row_uuid, jsonl_path)
+        if not suuid:
+            continue
+        try:
+            breakdown = json.loads(breakdown_json) if breakdown_json else {}
+        except (TypeError, ValueError):
+            breakdown = {}
+        if not isinstance(breakdown, dict):
+            breakdown = {}
+        models, cache_read, cache_create = {}, 0, 0
+        for model, parts in breakdown.items():
+            if not isinstance(parts, dict):
+                continue
+            clean, _ = sanitize_model_name(cfg, model)
+            models[clean] = {k: _num(parts.get(k)) for k in _MODEL_PART_KEYS}
+            cache_read += _num(parts.get("cache_read"))
+            cache_create += _num(parts.get("cache_create"))
+        # R4b cost precedence: stored -> breakdown -> dominant-model fallback.
+        cost, used_source = 0.0, None
+        if cost_source:
+            cost, used_source = _num(cost_usd, 0.0), clamp(cost_source, 40)
+        elif breakdown and cost_fn is not None:
+            try:
+                cost = float(cost_fn(breakdown, cache_create_1h=cc1h,
+                                     cache_create_5m=cc5m) or 0.0)
+            except Exception:
+                cost = 0.0
+        elif model_cost_fn is not None:
+            try:
+                usage = json.loads(model_usage_json) if model_usage_json else {}
+            except (TypeError, ValueError):
+                usage = {}
+            if isinstance(usage, dict) and usage:
+                dominant = max(usage, key=lambda m: _num(usage[m]
+                               if isinstance(usage[m], dict) else usage[m]))
+                parts = breakdown.get(dominant, {}) if isinstance(breakdown, dict) else {}
+                cost = float(model_cost_fn(dominant, _num(parts.get("fresh_input")),
+                                           _num(parts.get("output")),
+                                           _num(parts.get("cache_read")),
+                                           _num(parts.get("cache_create"))) or 0.0)
+        counted = runtime == "claude"
+        tokens, sav_cost = _counted_savings(conn, suuid) if counted else (0, 0.0)
+        events.append({
+            "type": "session",
+            "session_uuid": suuid,
+            "platform": clamp(platform or "unknown", 32),
+            "project_hash": project_hash(cfg, project),
+            "date": clamp(date, 10),
+            "started_at": None,
+            "ended_at": clamp(collected_at, 32),
+            "duration_minutes": _num(duration, None),
+            "input_tokens": _num(in_tok, None),
+            "output_tokens": _num(out_tok, None),
+            "cache_read_tokens": cache_read,
+            "cache_create_tokens": cache_create,
+            "reported_input_tokens": _num(rep_in, None),
+            "reported_output_tokens": _num(rep_out, None),
+            "api_calls": _num(calls, None),
+            "message_count": _num(msgs, None),
+            "models": models,
+            "cost_usd": round(cost, 6),
+            "cost_source": used_source,
+            "savings": {"tokens": tokens, "cost_usd": round(sav_cost, 6)},
+            "savings_coverage": "counted" if counted else "unsupported_platform",
+            "quality_score": _num(qscore, None),
+            "quality_grade": clamp(qgrade, 8) if qgrade else None,
+            "_src_id": int(rid),
+        })
+    try:
+        wm = conn.execute("SELECT MAX(computed_at) FROM counted_reread").fetchone()
+        max_wm = str(wm[0]) if wm and wm[0] else str(watermark or "")
+    except Exception:
+        max_wm = str(watermark or "")
+    return events, max_id, max_wm
+
+
+def _counted_savings(conn, session_uuid):
+    """R4c: the counted_reread ledger sums for one session."""
+    tokens, cost = 0, 0.0
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(tokens),0), COALESCE(SUM(oneshot_usd + reread_usd),0) "
+            "FROM counted_reread WHERE session_uuid = ?", (session_uuid,)).fetchone()
+        if row:
+            tokens, cost = int(row[0] or 0), float(row[1] or 0.0)
+    except Exception:
+        pass
+    return tokens, cost
+
+
+# --------------------------------------------------------------------------- #
+# Outbox, cursor, log (atomic 0600 writes, R6)
+# --------------------------------------------------------------------------- #
+
+def _write_private(path, text):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.parent / f".{path.name}.{os.getpid()}.{os.urandom(4).hex()}.tmp"
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.chmod(str(tmp), 0o600)
+        os.replace(str(tmp), str(path))
+    except BaseException:
+        try:
+            os.unlink(str(tmp))
+        except OSError:
+            pass
+        raise
+
+
+def snapshot_dir_ok(snapshot_dir):
+    """R6: a group/world-writable snapshot dir disables emission."""
+    if snapshot_dir is None:
+        return False
+    try:
+        st = os.stat(str(snapshot_dir))
+        return not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+    except OSError:
+        return False
+
+
+def reap_stale_tmp(snapshot_dir, now=None):
+    now = time.time() if now is None else now
+    try:
+        for p in Path(snapshot_dir).glob("*.tmp"):
+            try:
+                if now - p.stat().st_mtime > TMP_MAX_AGE_S:
+                    p.unlink()
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+def log_line(snapshot_dir, message):
+    try:
+        path = Path(snapshot_dir) / LOG_NAME if snapshot_dir else None
+        if path is None:
+            return
+        stamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = []
+        if path.exists():
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        lines.append(f"{stamp} {clamp(message, 300)}")
+        _write_private(path, "\n".join(lines[-LOG_MAX_LINES:]) + "\n")
+    except Exception:
+        pass
+
+
+def read_state(snapshot_dir):
+    """Cursor + savings watermark from one file."""
+    try:
+        data = json.loads((Path(snapshot_dir) / CURSOR_NAME).read_text(encoding="utf-8"))
+        return int(data.get("last_id") or 0), str(data.get("watermark") or "")
+    except Exception:
+        return 0, ""
+
+
+def write_state(snapshot_dir, last_id, watermark):
+    try:
+        _write_private(Path(snapshot_dir) / CURSOR_NAME, json.dumps({
+            "last_id": int(last_id), "watermark": str(watermark or ""),
+            "updated_at": datetime.utcnow().isoformat() + "Z"}))
+    except Exception:
+        pass
+
+
+def read_outbox(snapshot_dir):
+    items = []
+    try:
+        path = Path(snapshot_dir) / OUTBOX_NAME
+        if not path.exists():
+            return items
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and isinstance(rec.get("event"), dict):
+                items.append(rec)
+    except OSError:
+        pass
+    return items
+
+
+def write_outbox(snapshot_dir, items):
+    try:
+        path = Path(snapshot_dir) / OUTBOX_NAME
+        if not items:
+            if path.exists():
+                path.unlink()
+            return
+        _write_private(path, "".join(
+            json.dumps(i, separators=(",", ":")) + "\n" for i in items))
+    except Exception:
+        pass
+
+
+def enqueue(snapshot_dir, events, source_ids=None, now=None):
+    """Append sanitised events to the outbox, dedup by session_uuid (newest
+    wins), enforce the size and age caps. Returns the number now queued."""
+    now = now or datetime.utcnow()
+    reap_stale_tmp(snapshot_dir, now.timestamp())
+    items = read_outbox(snapshot_dir)
+    by_uuid = {r["event"].get("session_uuid"): r for r in items}
+    source_ids = source_ids or {}
+    for ev in events:
+        if not isinstance(ev, dict) or ev.get("type") != "session":
+            continue
+        by_uuid[ev["session_uuid"]] = {
+            "queued_at": now.isoformat() + "Z",
+            "id": int(source_ids.get(ev["session_uuid"], 0)),
+            "event": ev,
+        }
+    cutoff = (now - timedelta(days=MAX_OUTBOX_AGE_DAYS)).isoformat()
+    merged = [r for r in by_uuid.values() if str(r.get("queued_at", "")) >= cutoff]
+    merged.sort(key=lambda r: (str(r.get("queued_at", "")), int(r.get("id") or 0)))
+    merged = merged[-MAX_OUTBOX:]
+    write_outbox(snapshot_dir, merged)
+    return len(merged)
+
+
+def drain_outbox(snapshot_dir, cfg, version, post=None, max_posts=MAX_POSTS_PER_FLUSH,
+                 env=None, home=None, billing_mode="unknown", savings_method="none",
+                 meters=None):
+    """Send queued events in bounded batches. The cursor advances only over
+    acked ids (R6a). Returns stats. Never raises."""
+    post = post or post_payload
+    stats = {"sent": 0, "posts": 0, "failed": 0, "remaining": 0, "status": None}
+    try:
+        items = read_outbox(snapshot_dir)
+        last_id, watermark = read_state(snapshot_dir)
+        posts = 0
+        while items and posts < max_posts:
+            batch, ids = items[:MAX_BATCH], []
+            for rec in batch:
+                rid = int(rec.get("id") or 0)
+                if rid:
+                    ids.append(rid)
+            ok, status, _detail = post(cfg, batch, version, env=env, home=home,
+                                       billing_mode=billing_mode,
+                                       savings_method=savings_method, meters=meters)
+            stats["posts"] += 1
+            posts += 1
+            stats["status"] = status
+            if not ok:
+                stats["failed"] += 1
+                break
+            stats["sent"] += len(batch)
+            items = items[len(batch):]
+            if ids:
+                last_id = max(last_id, max(ids))
+            write_state(snapshot_dir, last_id, watermark)
+        write_outbox(snapshot_dir, items)
+        stats["remaining"] = len(items)
+    except Exception as exc:
+        stats["failed"] += 1
+        stats["status"] = exc.__class__.__name__
+    return stats
+
+
+# --------------------------------------------------------------------------- #
+# Network (lazy import; redirects refused, R6c)
+# --------------------------------------------------------------------------- #
+
+class _NoRedirect(Exception):
+    pass
+
+
+def post_payload(cfg, records, version, timeout=TIMEOUT_S, env=None, home=None,
+                 billing_mode="unknown", savings_method="none", meters=None):
+    """POST one batch of outbox records as a to.fleet.v1 envelope.
+    Returns (ok, status, detail). Never raises."""
+    try:
+        import urllib.error
+        import urllib.request
+
+        class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, req, fp, code, msg, headers, newurl):
+                raise _NoRedirect(f"redirect {code} refused")
+
+        events = [r.get("event") for r in records if isinstance(r, dict)]
+        payload = build_payload(cfg, events, version, env=env, home=home,
+                                meters=meters, billing_mode=billing_mode,
+                                savings_method=savings_method)
+        body = json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+        req = urllib.request.Request(
+            cfg["endpoint"].rstrip("/") + "/v1/ingest", data=body, method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {cfg['token']}",
+                "User-Agent": f"token-optimizer-fleet/{clamp(version or 'unknown', 40)}",
+            })
+        opener = urllib.request.build_opener(_NoRedirectHandler)
+        with opener.open(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", 200)
+            return (200 <= status < 300), status, ""
+    except _NoRedirect as exc:
+        return False, 0, str(exc)
+    except Exception as exc:  # HTTPError, URLError, socket.timeout, ValueError
+        status = int(getattr(exc, "code", 0) or 0)
+        return False, status, exc.__class__.__name__
+
+
+# --------------------------------------------------------------------------- #
+# Flush entry point (called from the session-end flush worker tail, R5)
+# --------------------------------------------------------------------------- #
+
+def emit_after_flush(trends_db=None, snapshot_dir=None, config_dir=None, runtime="claude",
+                     version="unknown", cost_fn=None, model_cost_fn=None, meters_fn=None,
+                     billing_mode="unknown", time_left_fn=None, env=None, home=None):
+    """Build events, enqueue, drain. Fail-open; returns a stats dict or None."""
+    env = os.environ if env is None else env
+    try:
+        cfg = load_config(env=env, config_dir=config_dir)
+        if cfg is None:
+            return None
+        if not snapshot_dir_ok(snapshot_dir):
+            log_line(snapshot_dir, "emission skipped: snapshot dir group/world-writable")
+            return None
+        reap_stale_tmp(snapshot_dir)
+        conn = sqlite_connect(trends_db)
+        if conn is None:
+            return None
+        try:
+            last_id, watermark = read_state(snapshot_dir)
+            outbox_len = len(read_outbox(snapshot_dir))
+            events, max_id, max_wm = build_session_events(
+                conn, cfg, cursor_id=last_id, watermark=watermark, runtime=runtime,
+                cost_fn=cost_fn, model_cost_fn=model_cost_fn,
+                max_events=max(0, MAX_OUTBOX - outbox_len))
+            meters = None
+            if meters_fn is not None:
+                try:
+                    meters = meters_fn()
+                except Exception:
+                    meters = None
+            if events:
+                ids = {e["session_uuid"]: e.pop("_src_id", 0) for e in events}
+                enqueue(snapshot_dir, events, source_ids=ids)
+            log_line(snapshot_dir, f"flush: {len(events)} new events, "
+                                   f"outbox={len(read_outbox(snapshot_dir))}, "
+                                   f"endpoint={cfg['endpoint']}")
+            if time_left_fn is not None:
+                try:
+                    if float(time_left_fn()) < MIN_NETWORK_SECONDS:
+                        return {"skipped_network": True}
+                except Exception:
+                    pass
+            return drain_outbox(snapshot_dir, cfg, version, env=env, home=home,
+                                billing_mode=billing_mode,
+                                savings_method="counted_reread" if runtime == "claude"
+                                else "none", meters=meters)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    except Exception as exc:
+        log_line(snapshot_dir, f"emit failed: {exc.__class__.__name__}")
+        return None
+
+
+def sqlite_connect(trends_db):
+    try:
+        import sqlite3
+        conn = sqlite3.connect(str(trends_db), timeout=5.0)
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# CLI (R7). Paths come from measure (KTD9); no path resolver of its own.
+# --------------------------------------------------------------------------- #
+
+def _measure():
+    import importlib
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    if "measure" in sys.modules and not hasattr(sys.modules["measure"], "__file__"):
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    return mod
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if "--enable" in argv:
+        i = argv.index("--enable")
+        vals = argv[i + 1:i + 4]
+        if len(vals) < 3:
+            print("usage: fleet_emitter.py --enable <endpoint> <ingest-token> <hash-key>")
+            return 2
+        ok, where = enable(*vals)
+        print(("wrote " if ok else "failed: ") + str(where))
+        return 0 if ok else 1
+    m = _measure()
+    cfg = load_config(config_dir=str(m.CONFIG_DIR))
+    if "--status" in argv:
+        if cfg is None:
+            print("FLEET TELEMETRY: DISABLED (no valid fleet.json)")
+        else:
+            outbox = len(read_outbox(str(m.SNAPSHOT_DIR)))
+            last_id, _wm = read_state(str(m.SNAPSHOT_DIR))
+            host = cfg["endpoint"].split("://", 1)[-1].split("/")[0]
+            print(f"FLEET TELEMETRY: ENABLED endpoint={host} source={cfg['source']} "
+                  f"outbox={outbox} cursor={last_id}")
+        return 0
+    if cfg is None:
+        return 0
+    if "--dry-run" in argv:
+        conn = sqlite_connect(m.TRENDS_DB)
+        if conn is None:
+            print("no trends.db")
+            return 1
+        last_id, wm = read_state(str(m.SNAPSHOT_DIR))
+        events, _mid, _w = build_session_events(conn, cfg, cursor_id=last_id,
+                                                watermark=wm, runtime="claude",
+                                                cost_fn=m._cost_from_model_breakdown,
+                                                model_cost_fn=m._get_model_cost)
+        conn.close()
+        meters = None
+        try:
+            meters = m._keepwarm_read_meters()
+        except Exception:
+            pass
+        payload = build_payload(cfg, events, m.TOKEN_OPTIMIZER_VERSION, meters=meters,
+                                billing_mode="unknown", savings_method="counted_reread")
+        print(json.dumps(payload, indent=2))
+        print("SENSITIVE: pseudonymous org aggregates; share deliberately.", file=sys.stderr)
+        return 0
+    # --flush [--all]
+    meters = None
+    try:
+        meters = m._keepwarm_read_meters()
+    except Exception:
+        pass
+    conn = sqlite_connect(m.TRENDS_DB)
+    if conn is None:
+        return 1
+    last_id, wm = read_state(str(m.SNAPSHOT_DIR))
+    if "--all" in argv:
+        last_id, wm = 0, ""
+    events, max_id, max_wm = build_session_events(
+        conn, cfg, cursor_id=last_id, watermark=wm, runtime="claude",
+        cost_fn=m._cost_from_model_breakdown, model_cost_fn=m._get_model_cost)
+    conn.close()
+    if events:
+        ids = {e["session_uuid"]: e.pop("_src_id", 0) for e in events}
+        enqueue(str(m.SNAPSHOT_DIR), events, source_ids=ids)
+    stats = drain_outbox(str(m.SNAPSHOT_DIR), cfg, m.TOKEN_OPTIMIZER_VERSION,
+                         savings_method="counted_reread", meters=meters)
+    print(json.dumps(stats))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6602,6 +6602,18 @@ def generate_standalone_dashboard(days=30, quiet=False, force=False):
         "runtime": detect_runtime(),
         "runtime_label": runtime_name_for_humans(),
     }
+    # Teams edition (R2d): when org telemetry is active on this machine, the
+    # developer whose sessions are emitted sees it on the local dashboard.
+    try:
+        import fleet_emitter as _fleet
+        _fcfg = _fleet.load_config(config_dir=str(CONFIG_DIR))
+        data["fleet_telemetry"] = {
+            "active": _fcfg is not None,
+            "endpoint_host": (_fcfg["endpoint"].split("://", 1)[-1].split("/")[0]
+                              if _fcfg else ""),
+        }
+    except Exception:
+        data["fleet_telemetry"] = {"active": False, "endpoint_host": ""}
     data = _sanitize_dashboard_paths(data)
 
     template = template_path.read_text(encoding="utf-8")
@@ -6826,6 +6838,21 @@ def _run_session_end_flush_worker(args):
             except Exception:
                 pass
     except _HookTimeout:
+        pass
+    # Teams-edition org telemetry (admin-enabled, OFF by default). Runs in the
+    # worker tail, outside the refresh block's exception paths: fail-open, and
+    # the network step is skipped when the 20s budget is nearly spent. The
+    # watchdog's os._exit(0) never unwinds here, so the emitter writes its
+    # outbox atomically before any POST.
+    try:
+        import fleet_emitter
+        fleet_emitter.emit_after_flush(
+            trends_db=TRENDS_DB, snapshot_dir=SNAPSHOT_DIR, config_dir=CONFIG_DIR,
+            runtime=detect_runtime(), version=TOKEN_OPTIMIZER_VERSION,
+            cost_fn=_cost_from_model_breakdown, model_cost_fn=_get_model_cost,
+            meters_fn=_keepwarm_read_meters, billing_mode=fleet_billing_mode(),
+            time_left_fn=old_budget.remaining)
+    except Exception:
         pass
     finally:
         _clear_hook_budget(old_budget)
@@ -12700,6 +12727,33 @@ def keepwarm_billing_mode(env=None, claude_json_path=None, settings_path=None):
         return "subscription"
     # Rung 4: nothing detectable -> conservative subscription (off).
     return "subscription"
+
+
+def fleet_billing_mode(env=None, claude_json_path=None, settings_path=None):
+    """Billing class for the org-telemetry emitter (Teams edition).
+
+    Same ladder as keepwarm_billing_mode, but the 'nothing detectable' rung
+    maps to 'unknown', never 'subscription': keep-warm must assume the worst
+    (an unknown user is subscription and stays off), while telemetry must not
+    claim a billing mode it cannot see.
+    """
+    if env is None:
+        env = os.environ
+    if _keepwarm_env_says_api(env):
+        return "api"
+    json_verdict = _keepwarm_json_says_api(
+        claude_json_path if claude_json_path is not None
+        else _keepwarm_default_claude_json_path())
+    if json_verdict == "api":
+        return "api"
+    settings_verdict = _keepwarm_json_says_api(
+        settings_path if settings_path is not None
+        else _keepwarm_default_settings_path())
+    if settings_verdict == "api":
+        return "api"
+    if json_verdict == "subscription":
+        return "subscription"
+    return "unknown"
 
 
 def keepwarm_consent():

--- a/skills/token-optimizer/assets/dashboard.html
+++ b/skills/token-optimizer/assets/dashboard.html
@@ -2046,6 +2046,8 @@ window.__TOKEN_DATA__ = null;
 
   <!-- MAIN -->
   <main class="main-col">
+    <!-- Org telemetry banner (Teams edition): rendered only when active -->
+    <div id="fleet-telemetry-banner" style="display:none;font-size:12px;font-family:var(--font-mono);padding:6px 12px;border:1px solid var(--c-border);border-radius:6px;margin:8px 0 0;color:var(--c-text-dim);"></div>
     <!-- Overview View -->
     <div class="view active" id="view-overview">
       <header class="header">
@@ -7009,6 +7011,14 @@ document.addEventListener('DOMContentLoaded', function() {
     if (data.version) brandParts.push('v' + data.version);
     if (data.runtime === 'codex') brandParts.push('Codex');
     brandMeta.textContent = brandParts.join(' \u00b7 ');
+  }
+  // Org telemetry banner (Teams edition): visible only when an admin-enabled
+  // fleet.json is active on this machine. textContent only, never innerHTML.
+  var fleetBanner = document.getElementById('fleet-telemetry-banner');
+  if (fleetBanner && data.fleet_telemetry && data.fleet_telemetry.active) {
+    fleetBanner.textContent = 'Org telemetry active: sending session aggregates to '
+      + (data.fleet_telemetry.endpoint_host || 'unknown endpoint');
+    fleetBanner.style.display = 'block';
   }
 
   function startApp() { DB.init(data); refreshSavingsLive(); }

--- a/skills/token-optimizer/scripts/fleet_emitter.py
+++ b/skills/token-optimizer/scripts/fleet_emitter.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""Admin-enabled org telemetry emitter (Token Optimizer Teams edition).
+
+OFF BY DEFAULT, and file-only: nothing is emitted unless an org admin has
+placed a ``fleet.json`` (mode 0600) in Token Optimizer's config dir holding
+``endpoint``, ``hash_key`` and either ``token`` or ``token_env``. Environment
+variables alone never enable emission (a cloned repo's settings must not be
+able to switch telemetry on). ``TO_FLEET_DISABLE=1`` overrides everything.
+
+What it sends when enabled: per-session aggregates Token Optimizer already
+stores locally (platform, pseudonymous ids, token counts, model split, cost,
+counted savings, one account-level limit-meter reading, timestamps). Never
+prompts, never responses, never file contents, never file paths, never command
+text, never tool output. The allowlist below is enforced on keys AND values
+before serialisation.
+
+Delivery: events queue in a local outbox (JSONL, 0600, atomic writes) first,
+then the outbox is drained with bounded POSTs (3s timeout, at most two batches
+per flush, redirects refused). A failed POST leaves the outbox intact; the id
+cursor advances only after a 2xx. Every entry point is fail-open: nothing here
+can raise into a hook.
+
+Inspect exactly what would be sent: ``python3 fleet_emitter.py --dry-run``
+(output is sensitive: it contains this org's pseudonymous aggregates).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import stat
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+SCHEMA = "to.fleet.v1"
+
+ENV_DISABLE = "TO_FLEET_DISABLE"
+ENV_CONFIG = "TO_FLEET_CONFIG"
+ENV_USER = "TO_FLEET_USER"
+ENV_HASH_KEY = "TO_FLEET_HASH_KEY"
+
+CONFIG_FILENAME = "fleet.json"
+OUTBOX_NAME = "fleet-outbox.jsonl"
+CURSOR_NAME = "fleet-cursor.json"
+LOG_NAME = "fleet.log"
+
+MAX_BATCH = 200            # events per POST
+MAX_POSTS_PER_FLUSH = 2    # bounded network time per session-end flush
+MAX_OUTBOX = 500           # events kept locally while the collector is down
+MAX_OUTBOX_AGE_DAYS = 7
+RECENT_DAYS = 2            # re-send rows this recent so backfilled columns land
+MIN_NETWORK_SECONDS = 7.0  # skip the network step when less budget remains
+TIMEOUT_S = 3.0
+LOG_MAX_LINES = 200
+TMP_MAX_AGE_S = 600
+
+_MODEL_RE = re.compile(r"^[A-Za-z0-9._:@-]{1,80}$")
+_HASHISH_RE = re.compile(r"^(?:[0-9a-f]{16,32}|p-[0-9a-f]{30})$")
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.I)
+_LOOPBACK = ("127.0.0.1", "localhost", "::1")
+
+# Every key a wire event may carry. Anything else is stripped by sanitize_event().
+EVENT_KEYS = frozenset({
+    "type", "session_uuid", "platform", "project_hash", "date",
+    "started_at", "ended_at", "duration_minutes",
+    "input_tokens", "output_tokens", "cache_read_tokens", "cache_create_tokens",
+    "reported_input_tokens", "reported_output_tokens", "api_calls", "message_count",
+    "models", "cost_usd", "cost_source", "savings", "savings_coverage",
+    "quality_score", "quality_grade",
+})
+ENVELOPE_KEYS = frozenset({
+    "schema", "sent_at", "to_version", "user_hash", "host_hash",
+    "limit", "billing_mode", "savings_method", "models_redacted",
+    "user_label", "events",
+})
+_MODEL_PART_KEYS = ("fresh_input", "cache_read", "cache_create", "output")
+_STR_KEYS = frozenset({"type", "session_uuid", "platform", "project_hash", "date",
+                       "started_at", "ended_at", "cost_source", "savings_coverage",
+                       "quality_grade"})
+
+
+def clamp(text, length=120):
+    """Clamp to printable ASCII (control chars and non-ASCII dropped)."""
+    return "".join(c for c in str(text or "") if 32 <= ord(c) < 127)[:length]
+
+
+# --------------------------------------------------------------------------- #
+# Configuration (file-only enablement, R2/R2a/R2b)
+# --------------------------------------------------------------------------- #
+
+def load_config(env=None, config_dir=None):
+    """Return a config dict, or None when telemetry is not configured.
+
+    A fleet.json is REQUIRED. Env vars alone never enable. The file must be
+    owner-readable only; a group/world-readable file is ignored with a logged
+    reason. TO_FLEET_CONFIG must resolve inside config_dir when config_dir is
+    given. Endpoints must be https:// except loopback http.
+    """
+    env = os.environ if env is None else env
+    if (env.get(ENV_DISABLE) or "").strip().lower() in ("1", "true", "yes", "on"):
+        return None
+    base = Path(config_dir).expanduser() if config_dir else _default_config_dir(env)
+    override = (env.get(ENV_CONFIG) or "").strip()
+    if override:
+        p = Path(override).expanduser().resolve()
+        try:
+            p.relative_to(base.resolve())
+        except ValueError:
+            return None
+    else:
+        p = base / CONFIG_FILENAME
+    try:
+        if not p.is_file():
+            return None
+        mode = p.stat().st_mode
+        if mode & (stat.S_IRWXG | stat.S_IRWXO):
+            log_line(None, f"config ignored: {p.name} is group/world-readable")
+            return None
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict) or raw.get("enabled") is False:
+        return None
+    endpoint = str(raw.get("endpoint") or "").strip()
+    token = str(raw.get("token") or "").strip()
+    if not token:
+        token = (env.get(str(raw.get("token_env") or "") or "") or "").strip()
+    hash_key = str(raw.get("hash_key") or "").strip()
+    if not hash_key:
+        hk_env = str(raw.get("hash_key_env") or "").strip()
+        hash_key = (env.get(hk_env) or "").strip() if hk_env else \
+            (env.get(ENV_HASH_KEY) or "").strip()
+    if not endpoint or not token or not hash_key:
+        return None
+    endpoint = clamp(endpoint, 300)
+    scheme, _, rest = endpoint.partition("://")
+    host = rest.split("/")[0].split(":")[0].lower()
+    if scheme == "http" and host not in _LOOPBACK:
+        return None
+    if scheme not in ("http", "https"):
+        return None
+    return {
+        "endpoint": endpoint.rstrip("/"),
+        "token": token,
+        "hash_key": hash_key,
+        "user": clamp(raw.get("user") or "", 120),
+        "send_user_label": bool(raw.get("send_user_label", False)),
+        "source": str(p),
+    }
+
+
+def _default_config_dir(env):
+    """Mirror measure.CONFIG_DIR cheaply (no measure import when disabled)."""
+    base = (env.get("TOKEN_OPTIMIZER_CONFIG_DIR") or "").strip()
+    if base:
+        return Path(base).expanduser()
+    runtime = (env.get("TOKEN_OPTIMIZER_RUNTIME") or "").strip().lower()
+    home = Path(env.get("HOME") or env.get("USERPROFILE") or str(Path.home()))
+    if runtime == "codex":
+        return home / ".codex" / "token-optimizer"
+    if runtime == "opencode":
+        return home / ".local" / "share" / "opencode" / "token-optimizer"
+    if runtime == "hermes":
+        return home / ".hermes" / "token-optimizer"
+    if runtime == "copilot":
+        return home / ".copilot" / "token-optimizer"
+    return home / ".claude" / "token-optimizer"
+
+
+def is_enabled(env=None, config_dir=None):
+    return load_config(env=env, config_dir=config_dir) is not None
+
+
+def enable(endpoint, token, hash_key, config_dir=None, env=None):
+    """Write fleet.json at mode 0600. Returns (ok, path_or_reason)."""
+    env = os.environ if env is None else env
+    base = Path(config_dir).expanduser() if config_dir else _default_config_dir(env)
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+        path = base / CONFIG_FILENAME
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump({"endpoint": endpoint, "token": token, "hash_key": hash_key}, fh)
+            fh.write("\n")
+        os.chmod(str(path), 0o600)
+        return True, str(path)
+    except OSError as exc:
+        return False, exc.__class__.__name__
+
+
+# --------------------------------------------------------------------------- #
+# Pseudonymous identity (R3/R3a, KTD7: HMAC keyed by the org hash_key)
+# --------------------------------------------------------------------------- #
+
+def canonical_identity(cfg, env=None, home=None):
+    """fleet.json user -> TO_FLEET_USER -> gitconfig user.email -> OS user."""
+    env = os.environ if env is None else env
+    if cfg.get("user"):
+        return cfg["user"]
+    v = (env.get(ENV_USER) or "").strip()
+    if v:
+        return v
+    gitconfig = Path(home or Path.home()) / ".gitconfig"
+    try:
+        in_user = False
+        for line in gitconfig.read_text(encoding="utf-8", errors="replace").splitlines():
+            s = line.strip()
+            if s.startswith("["):
+                in_user = s.lower().startswith("[user")
+                continue
+            if in_user and "=" in s:
+                k, _, val = s.partition("=")
+                if k.strip().lower() == "email" and val.strip():
+                    return val.strip()
+    except OSError:
+        pass
+    try:
+        import getpass
+        return getpass.getuser()
+    except Exception:
+        return "unknown"
+
+
+def _hmac(hash_key, value, length):
+    return hmac.new(hash_key.encode("utf-8"), str(value).encode("utf-8"),
+                    hashlib.sha256).hexdigest()[:length]
+
+
+def user_hash(cfg, env=None, home=None):
+    return _hmac(cfg["hash_key"], canonical_identity(cfg, env, home), 32)
+
+
+def host_hash(cfg):
+    try:
+        import socket
+        host = socket.gethostname()
+    except Exception:
+        host = "unknown"
+    return _hmac(cfg["hash_key"], host, 16)
+
+
+def project_hash(cfg, project):
+    return _hmac(cfg["hash_key"], project or "", 16)
+
+
+def session_uuid_for(cfg, row_uuid, jsonl_path):
+    """R4a: stored uuid verbatim; NULL falls back to the filename UUID, then an
+    HMAC of the path (the path itself never leaves the machine)."""
+    if row_uuid:
+        s = str(row_uuid).strip()
+        if _UUID_RE.fullmatch(s):
+            return s.lower()
+        return _hmac(cfg["hash_key"], "sid:" + s, 32)
+    m = _UUID_RE.search(Path(str(jsonl_path or "")).name)
+    if m:
+        return m.group(0).lower()
+    if jsonl_path:
+        return "p-" + _hmac(cfg["hash_key"], "path:" + str(jsonl_path), 30)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Value sanitisation (R4: allowlist on keys AND values)
+# --------------------------------------------------------------------------- #
+
+def _num(value, default=0):
+    try:
+        if value is None:
+            return default
+        n = float(value)
+        if n != n or n in (float("inf"), float("-inf")):
+            return default
+        return int(n) if float(n).is_integer() else round(n, 6)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def sanitize_model_name(cfg, name):
+    """Strip a provider prefix; enforce the R4 pattern; redact otherwise."""
+    raw = str(name or "")
+    stripped = raw.rsplit("/", 1)[-1] if "/" in raw else raw
+    if _MODEL_RE.fullmatch(stripped):
+        return stripped, False
+    return "custom-" + _hmac(cfg["hash_key"], "model:" + raw, 16), True
+
+
+def sanitize_event(cfg, event):
+    """Allowlist filter. Returns a clean dict or None when the event is unusable."""
+    if not isinstance(event, dict):
+        return None
+    out = {}
+    redacted = 0
+    for key, value in event.items():
+        if key not in EVENT_KEYS:
+            continue
+        if key == "models":
+            models = {}
+            if isinstance(value, dict):
+                for model, parts in value.items():
+                    if not isinstance(parts, dict):
+                        continue
+                    clean, was_redacted = sanitize_model_name(cfg, model)
+                    redacted += 1 if was_redacted else 0
+                    models[clean] = {k: _num(parts.get(k)) for k in _MODEL_PART_KEYS}
+            out[key] = models
+        elif key == "savings":
+            sv = value if isinstance(value, dict) else {}
+            out[key] = {"tokens": _num(sv.get("tokens")),
+                        "cost_usd": round(_num(sv.get("cost_usd"), 0.0), 6)}
+        elif key == "limit":
+            out[key] = None
+            if isinstance(value, dict):
+                out[key] = {
+                    "five_hour_pct": _num(value.get("five_hour_pct"), None),
+                    "seven_day_pct": _num(value.get("seven_day_pct"), None),
+                    "ts": _num(value.get("ts"), None),
+                }
+        elif key in _STR_KEYS:
+            out[key] = None if value is None else clamp(value, 64)
+            if key == "project_hash" and out[key] and not _HASHISH_RE.fullmatch(out[key]):
+                out[key] = _hmac(cfg.get("hash_key", ""), "proj:" + out[key], 16)
+        else:
+            out[key] = _num(value, None)
+    if out.get("type") != "session" or not out.get("session_uuid"):
+        return None
+    out["models_redacted"] = redacted
+    return out
+
+
+def build_payload(cfg, events, version, env=None, home=None, meters=None,
+                  billing_mode="unknown", savings_method="none"):
+    """Envelope + sanitised events. Envelope keys are the frozen ENVELOPE_KEYS."""
+    clean, redacted = [], 0
+    for ev in events:
+        c = sanitize_event(cfg, ev)
+        if c is None:
+            continue
+        redacted += c.pop("models_redacted", 0)
+        clean.append(c)
+    payload = {
+        "schema": SCHEMA,
+        "sent_at": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "to_version": clamp(version or "unknown", 40),
+        "user_hash": user_hash(cfg, env, home),
+        "host_hash": host_hash(cfg),
+        "billing_mode": clamp(billing_mode or "unknown", 20),
+        "savings_method": clamp(savings_method or "none", 40),
+        "models_redacted": redacted,
+        "events": clean,
+    }
+    if isinstance(meters, dict) and meters.get("available"):
+        payload["limit"] = {
+            "five_hour_pct": _num(meters.get("five_hour_pct"), None),
+            "seven_day_pct": _num(meters.get("seven_day_pct"), None),
+            "ts": _num(meters.get("ts"), None),
+        }
+    if cfg.get("send_user_label"):
+        payload["user_label"] = clamp(canonical_identity(cfg, env, home), 120)
+    assert set(payload) <= ENVELOPE_KEYS
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Event building from trends.db (R4a-R4c, R6a, R6b)
+# --------------------------------------------------------------------------- #
+
+def build_session_events(conn, cfg, cursor_id=0, watermark="", runtime="claude",
+                         cost_fn=None, model_cost_fn=None, max_events=MAX_OUTBOX,
+                         now=None):
+    """Union of three bounded queries (R6a/R6b), ascending id, capped so a
+    backlog drains over flushes. Returns (events, max_id_seen, max_computed_at)."""
+    now = now or datetime.now()
+    recent_cutoff = (now - timedelta(days=RECENT_DAYS)).strftime("%Y-%m-%d")
+    budget = max(0, int(max_events))
+    ids = set()
+    for (rid,) in conn.execute(
+            "SELECT id FROM session_log WHERE id > ? ORDER BY id ASC LIMIT ?",
+            (int(cursor_id or 0), budget)):
+        ids.add(int(rid))
+    for (rid,) in conn.execute(
+            "SELECT id FROM session_log WHERE date >= ? ORDER BY id ASC LIMIT ?",
+            (recent_cutoff, budget)):
+        ids.add(int(rid))
+    if watermark:
+        for (rid,) in conn.execute(
+                "SELECT s.id FROM session_log s WHERE s.session_uuid IN "
+                "(SELECT DISTINCT session_uuid FROM counted_reread "
+                " WHERE computed_at > ?) AND s.id > 0 ORDER BY s.id ASC LIMIT ?",
+                (str(watermark), budget)):
+            ids.add(int(rid))
+    if not ids:
+        return [], int(cursor_id or 0), str(watermark or "")
+    rows = conn.execute(
+        "SELECT id, jsonl_path, date, project, duration_minutes, input_tokens, "
+        "output_tokens, message_count, api_calls, cache_create_1h_tokens, "
+        "cache_create_5m_tokens, model_usage_json, model_usage_breakdown_json, "
+        "collected_at, quality_score, quality_grade, session_uuid, is_sidechain, "
+        "reported_input_tokens, reported_output_tokens, platform, "
+        "cost_usd, cost_source "
+        "FROM session_log WHERE id IN (%s) ORDER BY id ASC" % ",".join("?" * len(ids)),
+        tuple(sorted(ids))).fetchall()
+    events, max_id = [], int(cursor_id or 0)
+    for (rid, jsonl_path, date, project, duration, in_tok, out_tok, msgs, calls,
+         cc1h, cc5m, model_usage_json, breakdown_json, collected_at, qscore, qgrade,
+         row_uuid, sidechain, rep_in, rep_out, platform, cost_usd, cost_source) in rows:
+        max_id = max(max_id, int(rid or 0))
+        if sidechain:
+            continue
+        suuid = session_uuid_for(cfg, row_uuid, jsonl_path)
+        if not suuid:
+            continue
+        try:
+            breakdown = json.loads(breakdown_json) if breakdown_json else {}
+        except (TypeError, ValueError):
+            breakdown = {}
+        if not isinstance(breakdown, dict):
+            breakdown = {}
+        models, cache_read, cache_create = {}, 0, 0
+        for model, parts in breakdown.items():
+            if not isinstance(parts, dict):
+                continue
+            clean, _ = sanitize_model_name(cfg, model)
+            models[clean] = {k: _num(parts.get(k)) for k in _MODEL_PART_KEYS}
+            cache_read += _num(parts.get("cache_read"))
+            cache_create += _num(parts.get("cache_create"))
+        # R4b cost precedence: stored -> breakdown -> dominant-model fallback.
+        cost, used_source = 0.0, None
+        if cost_source:
+            cost, used_source = _num(cost_usd, 0.0), clamp(cost_source, 40)
+        elif breakdown and cost_fn is not None:
+            try:
+                cost = float(cost_fn(breakdown, cache_create_1h=cc1h,
+                                     cache_create_5m=cc5m) or 0.0)
+            except Exception:
+                cost = 0.0
+        elif model_cost_fn is not None:
+            try:
+                usage = json.loads(model_usage_json) if model_usage_json else {}
+            except (TypeError, ValueError):
+                usage = {}
+            if isinstance(usage, dict) and usage:
+                dominant = max(usage, key=lambda m: _num(usage[m]
+                               if isinstance(usage[m], dict) else usage[m]))
+                parts = breakdown.get(dominant, {}) if isinstance(breakdown, dict) else {}
+                cost = float(model_cost_fn(dominant, _num(parts.get("fresh_input")),
+                                           _num(parts.get("output")),
+                                           _num(parts.get("cache_read")),
+                                           _num(parts.get("cache_create"))) or 0.0)
+        counted = runtime == "claude"
+        tokens, sav_cost = _counted_savings(conn, suuid) if counted else (0, 0.0)
+        events.append({
+            "type": "session",
+            "session_uuid": suuid,
+            "platform": clamp(platform or "unknown", 32),
+            "project_hash": project_hash(cfg, project),
+            "date": clamp(date, 10),
+            "started_at": None,
+            "ended_at": clamp(collected_at, 32),
+            "duration_minutes": _num(duration, None),
+            "input_tokens": _num(in_tok, None),
+            "output_tokens": _num(out_tok, None),
+            "cache_read_tokens": cache_read,
+            "cache_create_tokens": cache_create,
+            "reported_input_tokens": _num(rep_in, None),
+            "reported_output_tokens": _num(rep_out, None),
+            "api_calls": _num(calls, None),
+            "message_count": _num(msgs, None),
+            "models": models,
+            "cost_usd": round(cost, 6),
+            "cost_source": used_source,
+            "savings": {"tokens": tokens, "cost_usd": round(sav_cost, 6)},
+            "savings_coverage": "counted" if counted else "unsupported_platform",
+            "quality_score": _num(qscore, None),
+            "quality_grade": clamp(qgrade, 8) if qgrade else None,
+            "_src_id": int(rid),
+        })
+    try:
+        wm = conn.execute("SELECT MAX(computed_at) FROM counted_reread").fetchone()
+        max_wm = str(wm[0]) if wm and wm[0] else str(watermark or "")
+    except Exception:
+        max_wm = str(watermark or "")
+    return events, max_id, max_wm
+
+
+def _counted_savings(conn, session_uuid):
+    """R4c: the counted_reread ledger sums for one session."""
+    tokens, cost = 0, 0.0
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(SUM(tokens),0), COALESCE(SUM(oneshot_usd + reread_usd),0) "
+            "FROM counted_reread WHERE session_uuid = ?", (session_uuid,)).fetchone()
+        if row:
+            tokens, cost = int(row[0] or 0), float(row[1] or 0.0)
+    except Exception:
+        pass
+    return tokens, cost
+
+
+# --------------------------------------------------------------------------- #
+# Outbox, cursor, log (atomic 0600 writes, R6)
+# --------------------------------------------------------------------------- #
+
+def _write_private(path, text):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.parent / f".{path.name}.{os.getpid()}.{os.urandom(4).hex()}.tmp"
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        os.chmod(str(tmp), 0o600)
+        os.replace(str(tmp), str(path))
+    except BaseException:
+        try:
+            os.unlink(str(tmp))
+        except OSError:
+            pass
+        raise
+
+
+def snapshot_dir_ok(snapshot_dir):
+    """R6: a group/world-writable snapshot dir disables emission."""
+    if snapshot_dir is None:
+        return False
+    try:
+        st = os.stat(str(snapshot_dir))
+        return not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+    except OSError:
+        return False
+
+
+def reap_stale_tmp(snapshot_dir, now=None):
+    now = time.time() if now is None else now
+    try:
+        for p in Path(snapshot_dir).glob("*.tmp"):
+            try:
+                if now - p.stat().st_mtime > TMP_MAX_AGE_S:
+                    p.unlink()
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+def log_line(snapshot_dir, message):
+    try:
+        path = Path(snapshot_dir) / LOG_NAME if snapshot_dir else None
+        if path is None:
+            return
+        stamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        lines = []
+        if path.exists():
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        lines.append(f"{stamp} {clamp(message, 300)}")
+        _write_private(path, "\n".join(lines[-LOG_MAX_LINES:]) + "\n")
+    except Exception:
+        pass
+
+
+def read_state(snapshot_dir):
+    """Cursor + savings watermark from one file."""
+    try:
+        data = json.loads((Path(snapshot_dir) / CURSOR_NAME).read_text(encoding="utf-8"))
+        return int(data.get("last_id") or 0), str(data.get("watermark") or "")
+    except Exception:
+        return 0, ""
+
+
+def write_state(snapshot_dir, last_id, watermark):
+    try:
+        _write_private(Path(snapshot_dir) / CURSOR_NAME, json.dumps({
+            "last_id": int(last_id), "watermark": str(watermark or ""),
+            "updated_at": datetime.utcnow().isoformat() + "Z"}))
+    except Exception:
+        pass
+
+
+def read_outbox(snapshot_dir):
+    items = []
+    try:
+        path = Path(snapshot_dir) / OUTBOX_NAME
+        if not path.exists():
+            return items
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(rec, dict) and isinstance(rec.get("event"), dict):
+                items.append(rec)
+    except OSError:
+        pass
+    return items
+
+
+def write_outbox(snapshot_dir, items):
+    try:
+        path = Path(snapshot_dir) / OUTBOX_NAME
+        if not items:
+            if path.exists():
+                path.unlink()
+            return
+        _write_private(path, "".join(
+            json.dumps(i, separators=(",", ":")) + "\n" for i in items))
+    except Exception:
+        pass
+
+
+def enqueue(snapshot_dir, events, source_ids=None, now=None):
+    """Append sanitised events to the outbox, dedup by session_uuid (newest
+    wins), enforce the size and age caps. Returns the number now queued."""
+    now = now or datetime.utcnow()
+    reap_stale_tmp(snapshot_dir, now.timestamp())
+    items = read_outbox(snapshot_dir)
+    by_uuid = {r["event"].get("session_uuid"): r for r in items}
+    source_ids = source_ids or {}
+    for ev in events:
+        if not isinstance(ev, dict) or ev.get("type") != "session":
+            continue
+        by_uuid[ev["session_uuid"]] = {
+            "queued_at": now.isoformat() + "Z",
+            "id": int(source_ids.get(ev["session_uuid"], 0)),
+            "event": ev,
+        }
+    cutoff = (now - timedelta(days=MAX_OUTBOX_AGE_DAYS)).isoformat()
+    merged = [r for r in by_uuid.values() if str(r.get("queued_at", "")) >= cutoff]
+    merged.sort(key=lambda r: (str(r.get("queued_at", "")), int(r.get("id") or 0)))
+    merged = merged[-MAX_OUTBOX:]
+    write_outbox(snapshot_dir, merged)
+    return len(merged)
+
+
+def drain_outbox(snapshot_dir, cfg, version, post=None, max_posts=MAX_POSTS_PER_FLUSH,
+                 env=None, home=None, billing_mode="unknown", savings_method="none",
+                 meters=None):
+    """Send queued events in bounded batches. The cursor advances only over
+    acked ids (R6a). Returns stats. Never raises."""
+    post = post or post_payload
+    stats = {"sent": 0, "posts": 0, "failed": 0, "remaining": 0, "status": None}
+    try:
+        items = read_outbox(snapshot_dir)
+        last_id, watermark = read_state(snapshot_dir)
+        posts = 0
+        while items and posts < max_posts:
+            batch, ids = items[:MAX_BATCH], []
+            for rec in batch:
+                rid = int(rec.get("id") or 0)
+                if rid:
+                    ids.append(rid)
+            ok, status, _detail = post(cfg, batch, version, env=env, home=home,
+                                       billing_mode=billing_mode,
+                                       savings_method=savings_method, meters=meters)
+            stats["posts"] += 1
+            posts += 1
+            stats["status"] = status
+            if not ok:
+                stats["failed"] += 1
+                break
+            stats["sent"] += len(batch)
+            items = items[len(batch):]
+            if ids:
+                last_id = max(last_id, max(ids))
+            write_state(snapshot_dir, last_id, watermark)
+        write_outbox(snapshot_dir, items)
+        stats["remaining"] = len(items)
+    except Exception as exc:
+        stats["failed"] += 1
+        stats["status"] = exc.__class__.__name__
+    return stats
+
+
+# --------------------------------------------------------------------------- #
+# Network (lazy import; redirects refused, R6c)
+# --------------------------------------------------------------------------- #
+
+class _NoRedirect(Exception):
+    pass
+
+
+def post_payload(cfg, records, version, timeout=TIMEOUT_S, env=None, home=None,
+                 billing_mode="unknown", savings_method="none", meters=None):
+    """POST one batch of outbox records as a to.fleet.v1 envelope.
+    Returns (ok, status, detail). Never raises."""
+    try:
+        import urllib.error
+        import urllib.request
+
+        class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+            def redirect_request(self, req, fp, code, msg, headers, newurl):
+                raise _NoRedirect(f"redirect {code} refused")
+
+        events = [r.get("event") for r in records if isinstance(r, dict)]
+        payload = build_payload(cfg, events, version, env=env, home=home,
+                                meters=meters, billing_mode=billing_mode,
+                                savings_method=savings_method)
+        body = json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+        req = urllib.request.Request(
+            cfg["endpoint"].rstrip("/") + "/v1/ingest", data=body, method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {cfg['token']}",
+                "User-Agent": f"token-optimizer-fleet/{clamp(version or 'unknown', 40)}",
+            })
+        opener = urllib.request.build_opener(_NoRedirectHandler)
+        with opener.open(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", 200)
+            return (200 <= status < 300), status, ""
+    except _NoRedirect as exc:
+        return False, 0, str(exc)
+    except Exception as exc:  # HTTPError, URLError, socket.timeout, ValueError
+        status = int(getattr(exc, "code", 0) or 0)
+        return False, status, exc.__class__.__name__
+
+
+# --------------------------------------------------------------------------- #
+# Flush entry point (called from the session-end flush worker tail, R5)
+# --------------------------------------------------------------------------- #
+
+def emit_after_flush(trends_db=None, snapshot_dir=None, config_dir=None, runtime="claude",
+                     version="unknown", cost_fn=None, model_cost_fn=None, meters_fn=None,
+                     billing_mode="unknown", time_left_fn=None, env=None, home=None):
+    """Build events, enqueue, drain. Fail-open; returns a stats dict or None."""
+    env = os.environ if env is None else env
+    try:
+        cfg = load_config(env=env, config_dir=config_dir)
+        if cfg is None:
+            return None
+        if not snapshot_dir_ok(snapshot_dir):
+            log_line(snapshot_dir, "emission skipped: snapshot dir group/world-writable")
+            return None
+        reap_stale_tmp(snapshot_dir)
+        conn = sqlite_connect(trends_db)
+        if conn is None:
+            return None
+        try:
+            last_id, watermark = read_state(snapshot_dir)
+            outbox_len = len(read_outbox(snapshot_dir))
+            events, max_id, max_wm = build_session_events(
+                conn, cfg, cursor_id=last_id, watermark=watermark, runtime=runtime,
+                cost_fn=cost_fn, model_cost_fn=model_cost_fn,
+                max_events=max(0, MAX_OUTBOX - outbox_len))
+            meters = None
+            if meters_fn is not None:
+                try:
+                    meters = meters_fn()
+                except Exception:
+                    meters = None
+            if events:
+                ids = {e["session_uuid"]: e.pop("_src_id", 0) for e in events}
+                enqueue(snapshot_dir, events, source_ids=ids)
+            log_line(snapshot_dir, f"flush: {len(events)} new events, "
+                                   f"outbox={len(read_outbox(snapshot_dir))}, "
+                                   f"endpoint={cfg['endpoint']}")
+            if time_left_fn is not None:
+                try:
+                    if float(time_left_fn()) < MIN_NETWORK_SECONDS:
+                        return {"skipped_network": True}
+                except Exception:
+                    pass
+            return drain_outbox(snapshot_dir, cfg, version, env=env, home=home,
+                                billing_mode=billing_mode,
+                                savings_method="counted_reread" if runtime == "claude"
+                                else "none", meters=meters)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    except Exception as exc:
+        log_line(snapshot_dir, f"emit failed: {exc.__class__.__name__}")
+        return None
+
+
+def sqlite_connect(trends_db):
+    try:
+        import sqlite3
+        conn = sqlite3.connect(str(trends_db), timeout=5.0)
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# CLI (R7). Paths come from measure (KTD9); no path resolver of its own.
+# --------------------------------------------------------------------------- #
+
+def _measure():
+    import importlib
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    if "measure" in sys.modules and not hasattr(sys.modules["measure"], "__file__"):
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    return mod
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if "--enable" in argv:
+        i = argv.index("--enable")
+        vals = argv[i + 1:i + 4]
+        if len(vals) < 3:
+            print("usage: fleet_emitter.py --enable <endpoint> <ingest-token> <hash-key>")
+            return 2
+        ok, where = enable(*vals)
+        print(("wrote " if ok else "failed: ") + str(where))
+        return 0 if ok else 1
+    m = _measure()
+    cfg = load_config(config_dir=str(m.CONFIG_DIR))
+    if "--status" in argv:
+        if cfg is None:
+            print("FLEET TELEMETRY: DISABLED (no valid fleet.json)")
+        else:
+            outbox = len(read_outbox(str(m.SNAPSHOT_DIR)))
+            last_id, _wm = read_state(str(m.SNAPSHOT_DIR))
+            host = cfg["endpoint"].split("://", 1)[-1].split("/")[0]
+            print(f"FLEET TELEMETRY: ENABLED endpoint={host} source={cfg['source']} "
+                  f"outbox={outbox} cursor={last_id}")
+        return 0
+    if cfg is None:
+        return 0
+    if "--dry-run" in argv:
+        conn = sqlite_connect(m.TRENDS_DB)
+        if conn is None:
+            print("no trends.db")
+            return 1
+        last_id, wm = read_state(str(m.SNAPSHOT_DIR))
+        events, _mid, _w = build_session_events(conn, cfg, cursor_id=last_id,
+                                                watermark=wm, runtime="claude",
+                                                cost_fn=m._cost_from_model_breakdown,
+                                                model_cost_fn=m._get_model_cost)
+        conn.close()
+        meters = None
+        try:
+            meters = m._keepwarm_read_meters()
+        except Exception:
+            pass
+        payload = build_payload(cfg, events, m.TOKEN_OPTIMIZER_VERSION, meters=meters,
+                                billing_mode="unknown", savings_method="counted_reread")
+        print(json.dumps(payload, indent=2))
+        print("SENSITIVE: pseudonymous org aggregates; share deliberately.", file=sys.stderr)
+        return 0
+    # --flush [--all]
+    meters = None
+    try:
+        meters = m._keepwarm_read_meters()
+    except Exception:
+        pass
+    conn = sqlite_connect(m.TRENDS_DB)
+    if conn is None:
+        return 1
+    last_id, wm = read_state(str(m.SNAPSHOT_DIR))
+    if "--all" in argv:
+        last_id, wm = 0, ""
+    events, max_id, max_wm = build_session_events(
+        conn, cfg, cursor_id=last_id, watermark=wm, runtime="claude",
+        cost_fn=m._cost_from_model_breakdown, model_cost_fn=m._get_model_cost)
+    conn.close()
+    if events:
+        ids = {e["session_uuid"]: e.pop("_src_id", 0) for e in events}
+        enqueue(str(m.SNAPSHOT_DIR), events, source_ids=ids)
+    stats = drain_outbox(str(m.SNAPSHOT_DIR), cfg, m.TOKEN_OPTIMIZER_VERSION,
+                         savings_method="counted_reread", meters=meters)
+    print(json.dumps(stats))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -6602,6 +6602,18 @@ def generate_standalone_dashboard(days=30, quiet=False, force=False):
         "runtime": detect_runtime(),
         "runtime_label": runtime_name_for_humans(),
     }
+    # Teams edition (R2d): when org telemetry is active on this machine, the
+    # developer whose sessions are emitted sees it on the local dashboard.
+    try:
+        import fleet_emitter as _fleet
+        _fcfg = _fleet.load_config(config_dir=str(CONFIG_DIR))
+        data["fleet_telemetry"] = {
+            "active": _fcfg is not None,
+            "endpoint_host": (_fcfg["endpoint"].split("://", 1)[-1].split("/")[0]
+                              if _fcfg else ""),
+        }
+    except Exception:
+        data["fleet_telemetry"] = {"active": False, "endpoint_host": ""}
     data = _sanitize_dashboard_paths(data)
 
     template = template_path.read_text(encoding="utf-8")
@@ -6826,6 +6838,21 @@ def _run_session_end_flush_worker(args):
             except Exception:
                 pass
     except _HookTimeout:
+        pass
+    # Teams-edition org telemetry (admin-enabled, OFF by default). Runs in the
+    # worker tail, outside the refresh block's exception paths: fail-open, and
+    # the network step is skipped when the 20s budget is nearly spent. The
+    # watchdog's os._exit(0) never unwinds here, so the emitter writes its
+    # outbox atomically before any POST.
+    try:
+        import fleet_emitter
+        fleet_emitter.emit_after_flush(
+            trends_db=TRENDS_DB, snapshot_dir=SNAPSHOT_DIR, config_dir=CONFIG_DIR,
+            runtime=detect_runtime(), version=TOKEN_OPTIMIZER_VERSION,
+            cost_fn=_cost_from_model_breakdown, model_cost_fn=_get_model_cost,
+            meters_fn=_keepwarm_read_meters, billing_mode=fleet_billing_mode(),
+            time_left_fn=old_budget.remaining)
+    except Exception:
         pass
     finally:
         _clear_hook_budget(old_budget)
@@ -12700,6 +12727,33 @@ def keepwarm_billing_mode(env=None, claude_json_path=None, settings_path=None):
         return "subscription"
     # Rung 4: nothing detectable -> conservative subscription (off).
     return "subscription"
+
+
+def fleet_billing_mode(env=None, claude_json_path=None, settings_path=None):
+    """Billing class for the org-telemetry emitter (Teams edition).
+
+    Same ladder as keepwarm_billing_mode, but the 'nothing detectable' rung
+    maps to 'unknown', never 'subscription': keep-warm must assume the worst
+    (an unknown user is subscription and stays off), while telemetry must not
+    claim a billing mode it cannot see.
+    """
+    if env is None:
+        env = os.environ
+    if _keepwarm_env_says_api(env):
+        return "api"
+    json_verdict = _keepwarm_json_says_api(
+        claude_json_path if claude_json_path is not None
+        else _keepwarm_default_claude_json_path())
+    if json_verdict == "api":
+        return "api"
+    settings_verdict = _keepwarm_json_says_api(
+        settings_path if settings_path is not None
+        else _keepwarm_default_settings_path())
+    if settings_verdict == "api":
+        return "api"
+    if json_verdict == "subscription":
+        return "subscription"
+    return "unknown"
 
 
 def keepwarm_consent():

--- a/tests/test_fleet_emitter.py
+++ b/tests/test_fleet_emitter.py
@@ -1,0 +1,468 @@
+"""Fleet emitter (Teams edition): off by default, file-only enablement,
+allowlisted payload, fail-open delivery, ack-advanced cursor.
+
+Run: python3 -m pytest tests/test_fleet_emitter.py -v
+"""
+import importlib.util
+import json
+import os
+import socket
+import sqlite3
+import stat
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "skills" / "token-optimizer" / "scripts"
+EMITTER = SCRIPTS / "fleet_emitter.py"
+HASH_KEY = "a" * 43
+
+
+def _load(name="fleet_emitter_test"):
+    spec = importlib.util.spec_from_file_location(name, str(EMITTER))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def fe(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKEN_OPTIMIZER_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", str(tmp_path / "snap"))
+    (tmp_path / "snap").mkdir()
+    (tmp_path / "config").mkdir()
+    for var in ("TO_FLEET_ENDPOINT", "TO_FLEET_TOKEN", "TO_FLEET_DISABLE",
+                "TO_FLEET_CONFIG", "TO_FLEET_USER", "TO_FLEET_HASH_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    mod = _load()
+    yield mod
+    _load("fleet_emitter_test_reload")  # fresh module globals for the next test
+
+
+def _write_config(tmp_path, fe, mode=0o600, **fields):
+    p = tmp_path / "config" / "fleet.json"
+    body = {"endpoint": "http://127.0.0.1:8787", "token": "tok", "hash_key": HASH_KEY}
+    body.update(fields)
+    p.write_text(json.dumps(body))
+    p.chmod(mode)
+    return p
+
+
+def _db(tmp_path, rows=(), counted=(), name="trends.db"):
+    conn = sqlite3.connect(str(tmp_path / name))
+    conn.execute("""CREATE TABLE session_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, jsonl_path TEXT, date TEXT, project TEXT,
+        duration_minutes REAL, input_tokens INTEGER, output_tokens INTEGER,
+        message_count INTEGER, api_calls INTEGER, cache_create_1h_tokens INTEGER DEFAULT 0,
+        cache_create_5m_tokens INTEGER DEFAULT 0, model_usage_json TEXT,
+        model_usage_breakdown_json TEXT, collected_at TEXT, quality_score REAL,
+        quality_grade TEXT, session_uuid TEXT, is_sidechain INTEGER DEFAULT 0,
+        reported_input_tokens INTEGER, reported_output_tokens INTEGER, platform TEXT,
+        cost_usd REAL, cost_source TEXT)""")
+    conn.execute("""CREATE TABLE counted_reread (
+        event_key TEXT PRIMARY KEY, source TEXT, session_uuid TEXT, event_ts TEXT,
+        event_month TEXT, tokens INTEGER DEFAULT 0, oneshot_usd REAL DEFAULT 0,
+        reread_tokens INTEGER DEFAULT 0, reread_usd REAL DEFAULT 0,
+        turns_counted INTEGER DEFAULT 0, transcript_mtime REAL, computed_at TEXT)""")
+    for r in rows:
+        conn.execute(
+            "INSERT INTO session_log (jsonl_path, date, project, session_uuid, platform,"
+            " cost_usd, cost_source, model_usage_breakdown_json, is_sidechain)"
+            " VALUES (?,?,?,?,?,?,?,?,?)", r)
+    for c in counted:
+        conn.execute("INSERT INTO counted_reread (event_key, session_uuid, tokens,"
+                     " oneshot_usd, reread_usd, computed_at) VALUES (?,?,?,?,?,?)", c)
+    conn.commit()
+    return conn
+
+
+_ROW = ("p/x.jsonl", "2026-09-01", "proj", "cafe0000-1111-2222-3333-444455556666",
+        "claude", 1.5, "copilot_credits", '{"claude-opus-5":{"fresh_input":10,"output":5,'
+        '"cache_read":100,"cache_create":3}}', 0)
+
+
+# --------------------------------------------------------------------------- #
+# Enablement (R1, R2, R2a, R2b)
+# --------------------------------------------------------------------------- #
+
+def test_disabled_by_default(fe, tmp_path):
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+    assert fe.emit_after_flush(trends_db=str(tmp_path / "trends.db"),
+                               snapshot_dir=str(tmp_path / "snap"),
+                               config_dir=str(tmp_path / "config")) is None
+    assert not (tmp_path / "snap" / "fleet-outbox.jsonl").exists()
+    assert not (tmp_path / "snap" / "fleet-cursor.json").exists()
+
+
+def test_env_alone_never_enables(fe, tmp_path, monkeypatch):
+    monkeypatch.setenv("TO_FLEET_ENDPOINT", "http://127.0.0.1:8787")
+    monkeypatch.setenv("TO_FLEET_TOKEN", "tok")
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+
+
+def test_disable_overrides_file(fe, tmp_path, monkeypatch):
+    _write_config(tmp_path, fe)
+    monkeypatch.setenv("TO_FLEET_DISABLE", "1")
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+
+
+def test_token_env_and_hash_key_env(fe, tmp_path, monkeypatch):
+    _write_config(tmp_path, fe, token="", token_env="MY_TOK", hash_key="",
+                  hash_key_env="MY_KEY")
+    monkeypatch.setenv("MY_TOK", "tok")
+    monkeypatch.setenv("MY_KEY", HASH_KEY)
+    cfg = fe.load_config(config_dir=str(tmp_path / "config"))
+    assert cfg and cfg["token"] == "tok" and cfg["hash_key"] == HASH_KEY
+
+
+def test_incomplete_file_disabled(fe, tmp_path):
+    _write_config(tmp_path, fe, token="")
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+    _write_config(tmp_path, fe, hash_key="")
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+
+
+def test_non_loopback_http_disabled(fe, tmp_path):
+    _write_config(tmp_path, fe, endpoint="http://collector.example.com")
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+
+
+def test_loopback_http_and_https_enabled(fe, tmp_path):
+    _write_config(tmp_path, fe, endpoint="http://127.0.0.1:8787")
+    assert fe.load_config(config_dir=str(tmp_path / "config"))
+    _write_config(tmp_path, fe, endpoint="https://x.example")
+    assert fe.load_config(config_dir=str(tmp_path / "config"))
+
+
+def test_group_readable_file_ignored(fe, tmp_path):
+    _write_config(tmp_path, fe, mode=0o644)
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+
+
+def test_config_override_outside_dir_ignored(fe, tmp_path, monkeypatch):
+    evil = tmp_path / "evil.json"
+    evil.write_text(json.dumps({"endpoint": "http://127.0.0.1:9", "token": "t",
+                                "hash_key": HASH_KEY}))
+    evil.chmod(0o600)
+    monkeypatch.setenv("TO_FLEET_CONFIG", str(evil))
+    assert fe.load_config(config_dir=str(tmp_path / "config")) is None
+
+
+def test_enable_writes_0600(fe, tmp_path):
+    ok, where = fe.enable("http://127.0.0.1:8787", "tok", HASH_KEY,
+                          config_dir=str(tmp_path / "config"))
+    assert ok
+    p = Path(where)
+    assert p.stat().st_mode & 0o777 == 0o600
+    assert fe.load_config(config_dir=str(tmp_path / "config"))
+
+
+def test_no_socket_when_disabled(fe, tmp_path, monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("network attempted while disabled")
+    monkeypatch.setattr(socket.socket, "connect", boom)
+    monkeypatch.setattr(socket, "getaddrinfo", boom)
+    assert fe.emit_after_flush(trends_db=str(tmp_path / "trends.db"),
+                               snapshot_dir=str(tmp_path / "snap"),
+                               config_dir=str(tmp_path / "config")) is None
+
+
+# --------------------------------------------------------------------------- #
+# Identity (R3, R3a, KTD7)
+# --------------------------------------------------------------------------- #
+
+def test_identity_precedence(fe, tmp_path, monkeypatch):
+    env = {"TO_FLEET_USER": "env-user"}
+    cfg = {"hash_key": HASH_KEY, "user": ""}
+    assert fe.canonical_identity(cfg, env) == "env-user"
+    cfg["user"] = "file-user"
+    assert fe.canonical_identity(cfg, env) == "file-user"
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".gitconfig").write_text("[core]\nx=1\n[user]\nemail=git@x.io\n")
+    cfg["user"] = ""
+    assert fe.canonical_identity(cfg, {}, home=home) == "git@x.io"
+    assert len(fe.user_hash(cfg, env, home=home)) == 32
+
+
+def test_hash_key_changes_identity(fe, monkeypatch):
+    env = {}
+    cfg = {"hash_key": HASH_KEY, "user": "u"}
+    h1 = fe.user_hash(cfg, env)
+    h2 = fe.user_hash({"hash_key": "b" * 43, "user": "u"}, env)
+    assert h1 != h2
+
+
+# --------------------------------------------------------------------------- #
+# Payload allowlist + canary (R3, R4)
+# --------------------------------------------------------------------------- #
+
+def test_sanitize_strips_unknown_keys_and_canary(fe):
+    cfg = {"hash_key": HASH_KEY}
+    ev = {"type": "session", "session_uuid": "s1", "prompt": "CANARY-prompt",
+          "topic": "CANARY-topic", "slug": "CANARY-slug", "cost_usd": 2.5}
+    out = fe.sanitize_event(cfg, ev)
+    assert "prompt" not in out and "topic" not in out and "slug" not in out
+    assert set(out) <= fe.EVENT_KEYS | {"models_redacted"}
+    assert out["cost_usd"] == 2.5
+
+
+def test_sanitize_requires_type_and_uuid(fe):
+    cfg = {"hash_key": HASH_KEY}
+    assert fe.sanitize_event(cfg, {"type": "session"}) is None
+    assert fe.sanitize_event(cfg, {"session_uuid": "s"}) is None
+
+
+def test_model_name_redaction(fe):
+    cfg = {"hash_key": HASH_KEY}
+    out = fe.sanitize_event(cfg, {"type": "session", "session_uuid": "s",
+                                  "models": {"anthropic/claude-opus-5": {"output": 3},
+                                             "CANARY-model!": {"output": 1}}})
+    assert "claude-opus-5" in out["models"]
+    assert list(out["models"])[1].startswith("custom-")
+    assert len(out["models"][list(out["models"])[1]]) == 4
+    assert "CANARY" not in json.dumps(out)
+
+
+def test_envelope_keys_frozen(fe):
+    cfg = {"hash_key": HASH_KEY, "user": "u", "send_user_label": True}
+    payload = fe.build_payload(cfg, [{"type": "session", "session_uuid": "s"}],
+                               "5.13.4", env={},
+                               meters={"available": True, "five_hour_pct": 10,
+                                       "seven_day_pct": 20, "ts": 1},
+                               billing_mode="api", savings_method="counted_reread")
+    assert set(payload) <= fe.ENVELOPE_KEYS
+    assert payload["limit"]["five_hour_pct"] == 10
+    assert payload["user_label"] == "u"
+
+
+def test_limit_omitted_when_meter_unavailable(fe):
+    cfg = {"hash_key": HASH_KEY, "user": "u"}
+    payload = fe.build_payload(cfg, [], "v", env={}, meters=None)
+    assert "limit" not in payload
+    assert "user_label" not in payload
+
+
+def test_canary_never_reaches_post_bytes(fe, tmp_path):
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    captured = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            captured["body"] = body.decode("utf-8", "replace")
+            captured["auth"] = self.headers.get("Authorization")
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *a):
+            pass
+
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        cfg = {"hash_key": HASH_KEY, "endpoint": f"http://127.0.0.1:{srv.server_port}",
+               "token": "tok", "user": "u"}
+        ev = {"type": "session", "session_uuid": "s1", "project_hash": "CANARY-proj",
+              "models": {"m": {"output": 1}}, "quality_grade": "A"}
+        ok, status, _ = fe.post_payload(cfg, [{"id": 1, "event": ev}], "v", env={})
+        assert ok and status == 200
+        assert captured["auth"] == "Bearer tok"
+        assert "CANARY" not in captured["body"]
+        payload = json.loads(captured["body"])
+        assert payload["schema"] == "to.fleet.v1"
+        assert set(payload["events"][0]) <= fe.EVENT_KEYS
+    finally:
+        srv.shutdown()
+
+
+# --------------------------------------------------------------------------- #
+# Event building (R4a-R4c)
+# --------------------------------------------------------------------------- #
+
+def test_session_uuid_fallbacks(fe, tmp_path):
+    cfg = {"hash_key": HASH_KEY}
+    assert fe.session_uuid_for(cfg, "cafe0000-1111-2222-3333-444455556666", None) == \
+        "cafe0000-1111-2222-3333-444455556666"
+    m = fe.session_uuid_for(cfg, None, "/x/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl")
+    assert m == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    h = fe.session_uuid_for(cfg, None, "/x/opaque-path.jsonl")
+    assert h.startswith("p-") and len(h) == 32
+    assert fe.session_uuid_for(cfg, None, None) is None
+
+
+def test_cost_precedence(fe, tmp_path):
+    conn = _db(tmp_path, rows=[_ROW])
+    cfg = {"hash_key": HASH_KEY}
+    events, _mid, _w = fe.build_session_events(conn, cfg, runtime="claude")
+    assert events[0]["cost_usd"] == 1.5
+    assert events[0]["cost_source"] == "copilot_credits"
+    # no stored cost -> breakdown cost_fn
+    conn2 = _db(tmp_path, rows=[_ROW[:5] + (None, None) + _ROW[7:]], name="trends2.db")
+    events2, _m, _w = fe.build_session_events(
+        conn2, cfg, runtime="claude",
+        cost_fn=lambda b, **k: 4.25)
+    assert events2[0]["cost_usd"] == 4.25
+    conn.close()
+    conn2.close()
+
+
+def test_savings_from_counted_ledger(fe, tmp_path):
+    sid = "cafe0000-1111-2222-3333-444455556666"
+    conn = _db(tmp_path, rows=[_ROW],
+               counted=[("se:1", sid, 100, 0.5, 0.25, "2026-09-01T10:00:00")])
+    cfg = {"hash_key": HASH_KEY}
+    events, _mid, wm = fe.build_session_events(conn, cfg, runtime="claude")
+    assert events[0]["savings"] == {"tokens": 100, "cost_usd": 0.75}
+    assert events[0]["savings_coverage"] == "counted"
+    assert wm == "2026-09-01T10:00:00"
+    # non-Claude runtime: unsupported, zero savings
+    events2, _m2, _w2 = fe.build_session_events(conn, cfg, runtime="hermes")
+    assert events2[0]["savings_coverage"] == "unsupported_platform"
+    assert events2[0]["savings"]["tokens"] == 0
+    conn.close()
+
+
+def test_sidechain_and_platform_unknown(fe, tmp_path):
+    side = _ROW[:8] + (1,)
+    noplat = _ROW[:4] + (None,) + _ROW[5:]
+    conn = _db(tmp_path, rows=[side, noplat], name="trends3.db")
+    cfg = {"hash_key": HASH_KEY}
+    events, _m, _w = fe.build_session_events(conn, cfg, runtime="claude")
+    assert len(events) == 1
+    assert events[0]["platform"] == "unknown"
+    conn.close()
+
+
+def test_cursor_and_watermark_requeue(fe, tmp_path):
+    sid = "cafe0000-1111-2222-3333-444455556666"
+    conn = _db(tmp_path, rows=[_ROW],
+               counted=[("se:1", sid, 100, 0.5, 0.25, "2026-09-01T10:00:00")])
+    cfg = {"hash_key": HASH_KEY}
+    _e, mid, wm = fe.build_session_events(conn, cfg, cursor_id=0, runtime="claude")
+    # old row, past the 2-day window, but ledger moved past the watermark -> requeued
+    old = _ROW[:3] + _ROW[3:]
+    conn.execute("UPDATE session_log SET date='2026-08-01'")
+    conn.execute("UPDATE counted_reread SET computed_at='2026-09-02T00:00:00'")
+    conn.commit()
+    events, _m, _w = fe.build_session_events(conn, cfg, cursor_id=mid, watermark=wm,
+                                             runtime="claude",
+                                             now=datetime(2026, 9, 2))
+    assert any(e["session_uuid"] == sid for e in events)
+    conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Outbox + cursor + drain (R6, R6a, R6c)
+# --------------------------------------------------------------------------- #
+
+def test_enqueue_dedup_and_caps(fe, tmp_path):
+    snap = str(tmp_path / "snap")
+    now = datetime.utcnow()
+    old = (now - timedelta(days=8)).isoformat()
+    fe.enqueue(snap, [{"type": "session", "session_uuid": "s1", "cost_usd": 1}], now=now)
+    fe.enqueue(snap, [{"type": "session", "session_uuid": "s1", "cost_usd": 2}], now=now)
+    items = fe.read_outbox(snap)
+    assert len(items) == 1 and items[0]["event"]["cost_usd"] == 2
+    rec = {"queued_at": old, "id": 1,
+           "event": {"type": "session", "session_uuid": "old"}}
+    fe.write_outbox(snap, items + [rec])
+    fe.enqueue(snap, [], now=now)
+    assert all(r["event"]["session_uuid"] != "old" for r in fe.read_outbox(snap))
+
+
+def test_cursor_advances_only_on_ack(fe, tmp_path):
+    snap = str(tmp_path / "snap")
+    cfg = {"hash_key": HASH_KEY, "endpoint": "http://127.0.0.1:9", "token": "t"}
+    events = [{"type": "session", "session_uuid": f"s{i}", "_src_id": i}
+              for i in range(1, 4)]
+    ids = {e["session_uuid"]: e.pop("_src_id") for e in events}
+    fe.enqueue(snap, events, source_ids=ids)
+    calls = {"n": 0}
+
+    def flaky_post(c, records, version, **kw):
+        calls["n"] += 1
+        return (calls["n"] > 1), (200 if calls["n"] > 1 else 500), ""
+
+    stats = fe.drain_outbox(snap, cfg, "v", post=flaky_post, max_posts=2)
+    assert stats["failed"] == 1
+    last_id, _ = fe.read_state(snap)
+    assert last_id == 0  # nothing acked yet
+    stats = fe.drain_outbox(snap, cfg, "v", post=flaky_post, max_posts=2)
+    assert stats["sent"] == 3 and stats["remaining"] == 0
+    last_id, _ = fe.read_state(snap)
+    assert last_id == 3
+
+
+def test_two_posts_per_flush_max(fe, tmp_path):
+    snap = str(tmp_path / "snap")
+    cfg = {"hash_key": HASH_KEY, "endpoint": "http://127.0.0.1:9", "token": "t"}
+    events = [{"type": "session", "session_uuid": f"s{i}"} for i in range(500)]
+    fe.enqueue(snap, events)
+    calls = {"n": 0}
+
+    def post(c, records, version, **kw):
+        calls["n"] += 1
+        return True, 200, ""
+
+    stats = fe.drain_outbox(snap, cfg, "v", post=post)
+    assert calls["n"] == 2 and stats["remaining"] == 100
+
+
+def test_redirect_is_failure(fe, tmp_path):
+    snap = str(tmp_path / "snap")
+    cfg = {"hash_key": HASH_KEY, "endpoint": "http://127.0.0.1:9", "token": "t"}
+    fe.enqueue(snap, [{"type": "session", "session_uuid": "s1"}])
+
+    def redirect_post(c, records, version, **kw):
+        return False, 302, "HTTPError"
+
+    stats = fe.drain_outbox(snap, cfg, "v", post=redirect_post)
+    assert stats["sent"] == 0 and len(fe.read_outbox(snap)) == 1
+
+
+def test_post_to_closed_port_fails_fast(fe):
+    cfg = {"hash_key": HASH_KEY, "endpoint": "http://127.0.0.1:1", "token": "t"}
+    ok, status, detail = fe.post_payload(
+        cfg, [{"event": {"type": "session", "session_uuid": "s"}}], "v")
+    assert ok is False and status == 0
+
+
+def test_atomic_writes_and_dir_mode_gate(fe, tmp_path):
+    snap = str(tmp_path / "snap")
+    fe._write_private(Path(snap) / "f.json", "x")
+    assert (Path(snap) / "f.json").stat().st_mode & 0o777 == 0o600
+    (tmp_path / "ro").mkdir()
+    os.chmod(str(tmp_path / "ro"), 0o777)
+    assert fe.snapshot_dir_ok(str(tmp_path / "ro")) is False
+    os.chmod(str(tmp_path / "ro"), 0o755)
+    assert fe.snapshot_dir_ok(str(tmp_path / "ro")) is True
+
+
+def test_stale_tmp_reaped(fe, tmp_path):
+    snap = tmp_path / "snap"
+    stale = snap / "fleet-outbox.jsonl.1.tmp"
+    stale.write_text("junk")
+    old = (datetime.now().timestamp()) - 3600
+    os.utime(str(stale), (old, old))
+    fe.reap_stale_tmp(str(snap))
+    assert not stale.exists()
+
+
+def test_time_left_below_threshold_skips_network(fe, tmp_path):
+    snap = str(tmp_path / "snap")
+    cfg = {"hash_key": HASH_KEY, "endpoint": "http://127.0.0.1:9", "token": "t"}
+    fe.enqueue(snap, [{"type": "session", "session_uuid": "s1"}])
+    stats = fe.drain_outbox(snap, cfg, "v", post=lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("no POST under budget")), max_posts=0)
+    assert stats["posts"] == 0 and len(fe.read_outbox(snap)) == 1
+
+
+def test_emit_fail_open_on_db_error(fe, tmp_path):
+    _write_config(tmp_path, fe)
+    stats = fe.emit_after_flush(trends_db=str(tmp_path / "nonexistent-dir" / "x.db"),
+                                snapshot_dir=str(tmp_path / "snap"),
+                                config_dir=str(tmp_path / "config"))
+    assert stats is None  # fail-open, never raises

--- a/tests/test_fleet_emitter_wiring.py
+++ b/tests/test_fleet_emitter_wiring.py
@@ -1,0 +1,163 @@
+"""Wiring: the session-end flush worker emits only when an admin-enabled
+fleet.json is present, and the local dashboard shows the telemetry banner.
+
+Run: python3 -m pytest tests/test_fleet_emitter_wiring.py -v
+"""
+import importlib
+import json
+import os
+import socket
+import sqlite3
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "skills" / "token-optimizer" / "scripts"
+HASH_KEY = "c" * 43
+
+
+@pytest.fixture()
+def m(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", str(tmp_path / "snap"))
+    monkeypatch.setenv("TOKEN_OPTIMIZER_CONFIG_DIR", str(tmp_path / "config"))
+    (tmp_path / "snap").mkdir()
+    (tmp_path / "config").mkdir()
+    for var in ("TO_FLEET_ENDPOINT", "TO_FLEET_TOKEN", "TO_FLEET_DISABLE",
+                "TO_FLEET_CONFIG"):
+        monkeypatch.delenv(var, raising=False)
+    sys.path.insert(0, str(SCRIPTS))
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    importlib.reload(mod)
+    mod.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(mod, "CLAUDE_DIR", tmp_path / "claude")
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+def _seed_trends(m, sid="cafe0000-1111-2222-3333-444455556666"):
+    conn = sqlite3.connect(str(m.TRENDS_DB))
+    conn.execute("""CREATE TABLE IF NOT EXISTS session_log (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, jsonl_path TEXT, date TEXT, project TEXT,
+        duration_minutes REAL, input_tokens INTEGER, output_tokens INTEGER,
+        message_count INTEGER, api_calls INTEGER, cache_create_1h_tokens INTEGER DEFAULT 0,
+        cache_create_5m_tokens INTEGER DEFAULT 0, model_usage_json TEXT,
+        model_usage_breakdown_json TEXT, collected_at TEXT, quality_score REAL,
+        quality_grade TEXT, session_uuid TEXT, is_sidechain INTEGER DEFAULT 0,
+        reported_input_tokens INTEGER, reported_output_tokens INTEGER, platform TEXT,
+        cost_usd REAL, cost_source TEXT)""")
+    conn.execute("""CREATE TABLE IF NOT EXISTS counted_reread (
+        event_key TEXT PRIMARY KEY, source TEXT, session_uuid TEXT, event_ts TEXT,
+        event_month TEXT, tokens INTEGER DEFAULT 0, oneshot_usd REAL DEFAULT 0,
+        reread_tokens INTEGER DEFAULT 0, reread_usd REAL DEFAULT 0,
+        turns_counted INTEGER DEFAULT 0, transcript_mtime REAL, computed_at TEXT)""")
+    conn.execute(
+        "INSERT INTO session_log (jsonl_path, date, project, session_uuid, platform,"
+        " cost_usd, cost_source) VALUES ('p/x.jsonl', '2026-09-01', 'proj', ?,"
+        " 'claude', 1.5, 'copilot_credits')", (sid,))
+    conn.execute(
+        "INSERT INTO counted_reread (event_key, session_uuid, tokens, oneshot_usd,"
+        " reread_usd, computed_at) VALUES ('se:1', ?, 100, 0.5, 0.25,"
+        " '2026-09-01T10:00:00')", (sid,))
+    conn.commit()
+    conn.close()
+
+
+def _enable(m, endpoint):
+    (m.CONFIG_DIR / "fleet.json").write_text(json.dumps(
+        {"endpoint": endpoint, "token": "tok", "hash_key": HASH_KEY}))
+    os.chmod(str(m.CONFIG_DIR / "fleet.json"), 0o600)
+
+
+def test_worker_without_config_makes_no_network(m, monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("network attempted while disabled")
+    monkeypatch.setattr(socket.socket, "connect", boom)
+    monkeypatch.setattr(socket, "getaddrinfo", boom)
+    m._run_session_end_flush_worker([])
+    snap = m.SNAPSHOT_DIR
+    assert not (snap / "fleet-outbox.jsonl").exists()
+    assert not (snap / "fleet-cursor.json").exists()
+    assert not (snap / "fleet.log").exists()
+
+
+def test_worker_posts_when_enabled(m):
+    captured = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+            captured["body"] = json.loads(body)
+            captured["auth"] = self.headers.get("Authorization")
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *a):
+            pass
+
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        _seed_trends(m)
+        _enable(m, f"http://127.0.0.1:{srv.server_port}")
+        m._run_session_end_flush_worker([])
+        assert captured["auth"] == "Bearer tok"
+        assert captured["body"]["schema"] == "to.fleet.v1"
+        assert captured["body"]["events"][0]["session_uuid"].startswith("cafe")
+        assert (m.SNAPSHOT_DIR / "fleet-cursor.json").exists()
+        assert json.loads((m.SNAPSHOT_DIR / "fleet-cursor.json").read_text())["last_id"] == 1
+    finally:
+        srv.shutdown()
+
+
+def test_worker_fail_open_when_collector_down(m):
+    _seed_trends(m)
+    _enable(m, "http://127.0.0.1:1")  # closed port
+    m._run_session_end_flush_worker([])  # must not raise
+    assert (m.SNAPSHOT_DIR / "fleet-outbox.jsonl").exists()
+    assert (m.SNAPSHOT_DIR / "fleet.log").exists()
+    outbox = (m.SNAPSHOT_DIR / "fleet-outbox.jsonl").read_text()
+    assert "cafe0000" in outbox
+
+
+def test_worker_survives_emitter_crash_and_releases_lock(m, monkeypatch):
+    import fleet_emitter
+    def boom(*a, **k):
+        raise RuntimeError("emitter exploded")
+    monkeypatch.setattr(fleet_emitter, "emit_after_flush", boom)
+    _enable(m, "http://127.0.0.1:1")
+    m._run_session_end_flush_worker([])
+    assert m._acquire_session_end_flush_lock() is not None  # lock was released
+    m._release_session_end_flush_lock(m._acquire_session_end_flush_lock())
+
+
+def test_dashboard_banner_data(m):
+    _enable(m, "http://127.0.0.1:8787")
+    # load_config through measure's CONFIG_DIR
+    import fleet_emitter
+    cfg = fleet_emitter.load_config(config_dir=str(m.CONFIG_DIR))
+    assert cfg and cfg["endpoint"] == "http://127.0.0.1:8787"
+    template = (SCRIPTS.parent / "assets" / "dashboard.html").read_text()
+    assert 'id="fleet-telemetry-banner"' in template
+    assert "window.__TOKEN_DATA__ = null;" in template
+
+
+def test_fleet_billing_mode_rungs(m, monkeypatch, tmp_path):
+    # Rung 1: env api key -> api
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+    assert m.fleet_billing_mode() == "api"
+    monkeypatch.delenv("ANTHROPIC_API_KEY")
+    # Rung 4: nothing detectable -> unknown (never subscription)
+    empty = tmp_path / "empty.json"
+    empty.write_text("{}")
+    assert m.fleet_billing_mode(claude_json_path=empty, settings_path=empty) == "unknown"
+    # Rung 2: oauth account marker -> subscription
+    oauth = tmp_path / "claude.json"
+    oauth.write_text(json.dumps({"oauthAccount": {"emailAddress": "x@y.z"}}))
+    assert m.fleet_billing_mode(claude_json_path=oauth, settings_path=empty) == \
+        "subscription"

--- a/tests/test_teams_telemetry_docs.py
+++ b/tests/test_teams_telemetry_docs.py
@@ -1,0 +1,60 @@
+"""Docs claims: every absolute zero-network claim is qualified now that the
+Teams edition adds an admin-enabled telemetry channel.
+
+Run: python3 -m pytest tests/test_teams_telemetry_docs.py -v
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+ABSOLUTE_PHRASES = [
+    "nothing leaves",
+    "zero network",
+    "No data is transmitted",
+    "never leaves the machine",
+    "telemetry-none",
+]
+
+QUALIFIER_CONTEXT = ("admin", "fleet", "by default", "Teams", "default")
+
+
+def _qualified(text, idx, phrase_len):
+    window = text[max(0, idx - 200):idx + phrase_len + 200].lower()
+    return any(q.lower() in window for q in QUALIFIER_CONTEXT)
+
+
+def test_no_unqualified_absolute_claims():
+    offenders = []
+    for pattern in ("*.md", "*.mdx"):
+        for path in ROOT.rglob(pattern):
+            s = str(path)
+            if any(x in s for x in (".sprint-scratch", "node_modules", ".git/",
+                                    "sessions/")):
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for phrase in ABSOLUTE_PHRASES:
+                for m in re.finditer(re.escape(phrase), text):
+                    if not _qualified(text, m.start(), len(phrase)):
+                        offenders.append(f"{path}:{text[:m.start()].count(chr(10)) + 1}: {phrase}")
+    assert not offenders, "unqualified absolute claims:\n" + "\n".join(offenders)
+
+
+def test_privacy_md_names_the_mechanics():
+    text = (ROOT / "PRIVACY.md").read_text(encoding="utf-8")
+    for needle in ("fleet.json", "hash_key", "TO_FLEET_DISABLE", "--dry-run",
+                   "user_label", "billing_mode"):
+        assert needle in text, needle
+
+
+def test_gitignore_lists_fleet_files():
+    text = (ROOT / ".gitignore").read_text(encoding="utf-8")
+    for needle in ("fleet.json", "fleet-outbox.jsonl", "fleet-cursor.json", "fleet.log"):
+        assert needle in text, needle
+
+
+def test_teams_doc_exists_and_covers_admin_flow():
+    text = (ROOT / "docs" / "teams-telemetry.md").read_text(encoding="utf-8")
+    for needle in ("--enable", "add-org", "serve", "OTEL", "rotate-token",
+                   "user-level", "dashboard"):
+        assert needle in text, needle


### PR DESCRIPTION
## Summary
- Adds `skills/token-optimizer/scripts/fleet_emitter.py`: an admin-enabled org telemetry emitter for the Teams edition. OFF by default and file-only: nothing is emitted unless a 0600 `fleet.json` (endpoint + ingest token + per-org hash_key) exists in the config dir; env vars alone never enable; `TO_FLEET_DISABLE=1` overrides.
- Payload is allowlisted on keys AND values: per-session aggregates only (platform, HMAC-pseudonymous ids, token counts, model split, cost + cost_source, counted savings + coverage, one limit-meter reading, billing mode). Never prompts, content, paths, or command text.
- Delivery is bounded and fail-open: atomic 0600 outbox, ack-advanced cursor, savings watermark, at most two 3s no-redirect POSTs per session-end flush, network step skipped under 7s of budget.
- Wired into the session-end flush worker tail (outside refresh exception paths) and surfaced via a local-dashboard banner + `fleet_emitter.py --status` / `--dry-run`.
- Docs: PRIVACY.md Teams section, README badge + compare row qualified, SECURITY.md, docs-site claims, `docs/teams-telemetry.md` admin guide (incl. Windows fail-closed note), `.gitignore` fleet files. Mirrors regenerated.

## Test plan
- [x] tests/test_fleet_emitter.py (33): off-by-default, env-never-enables, mode/override checks, canary never in POST bytes/outbox, allowlist, cursor-on-ack, redirect-failure, closed-port fail-fast
- [x] tests/test_fleet_emitter_wiring.py (6): no socket when disabled, real POST when enabled, fail-open collector-down, emitter crash survivable, banner, billing rungs
- [x] tests/test_teams_telemetry_docs.py: repo-wide grep for unqualified absolute claims
- [x] Mirror parity tests green after regeneration
- [x] Full suite: 2385 passed, 17 skipped, 1 pre-existing thread-timing flake (passes 4/5 in isolation, unrelated files)

Draft pending product wording decision on the README Teams-edition naming.

Generated with [Devin](https://devin.ai)