### PR TITLE
feat(core): optional local post-flush extension loader

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -118,6 +118,8 @@ Manual deletion: remove the following directories:
 
 ## Cross-Platform
 
+Locally installed extensions (see `docs/local-extensions.md`) may run inside the session-end flush worker; Token Optimizer ships none by default.
+
 The same privacy guarantees apply across all supported platforms (Claude Code, Codex, OpenCode, Hermes). Data paths vary by platform but the architecture is identical: local-only, zero network, credential-redacted storage.
 
 Consent is tracked per-runtime. A user running both Claude Code and Codex must acknowledge consent separately in each runtime.

--- a/cowork/token-optimizer/PRIVACY.md
+++ b/cowork/token-optimizer/PRIVACY.md
@@ -118,6 +118,8 @@ Manual deletion: remove the following directories:
 
 ## Cross-Platform
 
+Locally installed extensions (see `docs/local-extensions.md`) may run inside the session-end flush worker; Token Optimizer ships none by default.
+
 The same privacy guarantees apply across all supported platforms (Claude Code, Codex, OpenCode, Hermes). Data paths vary by platform but the architecture is identical: local-only, zero network, credential-redacted storage.
 
 Consent is tracked per-runtime. A user running both Claude Code and Codex must acknowledge consent separately in each runtime.

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6827,9 +6827,64 @@ def _run_session_end_flush_worker(args):
                 pass
     except _HookTimeout:
         pass
+    # Optional local post-flush extensions (admin-placed, OFF by default).
+    # See _run_post_flush_extensions: nothing is loaded unless the file exists,
+    # every failure is swallowed, and extensions get the remaining flush budget.
+    try:
+        _run_post_flush_extensions(
+            time_left_fn=old_budget.remaining,
+            version=TOKEN_OPTIMIZER_VERSION)
+    except Exception:
+        pass
     finally:
         _clear_hook_budget(old_budget)
         _release_session_end_flush_lock(lock_dir)
+
+
+def _run_post_flush_extensions(time_left_fn=None, version="unknown"):
+    """Load and run an optional local extension after the flush work.
+
+    A user or admin may place a single file at
+    ``<CONFIG_DIR>/extensions/post_flush.py`` defining ``run(context)``. It is
+    OFF by default: with no file present this function does nothing (no import,
+    no I/O beyond one existence check). The file is loaded ONLY from that exact
+    path — never from the repo, the snapshot dir, or an env override — and only
+    when it is not group/world-writable (a writable extension file would be
+    local code injection). Everything is fail-open: any exception the extension
+    raises (or the load itself) is swallowed; the hook always completes. The
+    extension receives the remaining flush budget via ``context["time_left_fn"]``
+    and should defer work that does not fit; the watchdog may hard-exit the
+    worker when the budget expires.
+
+    context keys: trends_db, snapshot_dir, config_dir, runtime, version,
+    time_left_fn. Token Optimizer ships no extensions and takes no
+    responsibility for third-party ones; they run with the user's privileges.
+    """
+    ext_path = CONFIG_DIR / "extensions" / "post_flush.py"
+    try:
+        if not ext_path.is_file():
+            return None
+        st = ext_path.stat()
+        if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return None
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_to_post_flush_ext", str(ext_path))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        run = getattr(module, "run", None)
+        if not callable(run):
+            return None
+        context = {
+            "trends_db": TRENDS_DB,
+            "snapshot_dir": SNAPSHOT_DIR,
+            "config_dir": CONFIG_DIR,
+            "runtime": detect_runtime(),
+            "version": version,
+            "time_left_fn": time_left_fn,
+        }
+        return run(context)
+    except Exception:
+        return None
 
 
 def _defer_session_end_flush(args):

