### PR TITLE
fix: refresh growing sessions and restore full weekly savings (5.13.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "token-optimizer",
       "source": "./",
       "description": "Audit, fix, and monitor Claude Code context window usage. Find the ghost tokens.",
-      "version": "5.13.8",
+      "version": "5.13.9",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"
@@ -55,7 +55,7 @@
       "name": "token-optimizer-cowork",
       "source": "./cowork/token-optimizer",
       "description": "Token Optimizer for Claude Cowork \u2014 full skills + Cowork-native hooks (beta). Install THIS in Cowork; the standard token-optimizer entry is for desktop Claude Code.",
-      "version": "5.13.8",
+      "version": "5.13.9",
       "author": {
         "name": "Alex Greenshpun",
         "url": "https://linkedin.com/in/alexgreensh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.13.8",
+  "version": "5.13.9",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.13.8",
+  "version": "5.13.9",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,9 @@
 - Fix: SessionStart no longer adds anything to the model's context. Startup diagnostics (health checks, dashboard setup, daemon status) now write to a local log file instead of stdout/stderr, both of which the host captures into the session context. Sessions begin at their true baseline, so the token savings start on the first turn.
 - Add: burn nudge. When the same command fails 3 times in a row with different output, a nudge suggests changing approach instead of re-running. Catches the edit-compile-fail cycle that the existing identical-output streak guard cannot see. Tunable with `TOKEN_OPTIMIZER_FAIL_STREAK_THRESHOLD` (default `3`).
 - Add: inline-script repeat nudge. When a command with a heredoc body >= 300 chars has been run 8 times in a session, a nudge suggests saving the script to a file and running that instead, so the body is not re-sent as input tokens every turn. Tunable with `TOKEN_OPTIMIZER_INLINE_SCRIPT_THRESHOLD` (default `8`).
+
+## [5.13.9] - 2026-09-08
+
+- Fix growing session logs being skipped after their first collection. Refresh parent and child activity without duplicating totals or overwriting newer collector results.
+- Show the full Savings-tab estimate for the actual subscription week, counting overlapping savings once and labeling the amount as estimated savings accrued so far. Include new sessions before background collection catches up.
+- Recover the workload comparison after history backfill or rebuild changes its baseline month. Cache weekly results for up to 60 seconds and retain weekly dollars when quota readings are unavailable.

--- a/cowork/token-optimizer/.claude-plugin/plugin.json
+++ b/cowork/token-optimizer/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/alexgreensh/token-optimizer",
   "repository": "https://github.com/alexgreensh/token-optimizer",
-  "version": "5.13.8",
+  "version": "5.13.9",
   "license": "PolyForm-Noncommercial-1.0.0",
   "keywords": [
     "token",

--- a/cowork/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/cowork/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -4083,6 +4083,16 @@ var DB = (function() {
           '</div>' +
         '</div>';
       }).join('');
+      // Savings remain available when the quota meter has no weekly reading.
+      var standaloneWeek = rw.weekly_full_value;
+      if (standaloneWeek && Number(standaloneWeek.saved_usd) >= 15 &&
+          !(rw.windows || []).some(function (w) { return w.key === 'seven_day'; })) {
+        rwCards += '<div style="padding:var(--s-3);border:1px solid var(--c-border);border-radius:8px;">' +
+          '<div class="label">Weekly savings</div><div style="font-size:22px;color:var(--c-savings-alt,#10b981);">&asymp;' +
+          rwMoney(standaloneWeek.saved_usd) + ' estimated savings so far this week</div>' +
+          '<p>Full workload estimate since ' + esc(new Date(standaloneWeek.start).toLocaleString()) +
+          '. Your weekly limit reading is unavailable.</p></div>';
+      }
       // USD-per-window headline: the dollar figure reuses the metered
       // savings ledger, apportioned to each window's span. Build the headline
       // from the windows that carry a saved_usd; fall back to the demoted

--- a/cowork/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/cowork/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -4011,7 +4011,7 @@ var DB = (function() {
     // unavailable meter used to vanish the whole card). runway_snapshot already
     // returns null when there is genuinely no story, so rw existing + a windows-
     // or-multiplier payload is the real render condition.
-    if (rw && (rwHasWindows || rwHasMultiplier)) {
+    if (rw && (rwHasWindows || rwHasMultiplier || rw.weekly_full_value)) {
       // Both sides are stated in the SAME unit (percent LEFT). An earlier revision
       // paired "89% left" against "16.6% used", which reads as a contradiction and
       // forces the reader to do the subtraction. The with/without pair is also the
@@ -4045,38 +4045,19 @@ var DB = (function() {
         // ledger has nothing to show; degrade to no line rather than $-0/NaN.
         var savedUsd = Number(w.saved_usd);
         var spanWord = w.key === 'five_hour' ? '5h' : 'week';
-        // Weekly $: shown whenever it is meaningful (>= $15) and NEVER gated on
-        // already being capped — at that size it is the overage you are on
-        // track to hit, not a hypothetical. Below $15 the line is noise: hide.
-        // The 5h window keeps the any-positive rule (its $ is already rare).
         var hasUsd = isFinite(savedUsd) && (w.key === 'five_hour' ? savedUsd > 0 : savedUsd >= 15);
-        // The per-window USD is the EXTRA you'd have paid in API credits to match
-        // this window's work WITHOUT Token Optimizer, priced over the window's OWN
-        // real span (the weekly card = the last 7 days, not a slice of a longer
-        // ledger). It is the API-equivalent savings delta, NOT total weekly cost
-        // and NOT strict post-cap overage; the explainer line + ESTIMATED $ chip
-        // carry that honesty. A big "$N more" number, a tiny "in API credits"
-        // caption, then a plain sentence that spells out the meaning.
-        // Honest per-window claim, conditional on whether the without-Optimizer arm
-        // would ACTUALLY have exceeded the cap this window. Capped => you'd have paid
-        // real overage (the value scenario). Not capped => the tokens removed have an
-        // API-rate value, but no bill was avoided; say so plainly (never claim overage
-        // that did not occur).
-        var usdExplainer = w.would_be_capped
-          ? ('Matching this ' + spanWord + '&rsquo;s work without Token Optimizer would have pushed you ' +
-             '<b style="color:var(--c-text-main);font-weight:500;">past your limit</b>. That&rsquo;s the extra you&rsquo;d have paid to do the same work.')
-          : (w.key === 'five_hour'
-             ? ('That&rsquo;s what this ' + spanWord + '&rsquo;s work would have cost you in API credits ' +
-                'without Token Optimizer &mdash; compute it kept off your plan. ' +
-                '<b style="color:var(--c-text-main);font-weight:500;">The harder you push your limits, ' +
-                'the more it saves you from paying to keep going.</b>')
-             : ('At this pace, doing this week&rsquo;s work without Token Optimizer ' +
-                '<b style="color:var(--c-text-main);font-weight:500;">would blow past your weekly limit</b> ' +
-                '&mdash; that&rsquo;s the API-credit overage you&rsquo;re on track to avoid.'));
+        var usdCaption = w.key === 'seven_day'
+          ? 'estimated savings so far this week' : 'of API-credit value kept off this 5h';
+        var usdExplainer = w.full_value
+          ? 'Estimated extra cost in API credits to do this week’s work without Token Optimizer. Includes the effects of lighter context, fewer repeat reads and your working habits, counted once.'
+          : 'API-equivalent value of the savings recorded in this window, including the available estimates.';
+        if (w.full_value && w.full_value.start) {
+          usdExplainer += ' Since ' + esc(new Date(w.full_value.start).toLocaleString([], {month:'short', day:'numeric', hour:'numeric', minute:'2-digit'})) + '.';
+        }
         return '<div style="background:rgba(255,255,255,.02);border:1px solid var(--c-border);border-radius:8px;padding:var(--s-3);">' +
           '<div class="label" style="display:block;margin-bottom:var(--s-3);">' + name + '</div>' +
           (hasUsd
-            ? '<div style="margin-bottom:6px;font-size:22px;font-weight:500;color:var(--c-savings-alt, #10b981);line-height:1.2;">&asymp;' + rwMoney(savedUsd) + (w.would_be_capped ? ' more <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">in API credits</span>' : (w.key === 'five_hour' ? ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">of API-credit value kept off this ' + spanWord + '</span>' : ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">of overage you&rsquo;re on track to avoid this week</span>')) + '</div>' +
+            ? '<div style="margin-bottom:6px;font-size:22px;font-weight:500;color:var(--c-savings-alt, #10b981);line-height:1.2;">&asymp;' + rwMoney(savedUsd) + ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">' + usdCaption + '</span>' + '</div>' +
               '<div style="margin-bottom:var(--s-3);font-size:13px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">' + usdExplainer + '</div>'
             : '') +
           '<div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:var(--s-3);">' +

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -9733,7 +9733,7 @@ def _osrc_prompt_text(record):
     return ""
 
 
-def _parse_session_jsonl(filepath):
+def _parse_session_jsonl(filepath, window_start=None, window_end=None):
     """Parse a single JSONL session file in one streaming pass.
 
     Returns a dict with extracted session metrics, or None if the file
@@ -9744,7 +9744,7 @@ def _parse_session_jsonl(filepath):
     # Memoization: skip re-parse if the file hasn't changed since we last saw it.
     try:
         st = os.stat(filepath)
-        cache_key = (str(filepath), st.st_mtime_ns, st.st_size)
+        cache_key = (str(filepath), st.st_mtime_ns, st.st_size, window_start, window_end)
         if cache_key in _parse_session_jsonl_cache:
             return _parse_session_jsonl_cache[cache_key]
     except OSError:
@@ -9840,6 +9840,21 @@ def _parse_session_jsonl(filepath):
                     s = record.get("slug")
                     if s:
                         slug = s
+
+                # Window reports must slice activity, including sessions that began
+                # before reset. Classify sidechains before filtering their records.
+                if window_start is not None or window_end is not None:
+                    try:
+                        activity_ts = datetime.fromisoformat(
+                            str(record.get("timestamp")).replace("Z", "+00:00"))
+                        if activity_ts.tzinfo is None:
+                            activity_ts = activity_ts.replace(tzinfo=timezone.utc)
+                    except (ValueError, TypeError):
+                        continue
+                    if window_start is not None and activity_ts < window_start:
+                        continue
+                    if window_end is not None and activity_ts >= window_end:
+                        continue
 
                 # Extract timestamp
                 ts_str = record.get("timestamp")
@@ -18728,12 +18743,19 @@ def _get_savings_summary(days=30, since=None):
 
 
 def _is_file_collected(conn, jsonl_path):
-    """Check if a JSONL file has already been collected."""
-    cur = conn.execute(
-        "SELECT 1 FROM session_log WHERE jsonl_path = ?",
+    """Skip only unchanged sessions, including their delegated transcripts."""
+    row = conn.execute(
+        "SELECT collected_at FROM session_log WHERE jsonl_path = ?",
         (str(jsonl_path),),
-    )
-    return cur.fetchone() is not None
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        collected = datetime.fromisoformat(row[0]).timestamp()
+        paths = [Path(jsonl_path), *_find_subagent_jsonl_files(jsonl_path)]
+        return all(path.stat().st_mtime <= collected for path in paths)
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def _insert_normalized_session(conn, dedup_key, parsed, platform, project_fallback, quiet=False):
@@ -20225,7 +20247,7 @@ def _collect_antigravity_sessions(days=90, quiet=False, rebuild=False):
 def collect_sessions(days=90, quiet=False, rebuild=False):
     """Parse new JSONL files and insert into SQLite. Zero token cost.
 
-    Skips files already collected. Safe to run repeatedly.
+    Refreshes changed files in place. Safe to run repeatedly.
     With rebuild=True, drops and re-collects all data (e.g., after a
     measurement fix such as model attribution).
     """
@@ -20245,6 +20267,12 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
         return _collect_grok_sessions(days=days, quiet=quiet, rebuild=rebuild)
 
     conn = _init_trends_db()
+
+    # Capture the existing comparison before refreshing historical session rows.
+    # The user's baseline must not move as collection catches up.
+    if not rebuild:
+        _session_weight_pool_savings(
+            (datetime.now() - timedelta(days=30)).date().isoformat())
 
     # One-time migration for the model attribution fix: wipe model_daily (safe, fast, no data loss)
     if _needs_model_daily_rebuild(conn):
@@ -20288,7 +20316,9 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
         if _COLLECT_MAX_PER_RUN and not rebuild and new_count >= _COLLECT_MAX_PER_RUN:
             break
 
-        parsed = _parse_session_jsonl(filepath)
+        collection_started = datetime.now().isoformat()
+        # Rollups must not mutate the parser cache when only a child grows.
+        parsed = copy.deepcopy(_parse_session_jsonl(filepath))
         if not parsed:
             continue
 
@@ -20353,7 +20383,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
         # Insert session_log
         cur = conn.execute(
-            """INSERT OR IGNORE INTO session_log
+            """INSERT INTO session_log
                (jsonl_path, date, project, duration_minutes, input_tokens,
                 output_tokens, message_count, api_calls, cache_hit_rate,
                 cache_create_1h_tokens, cache_create_5m_tokens, cache_ttl_scanned,
@@ -20363,7 +20393,40 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                     quality_score, quality_grade, stale_waste_tokens, is_sidechain,
                     sidechain_reason, reported_input_tokens, reported_output_tokens,
                     reported_model_usage_json, platform)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(jsonl_path) DO UPDATE SET
+               project=excluded.project,
+               duration_minutes=excluded.duration_minutes,
+               input_tokens=excluded.input_tokens,
+               output_tokens=excluded.output_tokens,
+               message_count=excluded.message_count,
+               api_calls=excluded.api_calls,
+               cache_hit_rate=excluded.cache_hit_rate,
+               cache_create_1h_tokens=excluded.cache_create_1h_tokens,
+               cache_create_5m_tokens=excluded.cache_create_5m_tokens,
+               cache_ttl_scanned=excluded.cache_ttl_scanned,
+               avg_call_gap_seconds=excluded.avg_call_gap_seconds,
+               max_call_gap_seconds=excluded.max_call_gap_seconds,
+               p95_call_gap_seconds=excluded.p95_call_gap_seconds,
+               skills_json=excluded.skills_json,
+               subagents_json=excluded.subagents_json,
+               tool_calls_json=excluded.tool_calls_json,
+               model_usage_json=excluded.model_usage_json,
+               all_model_usage_json=excluded.all_model_usage_json,
+               model_usage_breakdown_json=excluded.model_usage_breakdown_json,
+               version=excluded.version,
+               slug=excluded.slug,
+               topic=excluded.topic,
+               collected_at=excluded.collected_at,
+               quality_score=excluded.quality_score,
+               quality_grade=excluded.quality_grade,
+               stale_waste_tokens=excluded.stale_waste_tokens,
+               is_sidechain=excluded.is_sidechain,
+               sidechain_reason=excluded.sidechain_reason,
+               reported_input_tokens=excluded.reported_input_tokens,
+               reported_output_tokens=excluded.reported_output_tokens,
+               reported_model_usage_json=excluded.reported_model_usage_json,
+               platform=excluded.platform""",
             (
                 str(filepath), date, project_name,
                 parsed["duration_minutes"],
@@ -20387,7 +20450,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                 parsed["version"],
                 parsed.get("slug"),
                 parsed.get("topic"),
-                datetime.now().isoformat(),
+                collection_started,
                 sq["score"],
                 sq["grade"],
                 int(stale_waste or 0),
@@ -39647,6 +39710,9 @@ def runway_snapshot(days=30, now=None):
         meter_available = bool(meters.get("available"))
         meter_stale = bool(meters.get("stale")) or not meter_available
 
+        weekly_full = _weekly_full_savings(
+            resets_at=meters.get("seven_day_resets_at"), now=now)
+
         # --- context lever: measured, never estimated ---
         consumed = saved = 0
         spent_basis = None
@@ -39668,19 +39734,21 @@ def runway_snapshot(days=30, now=None):
                 conn.close()
         except Exception:
             return None
-        if consumed <= 0:
+        if consumed <= 0 and not weekly_full:
             return None
-        context_mult = (consumed + saved) / consumed
+        context_mult = (consumed + saved) / consumed if consumed > 0 else 1.0
 
         # --- routing lever: this user's own shift, priced by input rates ---
         routing_mult = _input_rate_mix_ratio(days=days)
         if routing_mult is None or routing_mult <= 0:
-            return None
+            if not weekly_full:
+                return None
+            routing_mult = 1.0
 
         mult = context_mult * routing_mult
         # Below ~1.02 there is no story worth telling and rounding noise would
         # dominate; say nothing rather than dress up a rounding artefact.
-        if mult < 1.02:
+        if mult < 1.02 and not weekly_full:
             return None
 
         # --- USD-per-window: API-credit OVERAGE over each window's OWN real span ---
@@ -39758,7 +39826,7 @@ def runway_snapshot(days=30, now=None):
                     # -- real, magnitude-metered (v5.13.1) savings that were simply
                     # unlabelled. Window-scoped already (days/since passed above).
                     _rl = wm.get("resume_lean_estimated") or {}
-                    _vs = wm.get("verbosity_steer_estimated") or {}
+                    _vs = wm.get("verbosity_steer") or wm.get("verbosity_steer_estimated") or {}
                     est_add = float(_rl.get("cost_saved_usd", 0.0) or 0.0) \
                         + float(_vs.get("cost_saved_usd", 0.0) or 0.0)
                 except Exception:
@@ -39790,6 +39858,9 @@ def runway_snapshot(days=30, now=None):
                 # trigger is counterfactual even though the magnitude is metered.
                 ctx += est_add
                 est_added = est_add > 0.0
+                if wdays == 7 and weekly_full:
+                    ctx, rt = weekly_full["saved_usd"], 0.0
+                    est_added = True
                 _overage_cache[cache_key] = (ctx, rt, repriced, counted_window, est_added)
             ctx, rt, repriced, counted_window, est_added = _overage_cache[cache_key]
             total = ctx + rt
@@ -39847,6 +39918,7 @@ def runway_snapshot(days=30, now=None):
                 "would_be_capped": head_cf <= 0.5,
                 "saved_usd": window_saved_usd,
                 "saved_usd_tier": window_usd_tier,
+                "full_value": weekly_full if key == "seven_day" else None,
             })
         # REGRESSION FIX (the "Your plan goes further" card vanished after a quiet
         # week): the per-window guard above drops the 5h window once the meter is
@@ -39919,7 +39991,9 @@ def runway_snapshot(days=30, now=None):
             "saved_usd_context": round(saved_context_usd, 2),
             "saved_usd_routing": round(saved_routing_usd, 2),
             "saved_usd_tier": saved_usd_tier,
+            "weekly_full_value": weekly_full,
             "window_savings_basis": (
+                "full workload, exact subscription week" if weekly_full else
                 "counted transcript window" if _wk_counted else "flat savings ledger fallback"),
             # period_days scopes the throughput MULTIPLIERS (context/routing), not
             # the per-window dollars: each window now prices overage over its OWN
@@ -39938,13 +40012,17 @@ def runway_snapshot(days=30, now=None):
             # longer repeats it. Keep the phrases "metered savings ledger" and "not
             # derived from the throughput multipliers" -- guarded by
             # test_proxy_disclosure_mentions_ledger_reuse.
-            "proxy": ("Your window usage is measured; the “without” "
+            "proxy": ("Weekly dollars use the Savings tab's full workload estimate for activity "
+                      "since the subscription reset, at constant prices. Measured and estimated "
+                      "effects overlap, so they are counted once. This is accrued API-equivalent "
+                      "value, not a forecast or an overage bill. The headline percentage covers "
+                      "30 days; window comparisons are estimates." if weekly_full else ("Your window usage is measured; the “without” "
                       "comparison and routing dollars are estimated (the provider "
                       "does not publish how it weights models inside a window, so "
                       "public input-rate ratios stand in). Per-window dollars reuse "
                       "the metered savings ledger (context tokens never sent, priced "
                       "at input rates, plus a routing estimate) and are not derived "
-                      "from the throughput multipliers."),
+                      "from the throughput multipliers.")),
         }
     except Exception:
         return None
@@ -42389,6 +42467,10 @@ def _price_parent_window(conn, where, params, tier):
         "FROM session_log WHERE input_tokens IS NOT NULL "
         "AND COALESCE(is_sidechain, 0) = 0 " + where, params
     ).fetchall()
+    return _price_parent_rows(rows, tier)
+
+
+def _price_parent_rows(rows, tier):
     if not rows:
         return None
     default_model = _default_model_for_runtime()
@@ -42427,7 +42509,29 @@ def _price_parent_window(conn, where, params, tier):
             "flat_usd": flat_usd, "api_calls": api_calls, "messages": messages}
 
 
-def _session_weight_pool_savings(cutoff, days=30, tier=None):
+def _stable_workload_anchor(before, month):
+    """Keep the existing workload comparison stable during session refreshes."""
+    path = SNAPSHOT_DIR / "workload_anchor.json"
+    try:
+        if path.exists():
+            frozen = json.loads(path.read_text(encoding="utf-8"))
+            metrics = frozen.get("metrics") or {}
+            if (frozen.get("month") == month
+                    and frozen.get("rates") == _WEIGHT_POOL_FLAT_RATES
+                    and all(k in metrics for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))):
+                return metrics
+            return None  # a changed/corrupt anchor needs review, not replacement
+        if (before and before["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
+                and before["api_calls"] > 0 and before["flat_usd"] > 0):
+            _write_baseline_state(path, {"month": month, "metrics": before,
+                                        "rates": _WEIGHT_POOL_FLAT_RATES,
+                                        "captured_at": datetime.now().isoformat()})
+        return before
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _session_weight_pool_savings(cutoff, days=30, tier=None, activity_window=None):
     """THE volume lever: cost per UNIT OF WORK, over the whole parent population.
 
     The frozen-anchor pool holds session volume constant across both arms by
@@ -42493,7 +42597,10 @@ def _session_weight_pool_savings(cutoff, days=30, tier=None):
                 return None
             before = _price_parent_window(
                 conn, "AND date LIKE ?", (anchor_month + "%",), tier)
-            now = _price_parent_window(conn, "AND date >= ?", (cutoff,), tier)
+            before = _stable_workload_anchor(before, anchor_month)
+            now = (_price_parent_activity_window(conn, *activity_window, tier)
+                   if activity_window else
+                   _price_parent_window(conn, "AND date >= ?", (cutoff,), tier))
         finally:
             conn.close()
         if not before or not now:
@@ -42596,6 +42703,74 @@ def _session_weight_pool_savings(cutoff, days=30, tier=None):
             "capacity_assumption": capacity_note,
         }
     except (sqlite3.Error, OSError, ValueError, TypeError, ZeroDivisionError):
+        return None
+
+
+def _price_parent_activity_window(conn, start, end, tier):
+    """Use real in-window activity with the standard parent/child pricing rules.
+
+    Reading transcripts here also keeps a weekly report correct while bounded
+    background collection catches up. Missing files produce an unavailable
+    estimate instead of silently treating missing work as zero cost.
+    """
+    paths = conn.execute(
+        "SELECT jsonl_path, date FROM session_log WHERE input_tokens IS NOT NULL "
+        "AND COALESCE(is_sidechain,0)=0").fetchall()
+    rows = []
+    for name, recorded_date in paths:
+        path = Path(name)
+        if not path.exists():
+            if str(recorded_date) < start.date().isoformat():
+                continue
+            return None
+        children = _find_subagent_jsonl_files(path)
+        if max(p.stat().st_mtime for p in [path, *children]) < start.timestamp():
+            continue
+        parsed = _parse_session_jsonl(path, window_start=start, window_end=end)
+        if not parsed or not parsed.get("api_calls"):
+            continue
+        inp, out = parsed["total_input_tokens"], parsed["total_output_tokens"]
+        cw1, cw5 = parsed["total_cache_create_1h"], parsed["total_cache_create_5m"]
+        for child in children:
+            cp = _parse_session_jsonl(child, window_start=start, window_end=end)
+            if cp:
+                inp += cp["total_input_tokens"]
+                out += cp["total_output_tokens"]
+                cw1 += cp["total_cache_create_1h"]
+                cw5 += cp["total_cache_create_5m"]
+        usage = json.dumps(parsed["model_usage"])
+        rows.append((inp, out, cw5, cw1, parsed["cache_hit_rate"], usage, usage,
+                     parsed["api_calls"], parsed["message_count"]))
+    return _price_parent_rows(rows, tier)
+
+
+def _weekly_full_savings(resets_at=None, now=None):
+    """The Savings tab's full estimate, accrued inside this subscription week.
+
+    Its before/after difference already includes overlapping measured and
+    estimated mechanisms. Never add their individual estimates on top.
+    """
+    if detect_runtime() != "claude":
+        return None
+    try:
+        end = datetime.fromtimestamp(now if now is not None else time.time(), timezone.utc)
+        start = (datetime.fromtimestamp(float(resets_at), timezone.utc) - timedelta(days=7)
+                 if resets_at is not None else end - timedelta(days=7))
+        if start >= end or (resets_at is not None and end.timestamp() >= float(resets_at)):
+            return None
+        pool = _session_weight_pool_savings(
+            start.isoformat(), days=7, activity_window=(start, end))
+        if not pool or pool["transformation_usd"] <= 0:
+            return None
+        # Same conservative display cap as the Savings tab.
+        saving = min(pool["transformation_usd"], pool["actual_usd"])
+        return {"saved_usd": round(saving, 2), "start": start.isoformat(),
+                "end": end.isoformat(), "method": "full workload",
+                "uncapped_usd": round(pool["transformation_usd"], 2),
+                "actual_usd": round(pool["actual_usd"], 2),
+                "counterfactual_usd": round(pool["counterfactual_usd"], 2),
+                "api_calls": pool["now_units"], "anchor_month": pool["anchor_month"]}
+    except (OSError, sqlite3.Error, ValueError, TypeError, KeyError):
         return None
 
 

--- a/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/cowork/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -9751,6 +9751,8 @@ def _parse_session_jsonl(filepath, window_start=None, window_end=None):
         cache_key = None  # stat failed — parse without caching
 
     if _use_codex_session_adapter(filepath):
+        if window_start is not None or window_end is not None:
+            return None  # This adapter does not yet support activity slicing.
         result = codex_session.parse_session_jsonl(filepath)
         if cache_key is not None:
             if len(_parse_session_jsonl_cache) >= _PARSE_CACHE_MAX:
@@ -18742,17 +18744,20 @@ def _get_savings_summary(days=30, since=None):
         }
 
 
-def _is_file_collected(conn, jsonl_path):
-    """Skip only unchanged sessions, including their delegated transcripts."""
+def _is_file_collected(conn, jsonl_path, check_mtime=False):
+    """Check stored IDs; file collectors also check delegated transcript changes."""
     row = conn.execute(
         "SELECT collected_at FROM session_log WHERE jsonl_path = ?",
         (str(jsonl_path),),
     ).fetchone()
     if row is None:
         return False
+    if not check_mtime:
+        return True  # Other adapters use synthetic IDs, not filesystem paths.
     try:
         collected = datetime.fromisoformat(row[0]).timestamp()
-        paths = [Path(jsonl_path), *_find_subagent_jsonl_files(jsonl_path)]
+        path = Path(jsonl_path)
+        paths = [path, *_find_subagent_jsonl_files(path)]
         return all(path.stat().st_mtime <= collected for path in paths)
     except (OSError, TypeError, ValueError):
         return False
@@ -20270,7 +20275,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
     # Capture the existing comparison before refreshing historical session rows.
     # The user's baseline must not move as collection catches up.
-    if not rebuild:
+    if not rebuild and not (SNAPSHOT_DIR / "workload_anchor.json").exists():
         _session_weight_pool_savings(
             (datetime.now() - timedelta(days=30)).date().isoformat())
 
@@ -20306,7 +20311,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
     new_count = 0
     for filepath, mtime, project_name in files:
-        if _is_file_collected(conn, filepath):
+        if _is_file_collected(conn, filepath, check_mtime=True):
             continue
 
         # Bounded per-run collection: never parse more than _COLLECT_MAX_PER_RUN new
@@ -20426,7 +20431,9 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                reported_input_tokens=excluded.reported_input_tokens,
                reported_output_tokens=excluded.reported_output_tokens,
                reported_model_usage_json=excluded.reported_model_usage_json,
-               platform=excluded.platform""",
+               platform=excluded.platform
+               WHERE session_log.collected_at IS NULL
+                  OR excluded.collected_at >= session_log.collected_at""",
             (
                 str(filepath), date, project_name,
                 parsed["duration_minutes"],
@@ -42515,12 +42522,17 @@ def _stable_workload_anchor(before, month):
     try:
         if path.exists():
             frozen = json.loads(path.read_text(encoding="utf-8"))
-            metrics = frozen.get("metrics") or {}
-            if (frozen.get("month") == month
+            metrics = frozen.get("metrics") if isinstance(frozen, dict) else None
+            if (isinstance(metrics, dict) and frozen.get("month") == month
                     and frozen.get("rates") == _WEIGHT_POOL_FLAT_RATES
-                    and all(k in metrics for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))):
+                    and all(isinstance(metrics.get(k), (int, float))
+                            and math.isfinite(metrics[k]) and metrics[k] >= 0
+                            for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))
+                    and metrics["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
+                    and metrics["api_calls"] > 0 and metrics["flat_usd"] > 0):
                 return metrics
-            return None  # a changed/corrupt anchor needs review, not replacement
+            # Backfill/rebuild can change the earliest covered month. Re-anchor
+            # from the same shared population instead of permanently hiding it.
         if (before and before["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
                 and before["api_calls"] > 0 and before["flat_usd"] > 0):
             _write_baseline_state(path, {"month": month, "metrics": before,
@@ -42716,6 +42728,12 @@ def _price_parent_activity_window(conn, start, end, tier):
     paths = conn.execute(
         "SELECT jsonl_path, date FROM session_log WHERE input_tokens IS NOT NULL "
         "AND COALESCE(is_sidechain,0)=0").fetchall()
+    # Include new sessions before bounded collection reaches them.
+    known = {str(name) for name, _ in paths}
+    for path, mtime, _ in _find_all_jsonl_files(8):
+        if str(path) not in known:
+            paths.append((str(path), datetime.fromtimestamp(mtime).date().isoformat()))
+            known.add(str(path))
     rows = []
     for name, recorded_date in paths:
         path = Path(name)
@@ -42727,10 +42745,16 @@ def _price_parent_activity_window(conn, start, end, tier):
         if max(p.stat().st_mtime for p in [path, *children]) < start.timestamp():
             continue
         parsed = _parse_session_jsonl(path, window_start=start, window_end=end)
-        if not parsed or not parsed.get("api_calls"):
+        if parsed and parsed.get("is_sidechain"):
             continue
+        if not parsed:
+            parsed = {"total_input_tokens": 0, "total_output_tokens": 0,
+                      "total_cache_create_1h": 0, "total_cache_create_5m": 0,
+                      "cache_hit_rate": 0, "model_usage": {}, "api_calls": 0,
+                      "message_count": 0}
         inp, out = parsed["total_input_tokens"], parsed["total_output_tokens"]
         cw1, cw5 = parsed["total_cache_create_1h"], parsed["total_cache_create_5m"]
+        child_cache_read = 0
         for child in children:
             cp = _parse_session_jsonl(child, window_start=start, window_end=end)
             if cp:
@@ -42738,8 +42762,13 @@ def _price_parent_activity_window(conn, start, end, tier):
                 out += cp["total_output_tokens"]
                 cw1 += cp["total_cache_create_1h"]
                 cw5 += cp["total_cache_create_5m"]
+                child_cache_read += cp["total_cache_read"]
+        if not parsed["api_calls"] and inp + out == 0:
+            continue
         usage = json.dumps(parsed["model_usage"])
-        rows.append((inp, out, cw5, cw1, parsed["cache_hit_rate"], usage, usage,
+        hit = (parsed["cache_hit_rate"] if parsed["api_calls"] else
+               child_cache_read / inp if inp else 0)
+        rows.append((inp, out, cw5, cw1, hit, usage, usage,
                      parsed["api_calls"], parsed["message_count"]))
     return _price_parent_rows(rows, tier)
 
@@ -42756,20 +42785,44 @@ def _weekly_full_savings(resets_at=None, now=None):
         end = datetime.fromtimestamp(now if now is not None else time.time(), timezone.utc)
         start = (datetime.fromtimestamp(float(resets_at), timezone.utc) - timedelta(days=7)
                  if resets_at is not None else end - timedelta(days=7))
-        if start >= end or (resets_at is not None and end.timestamp() >= float(resets_at)):
+        if resets_at is None or start >= end or end.timestamp() >= float(resets_at):
             return None
+        # Dashboard refreshes may run several times per minute in separate
+        # processes. Keep an explicitly dated result for at most 60 seconds.
+        cache_path = SNAPSHOT_DIR / "weekly_full_value.json"
+        anchor_path = SNAPSHOT_DIR / "workload_anchor.json"
+        anchor_stamp = anchor_path.stat().st_mtime_ns if anchor_path.exists() else None
+        if now is None and cache_path.exists():
+            try:
+                cached = json.loads(cache_path.read_text(encoding="utf-8"))
+                age = end.timestamp() - float(cached["computed_at"])
+                if (0 <= age < 60 and cached["start"] == start.isoformat()
+                        and cached["anchor_stamp"] == anchor_stamp
+                        and cached["version"] == TOKEN_OPTIMIZER_VERSION):
+                    return cached["value"]
+            except (OSError, ValueError, TypeError, KeyError):
+                pass
         pool = _session_weight_pool_savings(
             start.isoformat(), days=7, activity_window=(start, end))
-        if not pool or pool["transformation_usd"] <= 0:
+        if not pool:
             return None
         # Same conservative display cap as the Savings tab.
-        saving = min(pool["transformation_usd"], pool["actual_usd"])
-        return {"saved_usd": round(saving, 2), "start": start.isoformat(),
+        saving = max(0.0, min(pool["transformation_usd"], pool["actual_usd"]))
+        value = {"saved_usd": round(saving, 2), "start": start.isoformat(),
                 "end": end.isoformat(), "method": "full workload",
                 "uncapped_usd": round(pool["transformation_usd"], 2),
                 "actual_usd": round(pool["actual_usd"], 2),
                 "counterfactual_usd": round(pool["counterfactual_usd"], 2),
                 "api_calls": pool["now_units"], "anchor_month": pool["anchor_month"]}
+        if now is None:
+            try:
+                _write_baseline_state(cache_path, {
+                    "computed_at": end.timestamp(), "start": start.isoformat(),
+                    "anchor_stamp": anchor_path.stat().st_mtime_ns if anchor_path.exists() else None,
+                    "version": TOKEN_OPTIMIZER_VERSION, "value": value})
+            except OSError:
+                pass
+        return value
     except (OSError, sqlite3.Error, ValueError, TypeError, KeyError):
         return None
 

--- a/plugins/token-optimizer/.codex-plugin/plugin.json
+++ b/plugins/token-optimizer/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-optimizer",
-  "version": "5.13.8",
+  "version": "5.13.9",
   "description": "Audit, monitor, and reduce Codex context waste with continuity helpers and explicit outline tools.",
   "skills": "./skills/",
   "interface": {

--- a/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -4083,6 +4083,16 @@ var DB = (function() {
           '</div>' +
         '</div>';
       }).join('');
+      // Savings remain available when the quota meter has no weekly reading.
+      var standaloneWeek = rw.weekly_full_value;
+      if (standaloneWeek && Number(standaloneWeek.saved_usd) >= 15 &&
+          !(rw.windows || []).some(function (w) { return w.key === 'seven_day'; })) {
+        rwCards += '<div style="padding:var(--s-3);border:1px solid var(--c-border);border-radius:8px;">' +
+          '<div class="label">Weekly savings</div><div style="font-size:22px;color:var(--c-savings-alt,#10b981);">&asymp;' +
+          rwMoney(standaloneWeek.saved_usd) + ' estimated savings so far this week</div>' +
+          '<p>Full workload estimate since ' + esc(new Date(standaloneWeek.start).toLocaleString()) +
+          '. Your weekly limit reading is unavailable.</p></div>';
+      }
       // USD-per-window headline: the dollar figure reuses the metered
       // savings ledger, apportioned to each window's span. Build the headline
       // from the windows that carry a saved_usd; fall back to the demoted

--- a/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
+++ b/plugins/token-optimizer/skills/token-optimizer/assets/dashboard.html
@@ -4011,7 +4011,7 @@ var DB = (function() {
     // unavailable meter used to vanish the whole card). runway_snapshot already
     // returns null when there is genuinely no story, so rw existing + a windows-
     // or-multiplier payload is the real render condition.
-    if (rw && (rwHasWindows || rwHasMultiplier)) {
+    if (rw && (rwHasWindows || rwHasMultiplier || rw.weekly_full_value)) {
       // Both sides are stated in the SAME unit (percent LEFT). An earlier revision
       // paired "89% left" against "16.6% used", which reads as a contradiction and
       // forces the reader to do the subtraction. The with/without pair is also the
@@ -4045,38 +4045,19 @@ var DB = (function() {
         // ledger has nothing to show; degrade to no line rather than $-0/NaN.
         var savedUsd = Number(w.saved_usd);
         var spanWord = w.key === 'five_hour' ? '5h' : 'week';
-        // Weekly $: shown whenever it is meaningful (>= $15) and NEVER gated on
-        // already being capped — at that size it is the overage you are on
-        // track to hit, not a hypothetical. Below $15 the line is noise: hide.
-        // The 5h window keeps the any-positive rule (its $ is already rare).
         var hasUsd = isFinite(savedUsd) && (w.key === 'five_hour' ? savedUsd > 0 : savedUsd >= 15);
-        // The per-window USD is the EXTRA you'd have paid in API credits to match
-        // this window's work WITHOUT Token Optimizer, priced over the window's OWN
-        // real span (the weekly card = the last 7 days, not a slice of a longer
-        // ledger). It is the API-equivalent savings delta, NOT total weekly cost
-        // and NOT strict post-cap overage; the explainer line + ESTIMATED $ chip
-        // carry that honesty. A big "$N more" number, a tiny "in API credits"
-        // caption, then a plain sentence that spells out the meaning.
-        // Honest per-window claim, conditional on whether the without-Optimizer arm
-        // would ACTUALLY have exceeded the cap this window. Capped => you'd have paid
-        // real overage (the value scenario). Not capped => the tokens removed have an
-        // API-rate value, but no bill was avoided; say so plainly (never claim overage
-        // that did not occur).
-        var usdExplainer = w.would_be_capped
-          ? ('Matching this ' + spanWord + '&rsquo;s work without Token Optimizer would have pushed you ' +
-             '<b style="color:var(--c-text-main);font-weight:500;">past your limit</b>. That&rsquo;s the extra you&rsquo;d have paid to do the same work.')
-          : (w.key === 'five_hour'
-             ? ('That&rsquo;s what this ' + spanWord + '&rsquo;s work would have cost you in API credits ' +
-                'without Token Optimizer &mdash; compute it kept off your plan. ' +
-                '<b style="color:var(--c-text-main);font-weight:500;">The harder you push your limits, ' +
-                'the more it saves you from paying to keep going.</b>')
-             : ('At this pace, doing this week&rsquo;s work without Token Optimizer ' +
-                '<b style="color:var(--c-text-main);font-weight:500;">would blow past your weekly limit</b> ' +
-                '&mdash; that&rsquo;s the API-credit overage you&rsquo;re on track to avoid.'));
+        var usdCaption = w.key === 'seven_day'
+          ? 'estimated savings so far this week' : 'of API-credit value kept off this 5h';
+        var usdExplainer = w.full_value
+          ? 'Estimated extra cost in API credits to do this week’s work without Token Optimizer. Includes the effects of lighter context, fewer repeat reads and your working habits, counted once.'
+          : 'API-equivalent value of the savings recorded in this window, including the available estimates.';
+        if (w.full_value && w.full_value.start) {
+          usdExplainer += ' Since ' + esc(new Date(w.full_value.start).toLocaleString([], {month:'short', day:'numeric', hour:'numeric', minute:'2-digit'})) + '.';
+        }
         return '<div style="background:rgba(255,255,255,.02);border:1px solid var(--c-border);border-radius:8px;padding:var(--s-3);">' +
           '<div class="label" style="display:block;margin-bottom:var(--s-3);">' + name + '</div>' +
           (hasUsd
-            ? '<div style="margin-bottom:6px;font-size:22px;font-weight:500;color:var(--c-savings-alt, #10b981);line-height:1.2;">&asymp;' + rwMoney(savedUsd) + (w.would_be_capped ? ' more <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">in API credits</span>' : (w.key === 'five_hour' ? ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">of API-credit value kept off this ' + spanWord + '</span>' : ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">of overage you&rsquo;re on track to avoid this week</span>')) + '</div>' +
+            ? '<div style="margin-bottom:6px;font-size:22px;font-weight:500;color:var(--c-savings-alt, #10b981);line-height:1.2;">&asymp;' + rwMoney(savedUsd) + ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">' + usdCaption + '</span>' + '</div>' +
               '<div style="margin-bottom:var(--s-3);font-size:13px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">' + usdExplainer + '</div>'
             : '') +
           '<div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:var(--s-3);">' +

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -9733,7 +9733,7 @@ def _osrc_prompt_text(record):
     return ""
 
 
-def _parse_session_jsonl(filepath):
+def _parse_session_jsonl(filepath, window_start=None, window_end=None):
     """Parse a single JSONL session file in one streaming pass.
 
     Returns a dict with extracted session metrics, or None if the file
@@ -9744,7 +9744,7 @@ def _parse_session_jsonl(filepath):
     # Memoization: skip re-parse if the file hasn't changed since we last saw it.
     try:
         st = os.stat(filepath)
-        cache_key = (str(filepath), st.st_mtime_ns, st.st_size)
+        cache_key = (str(filepath), st.st_mtime_ns, st.st_size, window_start, window_end)
         if cache_key in _parse_session_jsonl_cache:
             return _parse_session_jsonl_cache[cache_key]
     except OSError:
@@ -9840,6 +9840,21 @@ def _parse_session_jsonl(filepath):
                     s = record.get("slug")
                     if s:
                         slug = s
+
+                # Window reports must slice activity, including sessions that began
+                # before reset. Classify sidechains before filtering their records.
+                if window_start is not None or window_end is not None:
+                    try:
+                        activity_ts = datetime.fromisoformat(
+                            str(record.get("timestamp")).replace("Z", "+00:00"))
+                        if activity_ts.tzinfo is None:
+                            activity_ts = activity_ts.replace(tzinfo=timezone.utc)
+                    except (ValueError, TypeError):
+                        continue
+                    if window_start is not None and activity_ts < window_start:
+                        continue
+                    if window_end is not None and activity_ts >= window_end:
+                        continue
 
                 # Extract timestamp
                 ts_str = record.get("timestamp")
@@ -18728,12 +18743,19 @@ def _get_savings_summary(days=30, since=None):
 
 
 def _is_file_collected(conn, jsonl_path):
-    """Check if a JSONL file has already been collected."""
-    cur = conn.execute(
-        "SELECT 1 FROM session_log WHERE jsonl_path = ?",
+    """Skip only unchanged sessions, including their delegated transcripts."""
+    row = conn.execute(
+        "SELECT collected_at FROM session_log WHERE jsonl_path = ?",
         (str(jsonl_path),),
-    )
-    return cur.fetchone() is not None
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        collected = datetime.fromisoformat(row[0]).timestamp()
+        paths = [Path(jsonl_path), *_find_subagent_jsonl_files(jsonl_path)]
+        return all(path.stat().st_mtime <= collected for path in paths)
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def _insert_normalized_session(conn, dedup_key, parsed, platform, project_fallback, quiet=False):
@@ -20225,7 +20247,7 @@ def _collect_antigravity_sessions(days=90, quiet=False, rebuild=False):
 def collect_sessions(days=90, quiet=False, rebuild=False):
     """Parse new JSONL files and insert into SQLite. Zero token cost.
 
-    Skips files already collected. Safe to run repeatedly.
+    Refreshes changed files in place. Safe to run repeatedly.
     With rebuild=True, drops and re-collects all data (e.g., after a
     measurement fix such as model attribution).
     """
@@ -20245,6 +20267,12 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
         return _collect_grok_sessions(days=days, quiet=quiet, rebuild=rebuild)
 
     conn = _init_trends_db()
+
+    # Capture the existing comparison before refreshing historical session rows.
+    # The user's baseline must not move as collection catches up.
+    if not rebuild:
+        _session_weight_pool_savings(
+            (datetime.now() - timedelta(days=30)).date().isoformat())
 
     # One-time migration for the model attribution fix: wipe model_daily (safe, fast, no data loss)
     if _needs_model_daily_rebuild(conn):
@@ -20288,7 +20316,9 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
         if _COLLECT_MAX_PER_RUN and not rebuild and new_count >= _COLLECT_MAX_PER_RUN:
             break
 
-        parsed = _parse_session_jsonl(filepath)
+        collection_started = datetime.now().isoformat()
+        # Rollups must not mutate the parser cache when only a child grows.
+        parsed = copy.deepcopy(_parse_session_jsonl(filepath))
         if not parsed:
             continue
 
@@ -20353,7 +20383,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
         # Insert session_log
         cur = conn.execute(
-            """INSERT OR IGNORE INTO session_log
+            """INSERT INTO session_log
                (jsonl_path, date, project, duration_minutes, input_tokens,
                 output_tokens, message_count, api_calls, cache_hit_rate,
                 cache_create_1h_tokens, cache_create_5m_tokens, cache_ttl_scanned,
@@ -20363,7 +20393,40 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                     quality_score, quality_grade, stale_waste_tokens, is_sidechain,
                     sidechain_reason, reported_input_tokens, reported_output_tokens,
                     reported_model_usage_json, platform)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(jsonl_path) DO UPDATE SET
+               project=excluded.project,
+               duration_minutes=excluded.duration_minutes,
+               input_tokens=excluded.input_tokens,
+               output_tokens=excluded.output_tokens,
+               message_count=excluded.message_count,
+               api_calls=excluded.api_calls,
+               cache_hit_rate=excluded.cache_hit_rate,
+               cache_create_1h_tokens=excluded.cache_create_1h_tokens,
+               cache_create_5m_tokens=excluded.cache_create_5m_tokens,
+               cache_ttl_scanned=excluded.cache_ttl_scanned,
+               avg_call_gap_seconds=excluded.avg_call_gap_seconds,
+               max_call_gap_seconds=excluded.max_call_gap_seconds,
+               p95_call_gap_seconds=excluded.p95_call_gap_seconds,
+               skills_json=excluded.skills_json,
+               subagents_json=excluded.subagents_json,
+               tool_calls_json=excluded.tool_calls_json,
+               model_usage_json=excluded.model_usage_json,
+               all_model_usage_json=excluded.all_model_usage_json,
+               model_usage_breakdown_json=excluded.model_usage_breakdown_json,
+               version=excluded.version,
+               slug=excluded.slug,
+               topic=excluded.topic,
+               collected_at=excluded.collected_at,
+               quality_score=excluded.quality_score,
+               quality_grade=excluded.quality_grade,
+               stale_waste_tokens=excluded.stale_waste_tokens,
+               is_sidechain=excluded.is_sidechain,
+               sidechain_reason=excluded.sidechain_reason,
+               reported_input_tokens=excluded.reported_input_tokens,
+               reported_output_tokens=excluded.reported_output_tokens,
+               reported_model_usage_json=excluded.reported_model_usage_json,
+               platform=excluded.platform""",
             (
                 str(filepath), date, project_name,
                 parsed["duration_minutes"],
@@ -20387,7 +20450,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                 parsed["version"],
                 parsed.get("slug"),
                 parsed.get("topic"),
-                datetime.now().isoformat(),
+                collection_started,
                 sq["score"],
                 sq["grade"],
                 int(stale_waste or 0),
@@ -39647,6 +39710,9 @@ def runway_snapshot(days=30, now=None):
         meter_available = bool(meters.get("available"))
         meter_stale = bool(meters.get("stale")) or not meter_available
 
+        weekly_full = _weekly_full_savings(
+            resets_at=meters.get("seven_day_resets_at"), now=now)
+
         # --- context lever: measured, never estimated ---
         consumed = saved = 0
         spent_basis = None
@@ -39668,19 +39734,21 @@ def runway_snapshot(days=30, now=None):
                 conn.close()
         except Exception:
             return None
-        if consumed <= 0:
+        if consumed <= 0 and not weekly_full:
             return None
-        context_mult = (consumed + saved) / consumed
+        context_mult = (consumed + saved) / consumed if consumed > 0 else 1.0
 
         # --- routing lever: this user's own shift, priced by input rates ---
         routing_mult = _input_rate_mix_ratio(days=days)
         if routing_mult is None or routing_mult <= 0:
-            return None
+            if not weekly_full:
+                return None
+            routing_mult = 1.0
 
         mult = context_mult * routing_mult
         # Below ~1.02 there is no story worth telling and rounding noise would
         # dominate; say nothing rather than dress up a rounding artefact.
-        if mult < 1.02:
+        if mult < 1.02 and not weekly_full:
             return None
 
         # --- USD-per-window: API-credit OVERAGE over each window's OWN real span ---
@@ -39758,7 +39826,7 @@ def runway_snapshot(days=30, now=None):
                     # -- real, magnitude-metered (v5.13.1) savings that were simply
                     # unlabelled. Window-scoped already (days/since passed above).
                     _rl = wm.get("resume_lean_estimated") or {}
-                    _vs = wm.get("verbosity_steer_estimated") or {}
+                    _vs = wm.get("verbosity_steer") or wm.get("verbosity_steer_estimated") or {}
                     est_add = float(_rl.get("cost_saved_usd", 0.0) or 0.0) \
                         + float(_vs.get("cost_saved_usd", 0.0) or 0.0)
                 except Exception:
@@ -39790,6 +39858,9 @@ def runway_snapshot(days=30, now=None):
                 # trigger is counterfactual even though the magnitude is metered.
                 ctx += est_add
                 est_added = est_add > 0.0
+                if wdays == 7 and weekly_full:
+                    ctx, rt = weekly_full["saved_usd"], 0.0
+                    est_added = True
                 _overage_cache[cache_key] = (ctx, rt, repriced, counted_window, est_added)
             ctx, rt, repriced, counted_window, est_added = _overage_cache[cache_key]
             total = ctx + rt
@@ -39847,6 +39918,7 @@ def runway_snapshot(days=30, now=None):
                 "would_be_capped": head_cf <= 0.5,
                 "saved_usd": window_saved_usd,
                 "saved_usd_tier": window_usd_tier,
+                "full_value": weekly_full if key == "seven_day" else None,
             })
         # REGRESSION FIX (the "Your plan goes further" card vanished after a quiet
         # week): the per-window guard above drops the 5h window once the meter is
@@ -39919,7 +39991,9 @@ def runway_snapshot(days=30, now=None):
             "saved_usd_context": round(saved_context_usd, 2),
             "saved_usd_routing": round(saved_routing_usd, 2),
             "saved_usd_tier": saved_usd_tier,
+            "weekly_full_value": weekly_full,
             "window_savings_basis": (
+                "full workload, exact subscription week" if weekly_full else
                 "counted transcript window" if _wk_counted else "flat savings ledger fallback"),
             # period_days scopes the throughput MULTIPLIERS (context/routing), not
             # the per-window dollars: each window now prices overage over its OWN
@@ -39938,13 +40012,17 @@ def runway_snapshot(days=30, now=None):
             # longer repeats it. Keep the phrases "metered savings ledger" and "not
             # derived from the throughput multipliers" -- guarded by
             # test_proxy_disclosure_mentions_ledger_reuse.
-            "proxy": ("Your window usage is measured; the “without” "
+            "proxy": ("Weekly dollars use the Savings tab's full workload estimate for activity "
+                      "since the subscription reset, at constant prices. Measured and estimated "
+                      "effects overlap, so they are counted once. This is accrued API-equivalent "
+                      "value, not a forecast or an overage bill. The headline percentage covers "
+                      "30 days; window comparisons are estimates." if weekly_full else ("Your window usage is measured; the “without” "
                       "comparison and routing dollars are estimated (the provider "
                       "does not publish how it weights models inside a window, so "
                       "public input-rate ratios stand in). Per-window dollars reuse "
                       "the metered savings ledger (context tokens never sent, priced "
                       "at input rates, plus a routing estimate) and are not derived "
-                      "from the throughput multipliers."),
+                      "from the throughput multipliers.")),
         }
     except Exception:
         return None
@@ -42389,6 +42467,10 @@ def _price_parent_window(conn, where, params, tier):
         "FROM session_log WHERE input_tokens IS NOT NULL "
         "AND COALESCE(is_sidechain, 0) = 0 " + where, params
     ).fetchall()
+    return _price_parent_rows(rows, tier)
+
+
+def _price_parent_rows(rows, tier):
     if not rows:
         return None
     default_model = _default_model_for_runtime()
@@ -42427,7 +42509,29 @@ def _price_parent_window(conn, where, params, tier):
             "flat_usd": flat_usd, "api_calls": api_calls, "messages": messages}
 
 
-def _session_weight_pool_savings(cutoff, days=30, tier=None):
+def _stable_workload_anchor(before, month):
+    """Keep the existing workload comparison stable during session refreshes."""
+    path = SNAPSHOT_DIR / "workload_anchor.json"
+    try:
+        if path.exists():
+            frozen = json.loads(path.read_text(encoding="utf-8"))
+            metrics = frozen.get("metrics") or {}
+            if (frozen.get("month") == month
+                    and frozen.get("rates") == _WEIGHT_POOL_FLAT_RATES
+                    and all(k in metrics for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))):
+                return metrics
+            return None  # a changed/corrupt anchor needs review, not replacement
+        if (before and before["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
+                and before["api_calls"] > 0 and before["flat_usd"] > 0):
+            _write_baseline_state(path, {"month": month, "metrics": before,
+                                        "rates": _WEIGHT_POOL_FLAT_RATES,
+                                        "captured_at": datetime.now().isoformat()})
+        return before
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _session_weight_pool_savings(cutoff, days=30, tier=None, activity_window=None):
     """THE volume lever: cost per UNIT OF WORK, over the whole parent population.
 
     The frozen-anchor pool holds session volume constant across both arms by
@@ -42493,7 +42597,10 @@ def _session_weight_pool_savings(cutoff, days=30, tier=None):
                 return None
             before = _price_parent_window(
                 conn, "AND date LIKE ?", (anchor_month + "%",), tier)
-            now = _price_parent_window(conn, "AND date >= ?", (cutoff,), tier)
+            before = _stable_workload_anchor(before, anchor_month)
+            now = (_price_parent_activity_window(conn, *activity_window, tier)
+                   if activity_window else
+                   _price_parent_window(conn, "AND date >= ?", (cutoff,), tier))
         finally:
             conn.close()
         if not before or not now:
@@ -42596,6 +42703,74 @@ def _session_weight_pool_savings(cutoff, days=30, tier=None):
             "capacity_assumption": capacity_note,
         }
     except (sqlite3.Error, OSError, ValueError, TypeError, ZeroDivisionError):
+        return None
+
+
+def _price_parent_activity_window(conn, start, end, tier):
+    """Use real in-window activity with the standard parent/child pricing rules.
+
+    Reading transcripts here also keeps a weekly report correct while bounded
+    background collection catches up. Missing files produce an unavailable
+    estimate instead of silently treating missing work as zero cost.
+    """
+    paths = conn.execute(
+        "SELECT jsonl_path, date FROM session_log WHERE input_tokens IS NOT NULL "
+        "AND COALESCE(is_sidechain,0)=0").fetchall()
+    rows = []
+    for name, recorded_date in paths:
+        path = Path(name)
+        if not path.exists():
+            if str(recorded_date) < start.date().isoformat():
+                continue
+            return None
+        children = _find_subagent_jsonl_files(path)
+        if max(p.stat().st_mtime for p in [path, *children]) < start.timestamp():
+            continue
+        parsed = _parse_session_jsonl(path, window_start=start, window_end=end)
+        if not parsed or not parsed.get("api_calls"):
+            continue
+        inp, out = parsed["total_input_tokens"], parsed["total_output_tokens"]
+        cw1, cw5 = parsed["total_cache_create_1h"], parsed["total_cache_create_5m"]
+        for child in children:
+            cp = _parse_session_jsonl(child, window_start=start, window_end=end)
+            if cp:
+                inp += cp["total_input_tokens"]
+                out += cp["total_output_tokens"]
+                cw1 += cp["total_cache_create_1h"]
+                cw5 += cp["total_cache_create_5m"]
+        usage = json.dumps(parsed["model_usage"])
+        rows.append((inp, out, cw5, cw1, parsed["cache_hit_rate"], usage, usage,
+                     parsed["api_calls"], parsed["message_count"]))
+    return _price_parent_rows(rows, tier)
+
+
+def _weekly_full_savings(resets_at=None, now=None):
+    """The Savings tab's full estimate, accrued inside this subscription week.
+
+    Its before/after difference already includes overlapping measured and
+    estimated mechanisms. Never add their individual estimates on top.
+    """
+    if detect_runtime() != "claude":
+        return None
+    try:
+        end = datetime.fromtimestamp(now if now is not None else time.time(), timezone.utc)
+        start = (datetime.fromtimestamp(float(resets_at), timezone.utc) - timedelta(days=7)
+                 if resets_at is not None else end - timedelta(days=7))
+        if start >= end or (resets_at is not None and end.timestamp() >= float(resets_at)):
+            return None
+        pool = _session_weight_pool_savings(
+            start.isoformat(), days=7, activity_window=(start, end))
+        if not pool or pool["transformation_usd"] <= 0:
+            return None
+        # Same conservative display cap as the Savings tab.
+        saving = min(pool["transformation_usd"], pool["actual_usd"])
+        return {"saved_usd": round(saving, 2), "start": start.isoformat(),
+                "end": end.isoformat(), "method": "full workload",
+                "uncapped_usd": round(pool["transformation_usd"], 2),
+                "actual_usd": round(pool["actual_usd"], 2),
+                "counterfactual_usd": round(pool["counterfactual_usd"], 2),
+                "api_calls": pool["now_units"], "anchor_month": pool["anchor_month"]}
+    except (OSError, sqlite3.Error, ValueError, TypeError, KeyError):
         return None
 
 

--- a/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
+++ b/plugins/token-optimizer/skills/token-optimizer/scripts/measure.py
@@ -9751,6 +9751,8 @@ def _parse_session_jsonl(filepath, window_start=None, window_end=None):
         cache_key = None  # stat failed — parse without caching
 
     if _use_codex_session_adapter(filepath):
+        if window_start is not None or window_end is not None:
+            return None  # This adapter does not yet support activity slicing.
         result = codex_session.parse_session_jsonl(filepath)
         if cache_key is not None:
             if len(_parse_session_jsonl_cache) >= _PARSE_CACHE_MAX:
@@ -18742,17 +18744,20 @@ def _get_savings_summary(days=30, since=None):
         }
 
 
-def _is_file_collected(conn, jsonl_path):
-    """Skip only unchanged sessions, including their delegated transcripts."""
+def _is_file_collected(conn, jsonl_path, check_mtime=False):
+    """Check stored IDs; file collectors also check delegated transcript changes."""
     row = conn.execute(
         "SELECT collected_at FROM session_log WHERE jsonl_path = ?",
         (str(jsonl_path),),
     ).fetchone()
     if row is None:
         return False
+    if not check_mtime:
+        return True  # Other adapters use synthetic IDs, not filesystem paths.
     try:
         collected = datetime.fromisoformat(row[0]).timestamp()
-        paths = [Path(jsonl_path), *_find_subagent_jsonl_files(jsonl_path)]
+        path = Path(jsonl_path)
+        paths = [path, *_find_subagent_jsonl_files(path)]
         return all(path.stat().st_mtime <= collected for path in paths)
     except (OSError, TypeError, ValueError):
         return False
@@ -20270,7 +20275,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
     # Capture the existing comparison before refreshing historical session rows.
     # The user's baseline must not move as collection catches up.
-    if not rebuild:
+    if not rebuild and not (SNAPSHOT_DIR / "workload_anchor.json").exists():
         _session_weight_pool_savings(
             (datetime.now() - timedelta(days=30)).date().isoformat())
 
@@ -20306,7 +20311,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
     new_count = 0
     for filepath, mtime, project_name in files:
-        if _is_file_collected(conn, filepath):
+        if _is_file_collected(conn, filepath, check_mtime=True):
             continue
 
         # Bounded per-run collection: never parse more than _COLLECT_MAX_PER_RUN new
@@ -20426,7 +20431,9 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                reported_input_tokens=excluded.reported_input_tokens,
                reported_output_tokens=excluded.reported_output_tokens,
                reported_model_usage_json=excluded.reported_model_usage_json,
-               platform=excluded.platform""",
+               platform=excluded.platform
+               WHERE session_log.collected_at IS NULL
+                  OR excluded.collected_at >= session_log.collected_at""",
             (
                 str(filepath), date, project_name,
                 parsed["duration_minutes"],
@@ -42515,12 +42522,17 @@ def _stable_workload_anchor(before, month):
     try:
         if path.exists():
             frozen = json.loads(path.read_text(encoding="utf-8"))
-            metrics = frozen.get("metrics") or {}
-            if (frozen.get("month") == month
+            metrics = frozen.get("metrics") if isinstance(frozen, dict) else None
+            if (isinstance(metrics, dict) and frozen.get("month") == month
                     and frozen.get("rates") == _WEIGHT_POOL_FLAT_RATES
-                    and all(k in metrics for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))):
+                    and all(isinstance(metrics.get(k), (int, float))
+                            and math.isfinite(metrics[k]) and metrics[k] >= 0
+                            for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))
+                    and metrics["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
+                    and metrics["api_calls"] > 0 and metrics["flat_usd"] > 0):
                 return metrics
-            return None  # a changed/corrupt anchor needs review, not replacement
+            # Backfill/rebuild can change the earliest covered month. Re-anchor
+            # from the same shared population instead of permanently hiding it.
         if (before and before["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
                 and before["api_calls"] > 0 and before["flat_usd"] > 0):
             _write_baseline_state(path, {"month": month, "metrics": before,
@@ -42716,6 +42728,12 @@ def _price_parent_activity_window(conn, start, end, tier):
     paths = conn.execute(
         "SELECT jsonl_path, date FROM session_log WHERE input_tokens IS NOT NULL "
         "AND COALESCE(is_sidechain,0)=0").fetchall()
+    # Include new sessions before bounded collection reaches them.
+    known = {str(name) for name, _ in paths}
+    for path, mtime, _ in _find_all_jsonl_files(8):
+        if str(path) not in known:
+            paths.append((str(path), datetime.fromtimestamp(mtime).date().isoformat()))
+            known.add(str(path))
     rows = []
     for name, recorded_date in paths:
         path = Path(name)
@@ -42727,10 +42745,16 @@ def _price_parent_activity_window(conn, start, end, tier):
         if max(p.stat().st_mtime for p in [path, *children]) < start.timestamp():
             continue
         parsed = _parse_session_jsonl(path, window_start=start, window_end=end)
-        if not parsed or not parsed.get("api_calls"):
+        if parsed and parsed.get("is_sidechain"):
             continue
+        if not parsed:
+            parsed = {"total_input_tokens": 0, "total_output_tokens": 0,
+                      "total_cache_create_1h": 0, "total_cache_create_5m": 0,
+                      "cache_hit_rate": 0, "model_usage": {}, "api_calls": 0,
+                      "message_count": 0}
         inp, out = parsed["total_input_tokens"], parsed["total_output_tokens"]
         cw1, cw5 = parsed["total_cache_create_1h"], parsed["total_cache_create_5m"]
+        child_cache_read = 0
         for child in children:
             cp = _parse_session_jsonl(child, window_start=start, window_end=end)
             if cp:
@@ -42738,8 +42762,13 @@ def _price_parent_activity_window(conn, start, end, tier):
                 out += cp["total_output_tokens"]
                 cw1 += cp["total_cache_create_1h"]
                 cw5 += cp["total_cache_create_5m"]
+                child_cache_read += cp["total_cache_read"]
+        if not parsed["api_calls"] and inp + out == 0:
+            continue
         usage = json.dumps(parsed["model_usage"])
-        rows.append((inp, out, cw5, cw1, parsed["cache_hit_rate"], usage, usage,
+        hit = (parsed["cache_hit_rate"] if parsed["api_calls"] else
+               child_cache_read / inp if inp else 0)
+        rows.append((inp, out, cw5, cw1, hit, usage, usage,
                      parsed["api_calls"], parsed["message_count"]))
     return _price_parent_rows(rows, tier)
 
@@ -42756,20 +42785,44 @@ def _weekly_full_savings(resets_at=None, now=None):
         end = datetime.fromtimestamp(now if now is not None else time.time(), timezone.utc)
         start = (datetime.fromtimestamp(float(resets_at), timezone.utc) - timedelta(days=7)
                  if resets_at is not None else end - timedelta(days=7))
-        if start >= end or (resets_at is not None and end.timestamp() >= float(resets_at)):
+        if resets_at is None or start >= end or end.timestamp() >= float(resets_at):
             return None
+        # Dashboard refreshes may run several times per minute in separate
+        # processes. Keep an explicitly dated result for at most 60 seconds.
+        cache_path = SNAPSHOT_DIR / "weekly_full_value.json"
+        anchor_path = SNAPSHOT_DIR / "workload_anchor.json"
+        anchor_stamp = anchor_path.stat().st_mtime_ns if anchor_path.exists() else None
+        if now is None and cache_path.exists():
+            try:
+                cached = json.loads(cache_path.read_text(encoding="utf-8"))
+                age = end.timestamp() - float(cached["computed_at"])
+                if (0 <= age < 60 and cached["start"] == start.isoformat()
+                        and cached["anchor_stamp"] == anchor_stamp
+                        and cached["version"] == TOKEN_OPTIMIZER_VERSION):
+                    return cached["value"]
+            except (OSError, ValueError, TypeError, KeyError):
+                pass
         pool = _session_weight_pool_savings(
             start.isoformat(), days=7, activity_window=(start, end))
-        if not pool or pool["transformation_usd"] <= 0:
+        if not pool:
             return None
         # Same conservative display cap as the Savings tab.
-        saving = min(pool["transformation_usd"], pool["actual_usd"])
-        return {"saved_usd": round(saving, 2), "start": start.isoformat(),
+        saving = max(0.0, min(pool["transformation_usd"], pool["actual_usd"]))
+        value = {"saved_usd": round(saving, 2), "start": start.isoformat(),
                 "end": end.isoformat(), "method": "full workload",
                 "uncapped_usd": round(pool["transformation_usd"], 2),
                 "actual_usd": round(pool["actual_usd"], 2),
                 "counterfactual_usd": round(pool["counterfactual_usd"], 2),
                 "api_calls": pool["now_units"], "anchor_month": pool["anchor_month"]}
+        if now is None:
+            try:
+                _write_baseline_state(cache_path, {
+                    "computed_at": end.timestamp(), "start": start.isoformat(),
+                    "anchor_stamp": anchor_path.stat().st_mtime_ns if anchor_path.exists() else None,
+                    "version": TOKEN_OPTIMIZER_VERSION, "value": value})
+            except OSError:
+                pass
+        return value
     except (OSError, sqlite3.Error, ValueError, TypeError, KeyError):
         return None
 

--- a/skills/token-optimizer/assets/dashboard.html
+++ b/skills/token-optimizer/assets/dashboard.html
@@ -4083,6 +4083,16 @@ var DB = (function() {
           '</div>' +
         '</div>';
       }).join('');
+      // Savings remain available when the quota meter has no weekly reading.
+      var standaloneWeek = rw.weekly_full_value;
+      if (standaloneWeek && Number(standaloneWeek.saved_usd) >= 15 &&
+          !(rw.windows || []).some(function (w) { return w.key === 'seven_day'; })) {
+        rwCards += '<div style="padding:var(--s-3);border:1px solid var(--c-border);border-radius:8px;">' +
+          '<div class="label">Weekly savings</div><div style="font-size:22px;color:var(--c-savings-alt,#10b981);">&asymp;' +
+          rwMoney(standaloneWeek.saved_usd) + ' estimated savings so far this week</div>' +
+          '<p>Full workload estimate since ' + esc(new Date(standaloneWeek.start).toLocaleString()) +
+          '. Your weekly limit reading is unavailable.</p></div>';
+      }
       // USD-per-window headline: the dollar figure reuses the metered
       // savings ledger, apportioned to each window's span. Build the headline
       // from the windows that carry a saved_usd; fall back to the demoted

--- a/skills/token-optimizer/assets/dashboard.html
+++ b/skills/token-optimizer/assets/dashboard.html
@@ -4011,7 +4011,7 @@ var DB = (function() {
     // unavailable meter used to vanish the whole card). runway_snapshot already
     // returns null when there is genuinely no story, so rw existing + a windows-
     // or-multiplier payload is the real render condition.
-    if (rw && (rwHasWindows || rwHasMultiplier)) {
+    if (rw && (rwHasWindows || rwHasMultiplier || rw.weekly_full_value)) {
       // Both sides are stated in the SAME unit (percent LEFT). An earlier revision
       // paired "89% left" against "16.6% used", which reads as a contradiction and
       // forces the reader to do the subtraction. The with/without pair is also the
@@ -4045,38 +4045,19 @@ var DB = (function() {
         // ledger has nothing to show; degrade to no line rather than $-0/NaN.
         var savedUsd = Number(w.saved_usd);
         var spanWord = w.key === 'five_hour' ? '5h' : 'week';
-        // Weekly $: shown whenever it is meaningful (>= $15) and NEVER gated on
-        // already being capped — at that size it is the overage you are on
-        // track to hit, not a hypothetical. Below $15 the line is noise: hide.
-        // The 5h window keeps the any-positive rule (its $ is already rare).
         var hasUsd = isFinite(savedUsd) && (w.key === 'five_hour' ? savedUsd > 0 : savedUsd >= 15);
-        // The per-window USD is the EXTRA you'd have paid in API credits to match
-        // this window's work WITHOUT Token Optimizer, priced over the window's OWN
-        // real span (the weekly card = the last 7 days, not a slice of a longer
-        // ledger). It is the API-equivalent savings delta, NOT total weekly cost
-        // and NOT strict post-cap overage; the explainer line + ESTIMATED $ chip
-        // carry that honesty. A big "$N more" number, a tiny "in API credits"
-        // caption, then a plain sentence that spells out the meaning.
-        // Honest per-window claim, conditional on whether the without-Optimizer arm
-        // would ACTUALLY have exceeded the cap this window. Capped => you'd have paid
-        // real overage (the value scenario). Not capped => the tokens removed have an
-        // API-rate value, but no bill was avoided; say so plainly (never claim overage
-        // that did not occur).
-        var usdExplainer = w.would_be_capped
-          ? ('Matching this ' + spanWord + '&rsquo;s work without Token Optimizer would have pushed you ' +
-             '<b style="color:var(--c-text-main);font-weight:500;">past your limit</b>. That&rsquo;s the extra you&rsquo;d have paid to do the same work.')
-          : (w.key === 'five_hour'
-             ? ('That&rsquo;s what this ' + spanWord + '&rsquo;s work would have cost you in API credits ' +
-                'without Token Optimizer &mdash; compute it kept off your plan. ' +
-                '<b style="color:var(--c-text-main);font-weight:500;">The harder you push your limits, ' +
-                'the more it saves you from paying to keep going.</b>')
-             : ('At this pace, doing this week&rsquo;s work without Token Optimizer ' +
-                '<b style="color:var(--c-text-main);font-weight:500;">would blow past your weekly limit</b> ' +
-                '&mdash; that&rsquo;s the API-credit overage you&rsquo;re on track to avoid.'));
+        var usdCaption = w.key === 'seven_day'
+          ? 'estimated savings so far this week' : 'of API-credit value kept off this 5h';
+        var usdExplainer = w.full_value
+          ? 'Estimated extra cost in API credits to do this week’s work without Token Optimizer. Includes the effects of lighter context, fewer repeat reads and your working habits, counted once.'
+          : 'API-equivalent value of the savings recorded in this window, including the available estimates.';
+        if (w.full_value && w.full_value.start) {
+          usdExplainer += ' Since ' + esc(new Date(w.full_value.start).toLocaleString([], {month:'short', day:'numeric', hour:'numeric', minute:'2-digit'})) + '.';
+        }
         return '<div style="background:rgba(255,255,255,.02);border:1px solid var(--c-border);border-radius:8px;padding:var(--s-3);">' +
           '<div class="label" style="display:block;margin-bottom:var(--s-3);">' + name + '</div>' +
           (hasUsd
-            ? '<div style="margin-bottom:6px;font-size:22px;font-weight:500;color:var(--c-savings-alt, #10b981);line-height:1.2;">&asymp;' + rwMoney(savedUsd) + (w.would_be_capped ? ' more <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">in API credits</span>' : (w.key === 'five_hour' ? ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">of API-credit value kept off this ' + spanWord + '</span>' : ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">of overage you&rsquo;re on track to avoid this week</span>')) + '</div>' +
+            ? '<div style="margin-bottom:6px;font-size:22px;font-weight:500;color:var(--c-savings-alt, #10b981);line-height:1.2;">&asymp;' + rwMoney(savedUsd) + ' <span style="font-size:13px;color:var(--c-text-dim);font-weight:400;">' + usdCaption + '</span>' + '</div>' +
               '<div style="margin-bottom:var(--s-3);font-size:13px;color:var(--c-text-dim);line-height:1.5;text-wrap:pretty;">' + usdExplainer + '</div>'
             : '') +
           '<div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:var(--s-3);">' +

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -9733,7 +9733,7 @@ def _osrc_prompt_text(record):
     return ""
 
 
-def _parse_session_jsonl(filepath):
+def _parse_session_jsonl(filepath, window_start=None, window_end=None):
     """Parse a single JSONL session file in one streaming pass.
 
     Returns a dict with extracted session metrics, or None if the file
@@ -9744,7 +9744,7 @@ def _parse_session_jsonl(filepath):
     # Memoization: skip re-parse if the file hasn't changed since we last saw it.
     try:
         st = os.stat(filepath)
-        cache_key = (str(filepath), st.st_mtime_ns, st.st_size)
+        cache_key = (str(filepath), st.st_mtime_ns, st.st_size, window_start, window_end)
         if cache_key in _parse_session_jsonl_cache:
             return _parse_session_jsonl_cache[cache_key]
     except OSError:
@@ -9840,6 +9840,21 @@ def _parse_session_jsonl(filepath):
                     s = record.get("slug")
                     if s:
                         slug = s
+
+                # Window reports must slice activity, including sessions that began
+                # before reset. Classify sidechains before filtering their records.
+                if window_start is not None or window_end is not None:
+                    try:
+                        activity_ts = datetime.fromisoformat(
+                            str(record.get("timestamp")).replace("Z", "+00:00"))
+                        if activity_ts.tzinfo is None:
+                            activity_ts = activity_ts.replace(tzinfo=timezone.utc)
+                    except (ValueError, TypeError):
+                        continue
+                    if window_start is not None and activity_ts < window_start:
+                        continue
+                    if window_end is not None and activity_ts >= window_end:
+                        continue
 
                 # Extract timestamp
                 ts_str = record.get("timestamp")
@@ -18728,12 +18743,19 @@ def _get_savings_summary(days=30, since=None):
 
 
 def _is_file_collected(conn, jsonl_path):
-    """Check if a JSONL file has already been collected."""
-    cur = conn.execute(
-        "SELECT 1 FROM session_log WHERE jsonl_path = ?",
+    """Skip only unchanged sessions, including their delegated transcripts."""
+    row = conn.execute(
+        "SELECT collected_at FROM session_log WHERE jsonl_path = ?",
         (str(jsonl_path),),
-    )
-    return cur.fetchone() is not None
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        collected = datetime.fromisoformat(row[0]).timestamp()
+        paths = [Path(jsonl_path), *_find_subagent_jsonl_files(jsonl_path)]
+        return all(path.stat().st_mtime <= collected for path in paths)
+    except (OSError, TypeError, ValueError):
+        return False
 
 
 def _insert_normalized_session(conn, dedup_key, parsed, platform, project_fallback, quiet=False):
@@ -20225,7 +20247,7 @@ def _collect_antigravity_sessions(days=90, quiet=False, rebuild=False):
 def collect_sessions(days=90, quiet=False, rebuild=False):
     """Parse new JSONL files and insert into SQLite. Zero token cost.
 
-    Skips files already collected. Safe to run repeatedly.
+    Refreshes changed files in place. Safe to run repeatedly.
     With rebuild=True, drops and re-collects all data (e.g., after a
     measurement fix such as model attribution).
     """
@@ -20245,6 +20267,12 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
         return _collect_grok_sessions(days=days, quiet=quiet, rebuild=rebuild)
 
     conn = _init_trends_db()
+
+    # Capture the existing comparison before refreshing historical session rows.
+    # The user's baseline must not move as collection catches up.
+    if not rebuild:
+        _session_weight_pool_savings(
+            (datetime.now() - timedelta(days=30)).date().isoformat())
 
     # One-time migration for the model attribution fix: wipe model_daily (safe, fast, no data loss)
     if _needs_model_daily_rebuild(conn):
@@ -20288,7 +20316,9 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
         if _COLLECT_MAX_PER_RUN and not rebuild and new_count >= _COLLECT_MAX_PER_RUN:
             break
 
-        parsed = _parse_session_jsonl(filepath)
+        collection_started = datetime.now().isoformat()
+        # Rollups must not mutate the parser cache when only a child grows.
+        parsed = copy.deepcopy(_parse_session_jsonl(filepath))
         if not parsed:
             continue
 
@@ -20353,7 +20383,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
         # Insert session_log
         cur = conn.execute(
-            """INSERT OR IGNORE INTO session_log
+            """INSERT INTO session_log
                (jsonl_path, date, project, duration_minutes, input_tokens,
                 output_tokens, message_count, api_calls, cache_hit_rate,
                 cache_create_1h_tokens, cache_create_5m_tokens, cache_ttl_scanned,
@@ -20363,7 +20393,40 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                     quality_score, quality_grade, stale_waste_tokens, is_sidechain,
                     sidechain_reason, reported_input_tokens, reported_output_tokens,
                     reported_model_usage_json, platform)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(jsonl_path) DO UPDATE SET
+               project=excluded.project,
+               duration_minutes=excluded.duration_minutes,
+               input_tokens=excluded.input_tokens,
+               output_tokens=excluded.output_tokens,
+               message_count=excluded.message_count,
+               api_calls=excluded.api_calls,
+               cache_hit_rate=excluded.cache_hit_rate,
+               cache_create_1h_tokens=excluded.cache_create_1h_tokens,
+               cache_create_5m_tokens=excluded.cache_create_5m_tokens,
+               cache_ttl_scanned=excluded.cache_ttl_scanned,
+               avg_call_gap_seconds=excluded.avg_call_gap_seconds,
+               max_call_gap_seconds=excluded.max_call_gap_seconds,
+               p95_call_gap_seconds=excluded.p95_call_gap_seconds,
+               skills_json=excluded.skills_json,
+               subagents_json=excluded.subagents_json,
+               tool_calls_json=excluded.tool_calls_json,
+               model_usage_json=excluded.model_usage_json,
+               all_model_usage_json=excluded.all_model_usage_json,
+               model_usage_breakdown_json=excluded.model_usage_breakdown_json,
+               version=excluded.version,
+               slug=excluded.slug,
+               topic=excluded.topic,
+               collected_at=excluded.collected_at,
+               quality_score=excluded.quality_score,
+               quality_grade=excluded.quality_grade,
+               stale_waste_tokens=excluded.stale_waste_tokens,
+               is_sidechain=excluded.is_sidechain,
+               sidechain_reason=excluded.sidechain_reason,
+               reported_input_tokens=excluded.reported_input_tokens,
+               reported_output_tokens=excluded.reported_output_tokens,
+               reported_model_usage_json=excluded.reported_model_usage_json,
+               platform=excluded.platform""",
             (
                 str(filepath), date, project_name,
                 parsed["duration_minutes"],
@@ -20387,7 +20450,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                 parsed["version"],
                 parsed.get("slug"),
                 parsed.get("topic"),
-                datetime.now().isoformat(),
+                collection_started,
                 sq["score"],
                 sq["grade"],
                 int(stale_waste or 0),
@@ -39647,6 +39710,9 @@ def runway_snapshot(days=30, now=None):
         meter_available = bool(meters.get("available"))
         meter_stale = bool(meters.get("stale")) or not meter_available
 
+        weekly_full = _weekly_full_savings(
+            resets_at=meters.get("seven_day_resets_at"), now=now)
+
         # --- context lever: measured, never estimated ---
         consumed = saved = 0
         spent_basis = None
@@ -39668,19 +39734,21 @@ def runway_snapshot(days=30, now=None):
                 conn.close()
         except Exception:
             return None
-        if consumed <= 0:
+        if consumed <= 0 and not weekly_full:
             return None
-        context_mult = (consumed + saved) / consumed
+        context_mult = (consumed + saved) / consumed if consumed > 0 else 1.0
 
         # --- routing lever: this user's own shift, priced by input rates ---
         routing_mult = _input_rate_mix_ratio(days=days)
         if routing_mult is None or routing_mult <= 0:
-            return None
+            if not weekly_full:
+                return None
+            routing_mult = 1.0
 
         mult = context_mult * routing_mult
         # Below ~1.02 there is no story worth telling and rounding noise would
         # dominate; say nothing rather than dress up a rounding artefact.
-        if mult < 1.02:
+        if mult < 1.02 and not weekly_full:
             return None
 
         # --- USD-per-window: API-credit OVERAGE over each window's OWN real span ---
@@ -39758,7 +39826,7 @@ def runway_snapshot(days=30, now=None):
                     # -- real, magnitude-metered (v5.13.1) savings that were simply
                     # unlabelled. Window-scoped already (days/since passed above).
                     _rl = wm.get("resume_lean_estimated") or {}
-                    _vs = wm.get("verbosity_steer_estimated") or {}
+                    _vs = wm.get("verbosity_steer") or wm.get("verbosity_steer_estimated") or {}
                     est_add = float(_rl.get("cost_saved_usd", 0.0) or 0.0) \
                         + float(_vs.get("cost_saved_usd", 0.0) or 0.0)
                 except Exception:
@@ -39790,6 +39858,9 @@ def runway_snapshot(days=30, now=None):
                 # trigger is counterfactual even though the magnitude is metered.
                 ctx += est_add
                 est_added = est_add > 0.0
+                if wdays == 7 and weekly_full:
+                    ctx, rt = weekly_full["saved_usd"], 0.0
+                    est_added = True
                 _overage_cache[cache_key] = (ctx, rt, repriced, counted_window, est_added)
             ctx, rt, repriced, counted_window, est_added = _overage_cache[cache_key]
             total = ctx + rt
@@ -39847,6 +39918,7 @@ def runway_snapshot(days=30, now=None):
                 "would_be_capped": head_cf <= 0.5,
                 "saved_usd": window_saved_usd,
                 "saved_usd_tier": window_usd_tier,
+                "full_value": weekly_full if key == "seven_day" else None,
             })
         # REGRESSION FIX (the "Your plan goes further" card vanished after a quiet
         # week): the per-window guard above drops the 5h window once the meter is
@@ -39919,7 +39991,9 @@ def runway_snapshot(days=30, now=None):
             "saved_usd_context": round(saved_context_usd, 2),
             "saved_usd_routing": round(saved_routing_usd, 2),
             "saved_usd_tier": saved_usd_tier,
+            "weekly_full_value": weekly_full,
             "window_savings_basis": (
+                "full workload, exact subscription week" if weekly_full else
                 "counted transcript window" if _wk_counted else "flat savings ledger fallback"),
             # period_days scopes the throughput MULTIPLIERS (context/routing), not
             # the per-window dollars: each window now prices overage over its OWN
@@ -39938,13 +40012,17 @@ def runway_snapshot(days=30, now=None):
             # longer repeats it. Keep the phrases "metered savings ledger" and "not
             # derived from the throughput multipliers" -- guarded by
             # test_proxy_disclosure_mentions_ledger_reuse.
-            "proxy": ("Your window usage is measured; the “without” "
+            "proxy": ("Weekly dollars use the Savings tab's full workload estimate for activity "
+                      "since the subscription reset, at constant prices. Measured and estimated "
+                      "effects overlap, so they are counted once. This is accrued API-equivalent "
+                      "value, not a forecast or an overage bill. The headline percentage covers "
+                      "30 days; window comparisons are estimates." if weekly_full else ("Your window usage is measured; the “without” "
                       "comparison and routing dollars are estimated (the provider "
                       "does not publish how it weights models inside a window, so "
                       "public input-rate ratios stand in). Per-window dollars reuse "
                       "the metered savings ledger (context tokens never sent, priced "
                       "at input rates, plus a routing estimate) and are not derived "
-                      "from the throughput multipliers."),
+                      "from the throughput multipliers.")),
         }
     except Exception:
         return None
@@ -42389,6 +42467,10 @@ def _price_parent_window(conn, where, params, tier):
         "FROM session_log WHERE input_tokens IS NOT NULL "
         "AND COALESCE(is_sidechain, 0) = 0 " + where, params
     ).fetchall()
+    return _price_parent_rows(rows, tier)
+
+
+def _price_parent_rows(rows, tier):
     if not rows:
         return None
     default_model = _default_model_for_runtime()
@@ -42427,7 +42509,29 @@ def _price_parent_window(conn, where, params, tier):
             "flat_usd": flat_usd, "api_calls": api_calls, "messages": messages}
 
 
-def _session_weight_pool_savings(cutoff, days=30, tier=None):
+def _stable_workload_anchor(before, month):
+    """Keep the existing workload comparison stable during session refreshes."""
+    path = SNAPSHOT_DIR / "workload_anchor.json"
+    try:
+        if path.exists():
+            frozen = json.loads(path.read_text(encoding="utf-8"))
+            metrics = frozen.get("metrics") or {}
+            if (frozen.get("month") == month
+                    and frozen.get("rates") == _WEIGHT_POOL_FLAT_RATES
+                    and all(k in metrics for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))):
+                return metrics
+            return None  # a changed/corrupt anchor needs review, not replacement
+        if (before and before["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
+                and before["api_calls"] > 0 and before["flat_usd"] > 0):
+            _write_baseline_state(path, {"month": month, "metrics": before,
+                                        "rates": _WEIGHT_POOL_FLAT_RATES,
+                                        "captured_at": datetime.now().isoformat()})
+        return before
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def _session_weight_pool_savings(cutoff, days=30, tier=None, activity_window=None):
     """THE volume lever: cost per UNIT OF WORK, over the whole parent population.
 
     The frozen-anchor pool holds session volume constant across both arms by
@@ -42493,7 +42597,10 @@ def _session_weight_pool_savings(cutoff, days=30, tier=None):
                 return None
             before = _price_parent_window(
                 conn, "AND date LIKE ?", (anchor_month + "%",), tier)
-            now = _price_parent_window(conn, "AND date >= ?", (cutoff,), tier)
+            before = _stable_workload_anchor(before, anchor_month)
+            now = (_price_parent_activity_window(conn, *activity_window, tier)
+                   if activity_window else
+                   _price_parent_window(conn, "AND date >= ?", (cutoff,), tier))
         finally:
             conn.close()
         if not before or not now:
@@ -42596,6 +42703,74 @@ def _session_weight_pool_savings(cutoff, days=30, tier=None):
             "capacity_assumption": capacity_note,
         }
     except (sqlite3.Error, OSError, ValueError, TypeError, ZeroDivisionError):
+        return None
+
+
+def _price_parent_activity_window(conn, start, end, tier):
+    """Use real in-window activity with the standard parent/child pricing rules.
+
+    Reading transcripts here also keeps a weekly report correct while bounded
+    background collection catches up. Missing files produce an unavailable
+    estimate instead of silently treating missing work as zero cost.
+    """
+    paths = conn.execute(
+        "SELECT jsonl_path, date FROM session_log WHERE input_tokens IS NOT NULL "
+        "AND COALESCE(is_sidechain,0)=0").fetchall()
+    rows = []
+    for name, recorded_date in paths:
+        path = Path(name)
+        if not path.exists():
+            if str(recorded_date) < start.date().isoformat():
+                continue
+            return None
+        children = _find_subagent_jsonl_files(path)
+        if max(p.stat().st_mtime for p in [path, *children]) < start.timestamp():
+            continue
+        parsed = _parse_session_jsonl(path, window_start=start, window_end=end)
+        if not parsed or not parsed.get("api_calls"):
+            continue
+        inp, out = parsed["total_input_tokens"], parsed["total_output_tokens"]
+        cw1, cw5 = parsed["total_cache_create_1h"], parsed["total_cache_create_5m"]
+        for child in children:
+            cp = _parse_session_jsonl(child, window_start=start, window_end=end)
+            if cp:
+                inp += cp["total_input_tokens"]
+                out += cp["total_output_tokens"]
+                cw1 += cp["total_cache_create_1h"]
+                cw5 += cp["total_cache_create_5m"]
+        usage = json.dumps(parsed["model_usage"])
+        rows.append((inp, out, cw5, cw1, parsed["cache_hit_rate"], usage, usage,
+                     parsed["api_calls"], parsed["message_count"]))
+    return _price_parent_rows(rows, tier)
+
+
+def _weekly_full_savings(resets_at=None, now=None):
+    """The Savings tab's full estimate, accrued inside this subscription week.
+
+    Its before/after difference already includes overlapping measured and
+    estimated mechanisms. Never add their individual estimates on top.
+    """
+    if detect_runtime() != "claude":
+        return None
+    try:
+        end = datetime.fromtimestamp(now if now is not None else time.time(), timezone.utc)
+        start = (datetime.fromtimestamp(float(resets_at), timezone.utc) - timedelta(days=7)
+                 if resets_at is not None else end - timedelta(days=7))
+        if start >= end or (resets_at is not None and end.timestamp() >= float(resets_at)):
+            return None
+        pool = _session_weight_pool_savings(
+            start.isoformat(), days=7, activity_window=(start, end))
+        if not pool or pool["transformation_usd"] <= 0:
+            return None
+        # Same conservative display cap as the Savings tab.
+        saving = min(pool["transformation_usd"], pool["actual_usd"])
+        return {"saved_usd": round(saving, 2), "start": start.isoformat(),
+                "end": end.isoformat(), "method": "full workload",
+                "uncapped_usd": round(pool["transformation_usd"], 2),
+                "actual_usd": round(pool["actual_usd"], 2),
+                "counterfactual_usd": round(pool["counterfactual_usd"], 2),
+                "api_calls": pool["now_units"], "anchor_month": pool["anchor_month"]}
+    except (OSError, sqlite3.Error, ValueError, TypeError, KeyError):
         return None
 
 

--- a/skills/token-optimizer/scripts/measure.py
+++ b/skills/token-optimizer/scripts/measure.py
@@ -9751,6 +9751,8 @@ def _parse_session_jsonl(filepath, window_start=None, window_end=None):
         cache_key = None  # stat failed — parse without caching
 
     if _use_codex_session_adapter(filepath):
+        if window_start is not None or window_end is not None:
+            return None  # This adapter does not yet support activity slicing.
         result = codex_session.parse_session_jsonl(filepath)
         if cache_key is not None:
             if len(_parse_session_jsonl_cache) >= _PARSE_CACHE_MAX:
@@ -18742,17 +18744,20 @@ def _get_savings_summary(days=30, since=None):
         }
 
 
-def _is_file_collected(conn, jsonl_path):
-    """Skip only unchanged sessions, including their delegated transcripts."""
+def _is_file_collected(conn, jsonl_path, check_mtime=False):
+    """Check stored IDs; file collectors also check delegated transcript changes."""
     row = conn.execute(
         "SELECT collected_at FROM session_log WHERE jsonl_path = ?",
         (str(jsonl_path),),
     ).fetchone()
     if row is None:
         return False
+    if not check_mtime:
+        return True  # Other adapters use synthetic IDs, not filesystem paths.
     try:
         collected = datetime.fromisoformat(row[0]).timestamp()
-        paths = [Path(jsonl_path), *_find_subagent_jsonl_files(jsonl_path)]
+        path = Path(jsonl_path)
+        paths = [path, *_find_subagent_jsonl_files(path)]
         return all(path.stat().st_mtime <= collected for path in paths)
     except (OSError, TypeError, ValueError):
         return False
@@ -20270,7 +20275,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
     # Capture the existing comparison before refreshing historical session rows.
     # The user's baseline must not move as collection catches up.
-    if not rebuild:
+    if not rebuild and not (SNAPSHOT_DIR / "workload_anchor.json").exists():
         _session_weight_pool_savings(
             (datetime.now() - timedelta(days=30)).date().isoformat())
 
@@ -20306,7 +20311,7 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
 
     new_count = 0
     for filepath, mtime, project_name in files:
-        if _is_file_collected(conn, filepath):
+        if _is_file_collected(conn, filepath, check_mtime=True):
             continue
 
         # Bounded per-run collection: never parse more than _COLLECT_MAX_PER_RUN new
@@ -20426,7 +20431,9 @@ def collect_sessions(days=90, quiet=False, rebuild=False):
                reported_input_tokens=excluded.reported_input_tokens,
                reported_output_tokens=excluded.reported_output_tokens,
                reported_model_usage_json=excluded.reported_model_usage_json,
-               platform=excluded.platform""",
+               platform=excluded.platform
+               WHERE session_log.collected_at IS NULL
+                  OR excluded.collected_at >= session_log.collected_at""",
             (
                 str(filepath), date, project_name,
                 parsed["duration_minutes"],
@@ -42515,12 +42522,17 @@ def _stable_workload_anchor(before, month):
     try:
         if path.exists():
             frozen = json.loads(path.read_text(encoding="utf-8"))
-            metrics = frozen.get("metrics") or {}
-            if (frozen.get("month") == month
+            metrics = frozen.get("metrics") if isinstance(frozen, dict) else None
+            if (isinstance(metrics, dict) and frozen.get("month") == month
                     and frozen.get("rates") == _WEIGHT_POOL_FLAT_RATES
-                    and all(k in metrics for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))):
+                    and all(isinstance(metrics.get(k), (int, float))
+                            and math.isfinite(metrics[k]) and metrics[k] >= 0
+                            for k in ("sessions", "usd", "tokens", "flat_usd", "api_calls", "messages"))
+                    and metrics["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
+                    and metrics["api_calls"] > 0 and metrics["flat_usd"] > 0):
                 return metrics
-            return None  # a changed/corrupt anchor needs review, not replacement
+            # Backfill/rebuild can change the earliest covered month. Re-anchor
+            # from the same shared population instead of permanently hiding it.
         if (before and before["sessions"] >= _SESSION_WEIGHT_MIN_ANCHOR_SESSIONS
                 and before["api_calls"] > 0 and before["flat_usd"] > 0):
             _write_baseline_state(path, {"month": month, "metrics": before,
@@ -42716,6 +42728,12 @@ def _price_parent_activity_window(conn, start, end, tier):
     paths = conn.execute(
         "SELECT jsonl_path, date FROM session_log WHERE input_tokens IS NOT NULL "
         "AND COALESCE(is_sidechain,0)=0").fetchall()
+    # Include new sessions before bounded collection reaches them.
+    known = {str(name) for name, _ in paths}
+    for path, mtime, _ in _find_all_jsonl_files(8):
+        if str(path) not in known:
+            paths.append((str(path), datetime.fromtimestamp(mtime).date().isoformat()))
+            known.add(str(path))
     rows = []
     for name, recorded_date in paths:
         path = Path(name)
@@ -42727,10 +42745,16 @@ def _price_parent_activity_window(conn, start, end, tier):
         if max(p.stat().st_mtime for p in [path, *children]) < start.timestamp():
             continue
         parsed = _parse_session_jsonl(path, window_start=start, window_end=end)
-        if not parsed or not parsed.get("api_calls"):
+        if parsed and parsed.get("is_sidechain"):
             continue
+        if not parsed:
+            parsed = {"total_input_tokens": 0, "total_output_tokens": 0,
+                      "total_cache_create_1h": 0, "total_cache_create_5m": 0,
+                      "cache_hit_rate": 0, "model_usage": {}, "api_calls": 0,
+                      "message_count": 0}
         inp, out = parsed["total_input_tokens"], parsed["total_output_tokens"]
         cw1, cw5 = parsed["total_cache_create_1h"], parsed["total_cache_create_5m"]
+        child_cache_read = 0
         for child in children:
             cp = _parse_session_jsonl(child, window_start=start, window_end=end)
             if cp:
@@ -42738,8 +42762,13 @@ def _price_parent_activity_window(conn, start, end, tier):
                 out += cp["total_output_tokens"]
                 cw1 += cp["total_cache_create_1h"]
                 cw5 += cp["total_cache_create_5m"]
+                child_cache_read += cp["total_cache_read"]
+        if not parsed["api_calls"] and inp + out == 0:
+            continue
         usage = json.dumps(parsed["model_usage"])
-        rows.append((inp, out, cw5, cw1, parsed["cache_hit_rate"], usage, usage,
+        hit = (parsed["cache_hit_rate"] if parsed["api_calls"] else
+               child_cache_read / inp if inp else 0)
+        rows.append((inp, out, cw5, cw1, hit, usage, usage,
                      parsed["api_calls"], parsed["message_count"]))
     return _price_parent_rows(rows, tier)
 
@@ -42756,20 +42785,44 @@ def _weekly_full_savings(resets_at=None, now=None):
         end = datetime.fromtimestamp(now if now is not None else time.time(), timezone.utc)
         start = (datetime.fromtimestamp(float(resets_at), timezone.utc) - timedelta(days=7)
                  if resets_at is not None else end - timedelta(days=7))
-        if start >= end or (resets_at is not None and end.timestamp() >= float(resets_at)):
+        if resets_at is None or start >= end or end.timestamp() >= float(resets_at):
             return None
+        # Dashboard refreshes may run several times per minute in separate
+        # processes. Keep an explicitly dated result for at most 60 seconds.
+        cache_path = SNAPSHOT_DIR / "weekly_full_value.json"
+        anchor_path = SNAPSHOT_DIR / "workload_anchor.json"
+        anchor_stamp = anchor_path.stat().st_mtime_ns if anchor_path.exists() else None
+        if now is None and cache_path.exists():
+            try:
+                cached = json.loads(cache_path.read_text(encoding="utf-8"))
+                age = end.timestamp() - float(cached["computed_at"])
+                if (0 <= age < 60 and cached["start"] == start.isoformat()
+                        and cached["anchor_stamp"] == anchor_stamp
+                        and cached["version"] == TOKEN_OPTIMIZER_VERSION):
+                    return cached["value"]
+            except (OSError, ValueError, TypeError, KeyError):
+                pass
         pool = _session_weight_pool_savings(
             start.isoformat(), days=7, activity_window=(start, end))
-        if not pool or pool["transformation_usd"] <= 0:
+        if not pool:
             return None
         # Same conservative display cap as the Savings tab.
-        saving = min(pool["transformation_usd"], pool["actual_usd"])
-        return {"saved_usd": round(saving, 2), "start": start.isoformat(),
+        saving = max(0.0, min(pool["transformation_usd"], pool["actual_usd"]))
+        value = {"saved_usd": round(saving, 2), "start": start.isoformat(),
                 "end": end.isoformat(), "method": "full workload",
                 "uncapped_usd": round(pool["transformation_usd"], 2),
                 "actual_usd": round(pool["actual_usd"], 2),
                 "counterfactual_usd": round(pool["counterfactual_usd"], 2),
                 "api_calls": pool["now_units"], "anchor_month": pool["anchor_month"]}
+        if now is None:
+            try:
+                _write_baseline_state(cache_path, {
+                    "computed_at": end.timestamp(), "start": start.isoformat(),
+                    "anchor_stamp": anchor_path.stat().st_mtime_ns if anchor_path.exists() else None,
+                    "version": TOKEN_OPTIMIZER_VERSION, "value": value})
+            except OSError:
+                pass
+        return value
     except (OSError, sqlite3.Error, ValueError, TypeError, KeyError):
         return None
 

--- a/tests/test_runtime_env_wsl_mnt.py
+++ b/tests/test_runtime_env_wsl_mnt.py
@@ -37,6 +37,7 @@ import sys
 import tempfile
 from contextlib import redirect_stderr
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -162,6 +163,8 @@ def test_non_wsl_mnt_rejected_with_warning():
     tmp = Path(tempfile.mkdtemp(prefix="t_nonwsl_mnt_"))
     mnt = _make_mnt_tree(tmp, "mnt")
     copilot_dir = _make_mnt_tree(mnt, "c/Users/asaf/.copilot")
+    # Keep the simulated mount outside HOME even when TMPDIR is under HOME.
+    home = _make_mnt_tree(tmp, "home")
 
     def body(mnt_root):
         os.environ["COPILOT_HOME"] = str(copilot_dir)
@@ -174,7 +177,8 @@ def test_non_wsl_mnt_rejected_with_warning():
         assert "rejected" in buf.getvalue().lower(), \
             f"non-WSL /mnt must warn, got: {buf.getvalue()!r}"
 
-    _with_env(wsl=False, mnt_root=mnt, fn=body)
+    with patch.object(Path, "home", return_value=home):
+        _with_env(wsl=False, mnt_root=mnt, fn=body)
 
 
 def test_non_wsl_mnt_helper_returns_none():

--- a/tests/test_session_log_platform.py
+++ b/tests/test_session_log_platform.py
@@ -178,8 +178,8 @@ def test_main_claude_insert_includes_platform():
     collect_end = src.index("\ndef ", collect_start + 1)
     collect_section = src[collect_start:collect_end]
 
-    # Find the INSERT OR IGNORE INTO session_log in the main collector
-    assert "INSERT OR IGNORE INTO session_log" in collect_section, (
+    # Find the INSERT INTO session_log in the main collector
+    assert "INSERT INTO session_log" in collect_section, (
         "main collector must have an INSERT into session_log"
     )
     # The INSERT must include platform as a column

--- a/tests/test_weekly_full_savings.py
+++ b/tests/test_weekly_full_savings.py
@@ -1,0 +1,135 @@
+"""Growing sessions and exact-week full-value regression coverage."""
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from test_runway_resume_lean_addback import measure, _wire
+
+
+def _turn(rid, ts, output=10, input_tokens=1000):
+    return {'type': 'assistant', 'timestamp': ts, 'requestId': rid,
+            'message': {'id': rid, 'model': 'claude-opus-4-6', 'content': [],
+                        'usage': {'input_tokens': input_tokens, 'output_tokens': output}}}
+
+
+def test_collector_refreshes_growing_session_without_duplicating(measure, monkeypatch, tmp_path):
+    p = tmp_path / 'growing.jsonl'
+    p.write_text(json.dumps(_turn('one', '2026-09-04T00:00:00Z'))+'\n')
+    monkeypatch.setattr(measure, '_find_all_jsonl_files', lambda days: [(p, p.stat().st_mtime, 'test')])
+    monkeypatch.setattr(measure, '_find_subagent_jsonl_files', lambda p: [])
+    measure.collect_sessions(quiet=True)
+    with p.open('a') as f:
+        f.write(json.dumps(_turn('two', '2026-09-04T00:01:00Z'))+'\n')
+    measure.collect_sessions(quiet=True)
+    c = sqlite3.connect(measure.TRENDS_DB)
+    assert c.execute('SELECT count(*), sum(api_calls) FROM session_log').fetchone() == (1, 2)
+    assert measure.collect_sessions(quiet=True) == 0
+    assert c.execute('SELECT count(*), sum(api_calls) FROM session_log').fetchone() == (1, 2)
+    c.close()
+
+
+def test_window_parser_excludes_outside_activity_and_dedups_streaming(measure, tmp_path):
+    p = tmp_path / 'cross-reset.jsonl'
+    rows = [_turn('before', '2026-09-03T16:59:00Z'),
+            _turn('inside', '2026-09-03T17:01:00Z', output=2),
+            _turn('inside', '2026-09-03T17:01:01Z', output=10),
+            _turn('after', '2026-09-10T17:00:00Z')]
+    p.write_text('\n'.join(map(json.dumps, rows)))
+    start = datetime(2026, 9, 3, 17, tzinfo=timezone.utc)
+    end = start + timedelta(days=7)
+    parsed = measure._parse_session_jsonl(p, window_start=start, window_end=end)
+    assert parsed['api_calls'] == 1
+    assert parsed['total_output_tokens'] == 10
+    assert measure._parse_session_jsonl(p)['api_calls'] == 3  # cache must be window-specific
+
+
+def test_weekly_full_value_replaces_overlapping_component_sum(measure, monkeypatch):
+    _wire(measure, monkeypatch, resume_lean_usd=18.32)
+    monkeypatch.setattr(measure, '_weekly_full_savings', lambda **kw: {
+        'saved_usd': 200.62, 'start': '2026-09-03T17:00:00+00:00',
+        'end': '2026-09-08T00:00:00+00:00', 'method': 'full workload',
+    }, raising=False)
+    snap = measure.runway_snapshot()
+    wk = next(w for w in snap['windows'] if w['key'] == 'seven_day')
+    assert wk['saved_usd'] == 200.62  # not 37.10, nor 200.62 + 37.10
+    assert snap['saved_usd_context'] + snap['saved_usd_routing'] == 200.62
+    assert next(w for w in snap['windows'] if w['key'] == 'five_hour')['saved_usd'] is None
+
+
+def test_activity_window_uses_grown_old_session_and_includes_child(measure, monkeypatch, tmp_path):
+    parent, child = tmp_path / 'parent.jsonl', tmp_path / 'child.jsonl'
+    parent.write_text('\n'.join(map(json.dumps, [
+        _turn('before', '2026-09-03T16:59:00Z', input_tokens=999999),
+        _turn('inside', '2026-09-03T17:01:00Z'),
+        _turn('after', '2026-09-10T17:00:00Z', input_tokens=999999)])))
+    child.write_text(json.dumps(_turn('child', '2026-09-03T17:02:00Z', input_tokens=500)))
+    monkeypatch.setattr(measure, '_find_subagent_jsonl_files', lambda p: [child] if str(p)==str(parent) else [])
+    c=measure._init_trends_db()
+    c.execute("INSERT INTO session_log (jsonl_path,date,input_tokens,output_tokens,api_calls) VALUES (?,?,?,?,?)", (str(parent),'2026-08-01',1,0,1))
+    c.commit()
+    start=datetime(2026,9,3,17,tzinfo=timezone.utc)
+    result=measure._price_parent_activity_window(c,start,start+timedelta(days=7),'anthropic')
+    c.close()
+    assert result['api_calls']==1
+    assert result['tokens']==1520
+    assert result['flat_usd']==pytest.approx(0.008)
+
+
+def test_full_week_uses_shared_baseline_and_real_activity(measure, monkeypatch, tmp_path):
+    monkeypatch.setenv('TOKEN_OPTIMIZER_RUNTIME','claude')
+    monkeypatch.setattr(measure,'detect_runtime',lambda:'claude')
+    monkeypatch.setattr(measure,'_SESSION_WEIGHT_MIN_ANCHOR_SESSIONS',2)
+    monkeypatch.setattr(measure,'_AFTER_MIN_SESSIONS',1)
+    p=tmp_path/'weekly.jsonl'
+    p.write_text(json.dumps(_turn('one','2026-09-04T00:00:00Z')))
+    monkeypatch.setattr(measure,'_find_subagent_jsonl_files',lambda p:[])
+    c=measure._init_trends_db()
+    for i in range(2):
+        c.execute('INSERT INTO session_log (jsonl_path,date,input_tokens,output_tokens,api_calls,cache_hit_rate,model_usage_json) VALUES (?,?,?,?,?,?,?)',
+            (str(tmp_path/f'anchor{i}'),'2026-06-01',10000,10,1,0,'{"opus":10010}'))
+    c.execute('INSERT INTO session_log (jsonl_path,date,input_tokens,output_tokens,api_calls) VALUES (?,?,?,?,?)',
+        (str(p),'2026-09-01',1,0,1))
+    c.commit();c.close()
+    # Baseline source files may have been archived; only current-period gaps
+    # make activity coverage incomplete.
+    start=datetime(2026,9,3,17,tzinfo=timezone.utc)
+    end=datetime(2026,9,5,tzinfo=timezone.utc)
+    value=measure._weekly_full_savings(resets_at=(start+timedelta(days=7)).timestamp(),now=end.timestamp())
+    assert value['uncapped_usd']==pytest.approx(0.05,abs=0.005)
+    assert value['api_calls']==1
+    assert datetime.fromisoformat(value['start'])==start
+
+
+def test_full_savings_survives_flat_throughput_multiplier(measure, monkeypatch):
+    _wire(measure, monkeypatch, resume_lean_usd=0)
+    monkeypatch.setattr(measure, '_input_rate_mix_ratio', lambda days=30: 1.0)
+    monkeypatch.setattr(measure, '_weekly_full_savings', lambda **kw: {'saved_usd': 200.62})
+    snap=measure.runway_snapshot()
+    assert snap is not None
+    assert next(w for w in snap['windows'] if w['key']=='seven_day')['saved_usd']==200.62
+
+
+def test_child_growth_refresh_does_not_double_count_cached_parent(measure, monkeypatch, tmp_path):
+    parent, child=tmp_path/'main.jsonl',tmp_path/'child.jsonl'
+    parent.write_text(json.dumps(_turn('parent','2026-09-04T00:00:00Z'))+'\n')
+    child.write_text(json.dumps(_turn('child1','2026-09-04T00:00:01Z'))+'\n')
+    monkeypatch.setattr(measure,'_find_all_jsonl_files',lambda days:[(parent,parent.stat().st_mtime,'test')])
+    monkeypatch.setattr(measure,'_find_subagent_jsonl_files',lambda p:[child] if str(p)==str(parent) else [])
+    measure.collect_sessions(quiet=True)
+    with child.open('a') as f:
+        f.write(json.dumps(_turn('child2','2026-09-04T00:00:02Z'))+'\n')
+    measure.collect_sessions(quiet=True)
+    c=sqlite3.connect(measure.TRENDS_DB)
+    assert c.execute('SELECT count(*),sum(input_tokens),sum(api_calls) FROM session_log').fetchone()==(1,3000,1)
+    c.close()
+
+
+def test_collection_catchup_cannot_move_workload_anchor(measure, monkeypatch):
+    monkeypatch.setattr(measure,'_SESSION_WEIGHT_MIN_ANCHOR_SESSIONS',2)
+    original=dict(sessions=2,usd=10,tokens=10000,flat_usd=12,api_calls=10,messages=12)
+    assert measure._stable_workload_anchor(original,'2026-06')==original
+    refreshed=dict(original,flat_usd=100,api_calls=15)
+    assert measure._stable_workload_anchor(refreshed,'2026-06')==original
+    assert json.loads((measure.SNAPSHOT_DIR/'workload_anchor.json').read_text())['metrics']==original

--- a/tests/test_weekly_full_savings.py
+++ b/tests/test_weekly_full_savings.py
@@ -133,3 +133,103 @@ def test_collection_catchup_cannot_move_workload_anchor(measure, monkeypatch):
     refreshed=dict(original,flat_usd=100,api_calls=15)
     assert measure._stable_workload_anchor(refreshed,'2026-06')==original
     assert json.loads((measure.SNAPSHOT_DIR/'workload_anchor.json').read_text())['metrics']==original
+
+
+@pytest.fixture(autouse=True)
+def _isolate_activity_discovery(measure, monkeypatch):
+    monkeypatch.setattr(measure, '_find_all_jsonl_files', lambda days: [])
+
+
+@pytest.mark.parametrize('change', ['older_month', 'rebuilt_month', 'rates', 'bad_shape'])
+def test_anchor_recovers_when_history_or_rates_change(measure, monkeypatch, change):
+    monkeypatch.setattr(measure, '_SESSION_WEIGHT_MIN_ANCHOR_SESSIONS', 2)
+    old = dict(sessions=2, usd=10, tokens=10000, flat_usd=12, api_calls=10, messages=12)
+    measure._stable_workload_anchor(old, '2026-07')
+    month = {'older_month': '2026-06', 'rebuilt_month': '2026-08'}.get(change, '2026-07')
+    if change == 'rates':
+        monkeypatch.setattr(measure, '_WEIGHT_POOL_FLAT_RATES', dict(measure._WEIGHT_POOL_FLAT_RATES, input=4))
+    if change == 'bad_shape':
+        (measure.SNAPSHOT_DIR / 'workload_anchor.json').write_text('[]')
+    updated = dict(old, flat_usd=20)
+    assert measure._stable_workload_anchor(updated, month) == updated
+    assert json.loads((measure.SNAPSHOT_DIR / 'workload_anchor.json').read_text())['month'] == month
+
+
+def _pool(saving=50):
+    return dict(transformation_usd=saving, actual_usd=100, counterfactual_usd=100+saving,
+                now_units=10, anchor_month='2026-06')
+
+
+def test_weekly_cache_expires_and_reset_change_invalidates(measure, monkeypatch):
+    monkeypatch.setattr(measure, 'detect_runtime', lambda: 'claude')
+    now = datetime(2026, 9, 5, tzinfo=timezone.utc).timestamp()
+    monkeypatch.setattr(measure.time, 'time', lambda: now)
+    calls = []
+    monkeypatch.setattr(measure, '_session_weight_pool_savings', lambda *a, **kw: calls.append(kw) or _pool())
+    reset = now + 3*86400
+    first = measure._weekly_full_savings(resets_at=reset)
+    assert measure._weekly_full_savings(resets_at=reset) == first
+    assert len(calls) == 1
+    now += 61
+    measure._weekly_full_savings(resets_at=reset)
+    assert len(calls) == 2
+    measure._weekly_full_savings(resets_at=reset+86400)
+    assert len(calls) == 3
+
+
+def test_missing_reset_does_not_claim_an_exact_week(measure, monkeypatch):
+    monkeypatch.setattr(measure, 'detect_runtime', lambda: 'claude')
+    monkeypatch.setattr(measure, '_session_weight_pool_savings', lambda *a, **kw: pytest.fail('No known subscription week'))
+    assert measure._weekly_full_savings() is None
+
+
+def test_nonpositive_full_result_does_not_fall_back_to_positive_components(measure, monkeypatch):
+    _wire(measure, monkeypatch, resume_lean_usd=30)
+    monkeypatch.setattr(measure, '_weekly_full_savings', lambda **kw: {'saved_usd': 0})
+    snap = measure.runway_snapshot()
+    assert snap['saved_usd_context'] + snap['saved_usd_routing'] == 0
+
+
+def test_new_uncollected_activity_is_included(measure, monkeypatch, tmp_path):
+    p = tmp_path / 'uncollected.jsonl'
+    p.write_text(json.dumps(_turn('new', '2026-09-04T00:00:00Z')))
+    monkeypatch.setattr(measure, '_find_all_jsonl_files', lambda days: [(p, p.stat().st_mtime, 'test')])
+    monkeypatch.setattr(measure, '_find_subagent_jsonl_files', lambda p: [])
+    conn = measure._init_trends_db()
+    start = datetime(2026, 9, 3, tzinfo=timezone.utc)
+    result = measure._price_parent_activity_window(conn, start, start+timedelta(days=7), 'anthropic')
+    conn.close()
+    assert result['api_calls'] == 1
+    assert result['tokens'] == 1010
+
+
+def test_child_activity_after_parent_stops_is_still_charged(measure, monkeypatch, tmp_path):
+    parent, child = tmp_path/'parent.jsonl', tmp_path/'child.jsonl'
+    parent.write_text(json.dumps(_turn('parent', '2026-09-02T00:00:00Z')))
+    child.write_text(json.dumps(_turn('child', '2026-09-04T00:00:00Z')))
+    monkeypatch.setattr(measure, '_find_subagent_jsonl_files', lambda p: [child])
+    conn = measure._init_trends_db()
+    conn.execute('INSERT INTO session_log (jsonl_path,date,input_tokens,api_calls) VALUES (?,?,?,?)',
+                 (str(parent), '2026-09-02', 1000, 1))
+    conn.commit()
+    start = datetime(2026, 9, 3, tzinfo=timezone.utc)
+    result = measure._price_parent_activity_window(conn, start, start+timedelta(days=7), 'anthropic')
+    conn.close()
+    assert result['api_calls'] == 0  # preserve the existing parent work unit
+    assert result['tokens'] == 1010
+
+
+def test_older_collector_cannot_overwrite_newer_row(measure, monkeypatch, tmp_path):
+    p = tmp_path / 'concurrent.jsonl'
+    p.write_text(json.dumps(_turn('one', '2026-09-04T00:00:00Z')))
+    monkeypatch.setattr(measure, '_find_all_jsonl_files', lambda days: [(p, p.stat().st_mtime, 'test')])
+    monkeypatch.setattr(measure, '_find_subagent_jsonl_files', lambda p: [])
+    measure.collect_sessions(quiet=True)
+    conn = measure._init_trends_db()
+    conn.execute('UPDATE session_log SET collected_at=?,api_calls=2',
+                 ((datetime.now()+timedelta(seconds=30)).isoformat(),))
+    conn.commit()
+    monkeypatch.setattr(measure, '_is_file_collected', lambda *a, **kw: False)
+    measure.collect_sessions(quiet=True)
+    assert conn.execute('SELECT api_calls FROM session_log').fetchone()[0] == 2
+    conn.close()


### PR DESCRIPTION
Growing Claude/Codex sessions were permanently skipped after their first collection, leaving later work missing from the dashboard. The weekly card also used a narrower component total than the Savings tab.

This patch refreshes changed parent/child transcripts safely, uses the Savings tab full-workload comparison for the actual subscription week, includes sessions still waiting for collection, and labels the result as estimated savings accrued so far. Synthetic session-ID collectors keep their existing behavior. Baseline recovery, dated caching, and concurrent-write protection cover the upgrade path.

Release version: 5.13.9 across Claude, Codex, marketplace, and Cowork manifests.

Validation: two independent Claude Fable reviews through Outsourcerer; targeted platform and weekly regressions; JavaScript render checks with and without a quota meter; source-copy parity; full Python suite: 3,167 passed, 20 skipped. The version-bumped candidate additionally passed 63 focused checks; Linux/Windows CI runs on the exact release commit.