--- a/docs/local-extensions.md
+++ b/docs/local-extensions.md
@@ -1,0 +1,37 @@
+# Local extensions (post-flush hook)
+
+Token Optimizer's session-end flush worker can run one optional **local
+extension** after its own work completes. This is a power-user/admin feature:
+Token Optimizer ships no extensions, runs none by default, and takes no
+responsibility for third-party ones.
+
+## How it works
+
+- Location: a single file at `<config dir>/extensions/post_flush.py`
+  (e.g. `~/.claude/token-optimizer/extensions/post_flush.py` on Claude Code).
+- Off by default: with no file present, nothing is loaded and nothing runs.
+- Contract: the file defines `run(context)`. `context` is a dict with:
+  - `trends_db` — path to the local `trends.db`
+  - `snapshot_dir` — the local snapshot dir
+  - `config_dir` — the config dir
+  - `runtime` — detected runtime name
+  - `version` — Token Optimizer version
+  - `time_left_fn` — callable returning seconds left in the flush budget;
+    defer work that does not fit, the worker may be hard-exited at 20s.
+- Fail-open: any exception the extension raises is swallowed; the hook always
+  completes and the flush lock is always released.
+- Safety: the file is loaded only from that exact path (never from the repo,
+  the snapshot dir, or an environment override) and only when it is not
+  group/world-writable. Extensions run with your user's privileges — only
+  install code you trust.
+
+## Example
+
+```python
+# extensions/post_flush.py
+def run(context):
+    left = context["time_left_fn"]()
+    if left < 5:
+        return  # not enough budget; do it next flush
+    # ... your local post-flush work ...
+```

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -6827,9 +6827,64 @@ def _run_session_end_flush_worker(args):
                 pass
     except _HookTimeout:
         pass
+    # Optional local post-flush extensions (admin-placed, OFF by default).
+    # See _run_post_flush_extensions: nothing is loaded unless the file exists,
+    # every failure is swallowed, and extensions get the remaining flush budget.
+    try:
+        _run_post_flush_extensions(
+            time_left_fn=old_budget.remaining,
+            version=TOKEN_OPTIMIZER_VERSION)
+    except Exception:
+        pass
     finally:
         _clear_hook_budget(old_budget)
         _release_session_end_flush_lock(lock_dir)
+
+
+def _run_post_flush_extensions(time_left_fn=None, version="unknown"):
+    """Load and run an optional local extension after the flush work.
+
+    A user or admin may place a single file at
+    ``<CONFIG_DIR>/extensions/post_flush.py`` defining ``run(context)``. It is
+    OFF by default: with no file present this function does nothing (no import,
+    no I/O beyond one existence check). The file is loaded ONLY from that exact
+    path — never from the repo, the snapshot dir, or an env override — and only
+    when it is not group/world-writable (a writable extension file would be
+    local code injection). Everything is fail-open: any exception the extension
+    raises (or the load itself) is swallowed; the hook always completes. The
+    extension receives the remaining flush budget via ``context["time_left_fn"]``
+    and should defer work that does not fit; the watchdog may hard-exit the
+    worker when the budget expires.
+
+    context keys: trends_db, snapshot_dir, config_dir, runtime, version,
+    time_left_fn. Token Optimizer ships no extensions and takes no
+    responsibility for third-party ones; they run with the user's privileges.
+    """
+    ext_path = CONFIG_DIR / "extensions" / "post_flush.py"
+    try:
+        if not ext_path.is_file():
+            return None
+        st = ext_path.stat()
+        if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return None
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_to_post_flush_ext", str(ext_path))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        run = getattr(module, "run", None)
+        if not callable(run):
+            return None
+        context = {
+            "trends_db": TRENDS_DB,
+            "snapshot_dir": SNAPSHOT_DIR,
+            "config_dir": CONFIG_DIR,
+            "runtime": detect_runtime(),
+            "version": version,
+            "time_left_fn": time_left_fn,
+        }
+        return run(context)
+    except Exception:
+        return None
 
 
 def _defer_session_end_flush(args):

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -6827,9 +6827,64 @@ def _run_session_end_flush_worker(args):
                 pass
     except _HookTimeout:
         pass
+    # Optional local post-flush extensions (admin-placed, OFF by default).
+    # See _run_post_flush_extensions: nothing is loaded unless the file exists,
+    # every failure is swallowed, and extensions get the remaining flush budget.
+    try:
+        _run_post_flush_extensions(
+            time_left_fn=old_budget.remaining,
+            version=TOKEN_OPTIMIZER_VERSION)
+    except Exception:
+        pass
     finally:
         _clear_hook_budget(old_budget)
         _release_session_end_flush_lock(lock_dir)
+
+
+def _run_post_flush_extensions(time_left_fn=None, version="unknown"):
+    """Load and run an optional local extension after the flush work.
+
+    A user or admin may place a single file at
+    ``<CONFIG_DIR>/extensions/post_flush.py`` defining ``run(context)``. It is
+    OFF by default: with no file present this function does nothing (no import,
+    no I/O beyond one existence check). The file is loaded ONLY from that exact
+    path — never from the repo, the snapshot dir, or an env override — and only
+    when it is not group/world-writable (a writable extension file would be
+    local code injection). Everything is fail-open: any exception the extension
+    raises (or the load itself) is swallowed; the hook always completes. The
+    extension receives the remaining flush budget via ``context["time_left_fn"]``
+    and should defer work that does not fit; the watchdog may hard-exit the
+    worker when the budget expires.
+
+    context keys: trends_db, snapshot_dir, config_dir, runtime, version,
+    time_left_fn. Token Optimizer ships no extensions and takes no
+    responsibility for third-party ones; they run with the user's privileges.
+    """
+    ext_path = CONFIG_DIR / "extensions" / "post_flush.py"
+    try:
+        if not ext_path.is_file():
+            return None
+        st = ext_path.stat()
+        if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return None
+        import importlib.util
+        spec = importlib.util.spec_from_file_location("_to_post_flush_ext", str(ext_path))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        run = getattr(module, "run", None)
+        if not callable(run):
+            return None
+        context = {
+            "trends_db": TRENDS_DB,
+            "snapshot_dir": SNAPSHOT_DIR,
+            "config_dir": CONFIG_DIR,
+            "runtime": detect_runtime(),
+            "version": version,
+            "time_left_fn": time_left_fn,
+        }
+        return run(context)
+    except Exception:
+        return None
 
 
 def _defer_session_end_flush(args):

--- a/tests/test_post_flush_extensions.py
+++ b/tests/test_post_flush_extensions.py
@@ -1,0 +1,110 @@
+"""Post-flush extension loader: off by default, config-dir-only, fail-open,
+budget passed through.
+
+Run: python3 -m pytest tests/test_post_flush_extensions.py -v
+"""
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "skills" / "token-optimizer" / "scripts"
+
+
+@pytest.fixture()
+def m(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOKEN_OPTIMIZER_SNAPSHOT_DIR", str(tmp_path / "snap"))
+    monkeypatch.setenv("TOKEN_OPTIMIZER_CONFIG_DIR", str(tmp_path / "config"))
+    (tmp_path / "snap").mkdir()
+    sys.path.insert(0, str(SCRIPTS))
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+    mod = importlib.import_module("measure")
+    importlib.reload(mod)
+    mod.CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(mod, "CLAUDE_DIR", tmp_path / "claude")
+    yield mod
+    if "measure" in sys.modules:
+        del sys.modules["measure"]
+
+
+def _install_ext(m, body):
+    ext_dir = m.CONFIG_DIR / "extensions"
+    ext_dir.mkdir(exist_ok=True)
+    p = ext_dir / "post_flush.py"
+    p.write_text(body)
+    os.chmod(str(p), 0o600)
+    return p
+
+
+def test_off_by_default_no_io(m, monkeypatch):
+    calls = []
+
+    def boom(*a, **k):
+        calls.append(1)
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr("builtins.open", boom)
+    assert m._run_post_flush_extensions(time_left_fn=lambda: 10) is None
+    assert not calls
+
+
+def test_loads_only_from_config_dir(m, tmp_path, monkeypatch):
+    _install_ext(m, "def run(ctx):\n    return 'ran'\n")
+    # a decoy elsewhere must be ignored (no env override exists)
+    decoy = tmp_path / "decoy" / "post_flush.py"
+    decoy.parent.mkdir()
+    decoy.write_text("def run(ctx):\n    raise AssertionError('decoy ran')")
+    monkeypatch.setenv("TO_EXTENSIONS_DIR", str(decoy.parent))  # not honoured
+    out = m._run_post_flush_extensions(time_left_fn=lambda: 10)
+    assert out == "ran"
+
+
+def test_context_keys(m):
+    body = (
+        "def run(ctx):\n"
+        "    assert set(ctx) >= {'trends_db', 'snapshot_dir', 'config_dir',"
+        " 'runtime', 'version', 'time_left_fn'}\n"
+        "    return ctx['time_left_fn']()\n")
+    _install_ext(m, body)
+    assert m._run_post_flush_extensions(time_left_fn=lambda: 7, version="5.13.4") == 7
+
+
+def test_fail_open_on_extension_exception(m):
+    _install_ext(m, "def run(ctx):\n    raise RuntimeError('exploded')\n")
+    assert m._run_post_flush_extensions(time_left_fn=lambda: 10) is None
+
+
+def test_fail_open_on_broken_module(m):
+    _install_ext(m, "this is not python (((\n")
+    assert m._run_post_flush_extensions(time_left_fn=lambda: 10) is None
+
+
+def test_fail_open_on_missing_run(m):
+    _install_ext(m, "x = 1\n")
+    assert m._run_post_flush_extensions(time_left_fn=lambda: 10) is None
+
+
+def test_world_writable_extension_ignored(m):
+    p = _install_ext(m, "def run(ctx):\n    return 'ran'\n")
+    os.chmod(str(p), 0o666)
+    assert m._run_post_flush_extensions(time_left_fn=lambda: 10) is None
+
+
+def test_worker_completes_and_releases_lock_with_extension(m, monkeypatch):
+    _install_ext(m, "def run(ctx):\n    raise RuntimeError('boom')\n")
+    m._run_session_end_flush_worker([])
+    assert m._acquire_session_end_flush_lock() is not None  # lock released
+    m._release_session_end_flush_lock(m._acquire_session_end_flush_lock())
+
+
+def test_worker_runs_extension_after_flush(m):
+    _install_ext(m, "def run(ctx):\n"
+                    "    import json, pathlib\n"
+                    "    p = pathlib.Path(ctx['snapshot_dir']) / 'ext-marker'\n"
+                    "    p.write_text(ctx['version'])\n"
+                    "    return True\n")
+    m._run_session_end_flush_worker([])
+    assert (m.SNAPSHOT_DIR / "ext-marker").read_text() == m.TOKEN_OPTIMIZER_VERSION


### PR DESCRIPTION
## Summary
- The session-end flush worker can now run one optional local extension: `<config dir>/extensions/post_flush.py` defining `run(context)`.
- OFF by default (no file, no load, no I/O beyond one existence check); loaded ONLY from that exact config-dir path (no env override, no repo/snapshot paths); group/world-writable files are ignored (local code injection guard).
- Fail-open end to end: extension exceptions, broken modules, missing `run` — all swallowed; the hook always completes and the flush lock is always released.
- Budgeted: the extension receives `context["time_left_fn"]` (seconds left in the flush budget) and is documented to defer work that does not fit; the existing 20s watchdog still governs.
- Neutral docs: `docs/local-extensions.md` + one sentence in PRIVACY.md. Token Optimizer ships no extensions.

## Test plan
- [x] tests/test_post_flush_extensions.py (9): off by default (no open() calls), config-dir-only (decoy + env override ignored), context keys, fail-open on exception/broken module/missing run, world-writable ignored, worker completes + releases lock, worker runs extension after flush
- [x] Mirror parity tests green after regeneration (67 passed across the parity suites)
- [x] scripts/check_docs_claims.py + check_readme_integrity.py green
- [ ] Full suite re-run at merge time (Track A sequences the merge)